### PR TITLE
feat(i18n): build localization-ready UI structure

### DIFF
--- a/src/app/docs/tokens/page.tsx
+++ b/src/app/docs/tokens/page.tsx
@@ -1,0 +1,484 @@
+const colorTokens = [
+  {
+    name: "--color-dark-900",
+    value: "#020617",
+    usage: "Primary app background and deep surfaces",
+    sample: "#020617",
+    lightText: "#E2E8F0",
+  },
+  {
+    name: "--color-dark-800",
+    value: "#0F172A",
+    usage: "Secondary panels and elevated dark containers",
+    sample: "#0F172A",
+    lightText: "#E2E8F0",
+  },
+  {
+    name: "--color-dark-700",
+    value: "#1E293B",
+    usage: "Card surfaces and subtle dark layer separation",
+    sample: "#1E293B",
+    lightText: "#E2E8F0",
+  },
+  {
+    name: "--color-brand-400",
+    value: "#38BDF8",
+    usage: "Brand highlights, links, and key interactive accents",
+    sample: "#38BDF8",
+    lightText: "#0F172A",
+  },
+  {
+    name: "--positive",
+    value: "#10B981",
+    usage: "Success states, positive performance, confirmations",
+    sample: "#10B981",
+    lightText: "#052E2B",
+  },
+  {
+    name: "--negative",
+    value: "#EF4444",
+    usage: "Error states, destructive actions, validation failures",
+    sample: "#EF4444",
+    lightText: "#3F0A0A",
+  },
+  {
+    name: "--neutral",
+    value: "#94A3B8",
+    usage: "Muted text, helper copy, secondary iconography",
+    sample: "#94A3B8",
+    lightText: "#0F172A",
+  },
+  {
+    name: "--chart-primary",
+    value: "#0F766E",
+    usage: "Primary series in chart visualizations",
+    sample: "#0F766E",
+    lightText: "#E2E8F0",
+  },
+  {
+    name: "--chart-accent",
+    value: "#38BDF8",
+    usage: "Chart highlights and active data points",
+    sample: "#38BDF8",
+    lightText: "#0F172A",
+  },
+  {
+    name: "--chart-warning",
+    value: "#F59E0B",
+    usage: "Warning thresholds and caution data overlays",
+    sample: "#F59E0B",
+    lightText: "#1F1301",
+  },
+  {
+    name: "--skeleton-base",
+    value: "rgba(148, 163, 184, 0.10)",
+    usage: "Base fill color for loading placeholders",
+    sample: "rgba(148, 163, 184, 0.10)",
+    lightText: "#0F172A",
+  },
+  {
+    name: "--skeleton-shine",
+    value: "rgba(148, 163, 184, 0.24)",
+    usage: "Animated shimmer highlight for skeleton states",
+    sample: "rgba(148, 163, 184, 0.24)",
+    lightText: "#0F172A",
+  },
+];
+
+const typographyTokens = [
+  {
+    name: "--font-sans",
+    value:
+      'Inter, "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif',
+    usage: "Default UI text, forms, labels, and application copy",
+  },
+  {
+    name: "--font-mono",
+    value:
+      '"IBM Plex Mono", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+    usage: "Numeric metrics, code snippets, and technical values",
+  },
+  {
+    name: "text-xs",
+    value: "12px / 16px",
+    usage: "Metadata, helper text, tertiary hints",
+  },
+  {
+    name: "text-sm",
+    value: "14px / 20px",
+    usage: "Body copy in forms, cards, and tables",
+  },
+  {
+    name: "text-base",
+    value: "16px / 24px",
+    usage: "Default paragraph and readable descriptive text",
+  },
+  {
+    name: "text-lg",
+    value: "18px / 28px",
+    usage: "Section subheadings and compact feature titles",
+  },
+  {
+    name: "text-2xl",
+    value: "24px / 32px",
+    usage: "Page-level headings and key summary titles",
+  },
+];
+
+const spacingTokens = [
+  { name: "space-1", value: "4px", usage: "Micro spacing between icons and labels" },
+  { name: "space-2", value: "8px", usage: "Tight spacing in compact controls" },
+  { name: "space-3", value: "12px", usage: "Field group spacing and inline sections" },
+  { name: "space-4", value: "16px", usage: "Default block spacing in cards" },
+  { name: "space-5", value: "20px", usage: "Panel internals and section breathing room" },
+  { name: "space-6", value: "24px", usage: "Card padding and major section gaps" },
+  { name: "space-8", value: "32px", usage: "Page-level vertical rhythm and large gaps" },
+];
+
+const shadowTokens = [
+  {
+    name: "--shadow-card",
+    value: "0 8px 30px rgba(2, 6, 23, 0.35)",
+    usage: "Default card elevation on dark surfaces",
+  },
+  {
+    name: "shadow-sm",
+    value: "0 1px 2px rgba(0,0,0,0.05)",
+    usage: "Subtle elevation for low-emphasis surfaces",
+  },
+  {
+    name: "shadow-lg",
+    value: "0 10px 15px rgba(0,0,0,0.10)",
+    usage: "Important overlays and interactive prominence",
+  },
+  {
+    name: "settings-action-elevation",
+    value: "0 8px 32px rgba(0,0,0,0.50)",
+    usage: "Sticky action bars and high-priority floating controls",
+  },
+];
+
+const radiusTokens = [
+  { name: "--skeleton-radius-default", value: "6px", usage: "Default skeleton primitive rounding" },
+  { name: "radius-sm", value: "8px", usage: "Inputs, pills, and compact controls" },
+  { name: "radius-md", value: "10px", usage: "Buttons and medium interactive elements" },
+  { name: "radius-lg", value: "12px", usage: "Cards, table shells, and panels" },
+  { name: "radius-xl", value: "16px", usage: "Modals and elevated overlays" },
+  { name: "radius-2xl", value: "20px", usage: "Onboarding cards and hero containers" },
+  { name: "radius-3xl", value: "24px", usage: "Large dashboard surfaces and premium containers" },
+  { name: "radius-full", value: "9999px", usage: "Badges, chips, and circular controls" },
+];
+
+const codeSnippets = {
+  color: `// Use semantic token classes for consistency\n<button className="bg-sky-500 hover:bg-sky-400 text-white">Primary Action</button>\n<p className="text-slate-400">Secondary helper text</p>`,
+  typography: `// Prefer tokenized typography roles\n<h2 className="text-2xl font-bold text-slate-50">Section Title</h2>\n<p className="text-sm text-slate-400">Supportive context copy</p>`,
+  spacing: `// Compose layouts with spacing scale\n<div className="p-6 space-y-4">\n  <h3 className="text-lg">Card heading</h3>\n  <p className="text-sm">Body content</p>\n</div>`,
+  surface: `// Keep elevation + radius paired\n<div className="rounded-xl border border-slate-700/40 bg-dark-800 shadow-card p-6">\n  Elevated content\n</div>`,
+};
+
+function Section({ id, title, description, children }: { id: string; title: string; description: string; children: React.ReactNode }) {
+  return (
+    <section id={id} className="rounded-2xl border border-slate-700/40 bg-dark-800/70 p-6 md:p-8">
+      <div className="mb-6">
+        <h2 className="text-2xl font-bold text-slate-50">{title}</h2>
+        <p className="mt-2 text-sm text-slate-300">{description}</p>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function TokenTable({
+  rows,
+}: {
+  rows: Array<{ name: string; value: string; usage: string }>;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-slate-700/50">
+      <table className="w-full text-left" style={{ minWidth: 720 }}>
+        <thead className="bg-slate-900/70">
+          <tr>
+            <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-300">Token</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-300">Value</th>
+            <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-300">Usage Context</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.name} className="border-t border-slate-700/50">
+              <td className="px-4 py-3 font-mono text-xs text-sky-300">{row.name}</td>
+              <td className="px-4 py-3 font-mono text-xs text-emerald-300">{row.value}</td>
+              <td className="px-4 py-3 text-sm text-slate-200">{row.usage}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function DoDont({
+  doTitle,
+  doBody,
+  dontTitle,
+  dontBody,
+}: {
+  doTitle: string;
+  doBody: string;
+  dontTitle: string;
+  dontBody: string;
+}) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4">
+        <p className="text-sm font-semibold text-emerald-300">✅ Do: {doTitle}</p>
+        <p className="mt-1 text-sm text-emerald-100/90">{doBody}</p>
+      </div>
+      <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4">
+        <p className="text-sm font-semibold text-red-300">❌ Don&apos;t: {dontTitle}</p>
+        <p className="mt-1 text-sm text-red-100/90">{dontBody}</p>
+      </div>
+    </div>
+  );
+}
+
+function CodeBlock({ title, code }: { title: string; code: string }) {
+  return (
+    <div className="rounded-xl border border-slate-700/60 bg-slate-950/80">
+      <p className="border-b border-slate-700/60 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-300">
+        {title}
+      </p>
+      <pre className="overflow-x-auto p-4 text-xs text-slate-100">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+function LightDarkPreview() {
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <div className="rounded-xl border border-slate-300 bg-white p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Light Surface Example</p>
+        <div className="mt-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="text-sm font-semibold text-slate-900">Portfolio summary</p>
+          <p className="mt-1 text-sm text-slate-600">Use dark text on light backgrounds for readable contrast.</p>
+          <button className="mt-3 rounded-md bg-sky-500 px-3 py-2 text-xs font-semibold text-white">Primary Action</button>
+        </div>
+      </div>
+      <div className="rounded-xl border border-slate-700 bg-dark-900 p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Dark Surface Example</p>
+        <div className="mt-3 rounded-lg border border-slate-700 bg-dark-800 p-4 shadow-card">
+          <p className="text-sm font-semibold text-slate-50">Portfolio summary</p>
+          <p className="mt-1 text-sm text-slate-300">Use light text and semantic accents on dark backgrounds.</p>
+          <button className="mt-3 rounded-md bg-sky-500 px-3 py-2 text-xs font-semibold text-white">Primary Action</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DesignTokensDocsPage() {
+  return (
+    <main className="min-h-screen bg-dark-900 px-4 py-8 text-slate-100 md:px-8 md:py-10">
+      <div className="mx-auto w-full max-w-7xl space-y-8">
+        <header className="rounded-2xl border border-slate-700/40 bg-dark-800/70 p-6 md:p-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">Design System</p>
+          <h1 className="mt-2 text-3xl font-bold text-slate-50 md:text-4xl">Token Documentation</h1>
+          <p className="mt-3 max-w-3xl text-sm text-slate-300 md:text-base">
+            Canonical tokens for colors, typography, spacing, shadows, and radii. Every token lists name, value, and intended usage to keep implementation consistent across features.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-2">
+            {[
+              ["colors", "Colors"],
+              ["typography", "Typography"],
+              ["spacing", "Spacing"],
+              ["shadows", "Shadows"],
+              ["radii", "Radii"],
+              ["misuse", "Do / Don’t"],
+            ].map(([id, label]) => (
+              <a
+                key={id}
+                href={`#${id}`}
+                className="rounded-full border border-slate-600 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:border-sky-400 hover:text-sky-300"
+              >
+                {label}
+              </a>
+            ))}
+          </div>
+        </header>
+
+        <Section
+          id="colors"
+          title="Color Tokens"
+          description="Semantic color tokens and where they should be used. Includes accessibility guidance and light/dark examples."
+        >
+          <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {colorTokens.map((token) => (
+              <article key={token.name} className="rounded-xl border border-slate-700/50 bg-slate-900/60 p-4">
+                <div
+                  className="h-12 w-full rounded-lg border border-slate-600/40"
+                  style={{ background: token.sample }}
+                  aria-label={`${token.name} swatch`}
+                />
+                <p className="mt-3 font-mono text-xs text-sky-300">{token.name}</p>
+                <p className="mt-1 font-mono text-xs text-emerald-300">{token.value}</p>
+                <p className="mt-2 text-xs text-slate-300">{token.usage}</p>
+              </article>
+            ))}
+          </div>
+
+          <TokenTable rows={colorTokens.map(({ name, value, usage }) => ({ name, value, usage }))} />
+
+          <div className="mt-6">
+            <LightDarkPreview />
+          </div>
+
+          <div className="mt-6 rounded-xl border border-amber-500/30 bg-amber-500/10 p-4">
+            <p className="text-sm font-semibold text-amber-300">Accessibility Notes</p>
+            <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-amber-100/90">
+              <li>Maintain at least 4.5:1 contrast for regular text and 3:1 for large text.</li>
+              <li>Never use color alone to communicate state; pair with iconography or text labels.</li>
+              <li>Reserve `--positive` and `--negative` for semantic meaning, not decorative accents.</li>
+            </ul>
+          </div>
+
+          <div className="mt-6">
+            <CodeBlock title="Color Usage Snippet" code={codeSnippets.color} />
+          </div>
+        </Section>
+
+        <Section
+          id="typography"
+          title="Typography Tokens"
+          description="Font families and size roles for readable hierarchy in UI and product copy."
+        >
+          <TokenTable rows={typographyTokens} />
+
+          <div className="mt-6 grid gap-4 lg:grid-cols-2">
+            <div className="rounded-xl border border-slate-700/60 bg-slate-900/60 p-5">
+              <p className="font-mono text-xs text-slate-400">Sans Preview (`--font-sans`)</p>
+              <p className="mt-2 text-2xl font-bold text-slate-50">Dashboard Overview</p>
+              <p className="mt-2 text-sm text-slate-300">Readable UI text with clear information hierarchy.</p>
+            </div>
+            <div className="rounded-xl border border-slate-700/60 bg-slate-900/60 p-5">
+              <p className="font-mono text-xs text-slate-400">Mono Preview (`--font-mono`)</p>
+              <p className="mt-2 font-mono text-2xl font-bold text-emerald-300">+8.42% APY</p>
+              <p className="mt-2 font-mono text-sm text-slate-300">Used for technical and numeric values.</p>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <CodeBlock title="Typography Usage Snippet" code={codeSnippets.typography} />
+          </div>
+        </Section>
+
+        <Section
+          id="spacing"
+          title="Spacing Tokens"
+          description="Spacing scale to keep layout rhythm consistent across cards, sections, and controls."
+        >
+          <TokenTable rows={spacingTokens} />
+
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            <div className="rounded-xl border border-slate-700/60 bg-slate-900/60 p-5">
+              <p className="text-sm font-semibold text-slate-200">Visual Spacing Scale</p>
+              <div className="mt-4 space-y-3">
+                {spacingTokens.map((token) => (
+                  <div key={token.name} className="flex items-center gap-3">
+                    <div className="font-mono text-xs text-sky-300" style={{ minWidth: 70 }}>{token.name}</div>
+                    <div className="h-3 rounded bg-sky-500/70" style={{ width: token.value }} />
+                    <div className="font-mono text-xs text-slate-300">{token.value}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <CodeBlock title="Spacing Usage Snippet" code={codeSnippets.spacing} />
+          </div>
+        </Section>
+
+        <Section
+          id="shadows"
+          title="Shadow Tokens"
+          description="Elevation tokens for depth hierarchy. Pair with radii and borders for cleaner surfaces."
+        >
+          <TokenTable rows={shadowTokens} />
+
+          <div className="mt-6 grid gap-4 lg:grid-cols-3">
+            <div className="rounded-xl border border-slate-700 bg-dark-800 p-5 shadow-sm">
+              <p className="text-sm font-semibold text-slate-100">Subtle</p>
+              <p className="mt-1 text-xs text-slate-300">Low emphasis content containers.</p>
+            </div>
+            <div className="rounded-xl border border-slate-700 bg-dark-800 p-5" style={{ boxShadow: "var(--shadow-card)" }}>
+              <p className="text-sm font-semibold text-slate-100">Card</p>
+              <p className="mt-1 text-xs text-slate-300">Standard dashboard card elevation.</p>
+            </div>
+            <div className="rounded-xl border border-slate-700 bg-dark-800 p-5" style={{ boxShadow: "0 8px 32px rgba(0, 0, 0, 0.5)" }}>
+              <p className="text-sm font-semibold text-slate-100">Floating Action</p>
+              <p className="mt-1 text-xs text-slate-300">Sticky and high-priority action surfaces.</p>
+            </div>
+          </div>
+
+          <div className="mt-6">
+            <CodeBlock title="Elevation Usage Snippet" code={codeSnippets.surface} />
+          </div>
+        </Section>
+
+        <Section
+          id="radii"
+          title="Radius Tokens"
+          description="Corner-radius scale for consistency from small controls to large containers."
+        >
+          <TokenTable rows={radiusTokens} />
+
+          <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {radiusTokens.map((token) => (
+              <div key={token.name} className="rounded-xl border border-slate-700/60 bg-slate-900/60 p-4">
+                <div
+                  className="h-14 border border-slate-500/50 bg-dark-700"
+                  style={{ borderRadius: token.value === "radius-full" ? "9999px" : token.value }}
+                />
+                <p className="mt-3 font-mono text-xs text-sky-300">{token.name}</p>
+                <p className="mt-1 font-mono text-xs text-emerald-300">{token.value}</p>
+                <p className="mt-2 text-xs text-slate-300">{token.usage}</p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <Section
+          id="misuse"
+          title="Common Do / Don’t Patterns"
+          description="Common implementation mistakes and correct usage patterns to prevent design drift."
+        >
+          <div className="space-y-4">
+            <DoDont
+              doTitle="Use semantic state colors"
+              doBody="Use `--positive`/`--negative` only for success and failure states so meaning stays consistent for users."
+              dontTitle="Use success red/green interchangeably"
+              dontBody="Avoid arbitrary color swaps that break user expectations and increase cognitive load."
+            />
+            <DoDont
+              doTitle="Use readable contrast on all surfaces"
+              doBody="Pair light text with dark surfaces and dark text with light surfaces; validate with contrast checks."
+              dontTitle="Place low-contrast text on tinted panels"
+              dontBody="Muted text over low-opacity backgrounds can fail WCAG and become unreadable under glare."
+            />
+            <DoDont
+              doTitle="Reuse spacing and radius scale"
+              doBody="Stick to documented values (4, 8, 12, 16, 20, 24, 32) and radius scale for predictable rhythm."
+              dontTitle="Hard-code random pixel values"
+              dontBody="Avoid one-off values like 13px/19px that create inconsistent alignments and brittle UI."
+            />
+            <DoDont
+              doTitle="Pair elevation with hierarchy"
+              doBody="Reserve stronger shadows for overlays and floating controls to preserve depth meaning."
+              dontTitle="Apply heavy shadows everywhere"
+              dontBody="Overusing strong shadows flattens hierarchy and makes important elements harder to identify."
+            />
+          </div>
+        </Section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { HowItWorksSection } from "@/features/landing/HowItWorksSection";
 import { StrategiesSection } from "@/features/landing/StrategiesSection";
 import { SecuritySection } from "@/features/landing/SecuritySection";
 import { CtaSection } from "@/features/landing/CtaSection";
+import { HomeFooter } from "@/features/landing/HomeFooter";
 
 export default function Home() {
   return (
@@ -31,9 +32,7 @@ export default function Home() {
         <CtaSection />
       </main>
 
-      <footer className="border-t border-gray-800 py-8 text-center text-sm text-slate-600">
-        &copy; {new Date().getFullYear()} NeuroWealth &middot; Built on Stellar
-      </footer>
+      <HomeFooter />
     </>
   );
 }

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -3,11 +3,14 @@
 import { ReactNode } from "react";
 import { AuthProvider } from "@/contexts";
 import { WalletProvider } from "@/contexts";
+import { I18nProvider } from "@/contexts/I18nContext";
 
 export function ClientProviders({ children }: { children: ReactNode }) {
   return (
-    <AuthProvider>
-      <WalletProvider>{children}</WalletProvider>
-    </AuthProvider>
+    <I18nProvider>
+      <AuthProvider>
+        <WalletProvider>{children}</WalletProvider>
+      </AuthProvider>
+    </I18nProvider>
   );
 }

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { ChangeEvent } from "react";
+import { useI18n } from "@/contexts";
+
+export function LocaleSwitcher() {
+  const { locale, setLocale, messages } = useI18n();
+
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setLocale(event.target.value as "en" | "fr");
+  };
+
+  return (
+    <div className="flex items-center gap-2">
+      <label htmlFor="locale-switcher" className="sr-only">
+        {messages.locale.switcherLabel}
+      </label>
+      <span className="hidden text-xs font-semibold uppercase tracking-wide text-slate-400 lg:inline">
+        {messages.locale.label}
+      </span>
+      <select
+        id="locale-switcher"
+        value={locale}
+        onChange={handleChange}
+        className="rounded-md border border-slate-700 bg-dark-800 px-2.5 py-1.5 text-xs text-slate-200 outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/30"
+        aria-label={messages.locale.switcherLabel}
+      >
+        <option value="en">{messages.locale.options.en}</option>
+        <option value="fr">{messages.locale.options.fr}</option>
+      </select>
+    </div>
+  );
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,8 +4,9 @@ import Link from "next/link";
 import WalletConnectButton from "./WalletConnectButton";
 import { ThemeToggle } from "./ThemeToggle";
 import { NotificationToggle } from "./notifications/NotificationToggle";
-import { useAuth, useWallet, useWalletConfig } from "@/contexts";
+import { useAuth, useI18n, useWallet, useWalletConfig } from "@/contexts";
 import { Button } from "./ui/Button";
+import { LocaleSwitcher } from "./LocaleSwitcher";
 
 function truncateAddress(address: string) {
   if (!address || address.length < 12) return address;
@@ -22,27 +23,30 @@ function formatNetworkLabel(network?: string) {
 
 export function Navbar() {
   const { user, signOut } = useAuth();
+  const { messages } = useI18n();
   const { connected, isRestoring, publicKey } = useWallet();
   const config = useWalletConfig();
   const networkLabel = formatNetworkLabel(config?.network);
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 border-b border-white/5 bg-dark-900/80 backdrop-blur-md">
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-8 py-5">
+      <div className="mx-auto flex max-w-7xl items-center justify-between gap-2 px-4 py-4 sm:px-6 md:px-8 md:py-5">
         <Link href="/" className="flex items-center gap-2 text-lg font-bold text-white">
           <span className="text-brand-400">&#x2B21;</span> NeuroWealth
         </Link>
 
         <div className="hidden md:flex items-center gap-8 text-sm text-slate-400">
-          <Link href="#features" className="hover:text-white transition-colors">Features</Link>
-          <Link href="#how-it-works" className="hover:text-white transition-colors">How it works</Link>
-          <Link href="#strategies" className="hover:text-white transition-colors">Strategies</Link>
-          <Link href="/help" className="hover:text-white transition-colors">Help</Link>
+          <Link href="#features" className="hover:text-white transition-colors">{messages.navbar.features}</Link>
+          <Link href="#how-it-works" className="hover:text-white transition-colors">{messages.navbar.howItWorks}</Link>
+          <Link href="#strategies" className="hover:text-white transition-colors">{messages.navbar.strategies}</Link>
+          <Link href="/help" className="hover:text-white transition-colors">{messages.navbar.help}</Link>
         </div>
 
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 sm:gap-3 md:gap-4">
+          <LocaleSwitcher />
+
           <Link href="/help" className="md:hidden text-sm text-slate-400 hover:text-white transition-colors">
-            Help
+            {messages.navbar.help}
           </Link>
 
           {!isRestoring && connected && publicKey && (
@@ -63,20 +67,20 @@ export function Navbar() {
           {user ? (
             <div className="flex items-center gap-3 ml-2 pl-4 border-l border-white/10">
               <div className="flex flex-col items-end">
-                <span className="text-[10px] text-slate-500 uppercase font-bold leading-none">Account</span>
+                <span className="text-[10px] text-slate-500 uppercase font-bold leading-none">{messages.navbar.account}</span>
                 <span className="text-xs text-white font-medium">{user.name}</span>
               </div>
               <button
                 onClick={signOut}
                 className="text-[10px] text-slate-500 hover:text-red-400 transition-colors uppercase font-bold"
               >
-                Sign Out
+                {messages.navbar.signOut}
               </button>
             </div>
           ) : (
             <Link href="/signin">
               <Button variant="secondary" size="sm" className="text-xs h-9">
-                Sign In
+                {messages.navbar.signIn}
               </Button>
             </Link>
           )}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -36,7 +36,7 @@ export function Button({
 }: ButtonProps) {
   return (
     <button
-      className={`inline-flex items-center justify-center gap-2 transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${variants[variant]} ${sizes[size]} ${className}`}
+      className={`inline-flex items-center justify-center gap-2 text-center whitespace-normal leading-snug transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed ${variants[variant]} ${sizes[size]} ${className}`}
       {...props}
     >
       {children}

--- a/src/contexts/I18nContext.tsx
+++ b/src/contexts/I18nContext.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { AppLocale, dictionaries, localeToIntl } from "@/lib/i18n/messages";
+import { setActiveLocale } from "@/lib/i18n/locale-state";
+
+const LOCALE_STORAGE_KEY = "neurowealth.locale";
+
+interface I18nContextValue {
+  locale: AppLocale;
+  setLocale: (locale: AppLocale) => void;
+  messages: (typeof dictionaries)[AppLocale];
+}
+
+const I18nContext = createContext<I18nContextValue | null>(null);
+
+function isSupportedLocale(value: string): value is AppLocale {
+  return value === "en" || value === "fr";
+}
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const [locale, setLocaleState] = useState<AppLocale>("en");
+
+  useEffect(() => {
+    const stored = window.localStorage.getItem(LOCALE_STORAGE_KEY);
+    if (stored && isSupportedLocale(stored)) {
+      setLocaleState(stored);
+      return;
+    }
+
+    const browserLanguage = window.navigator.language.toLowerCase();
+    if (browserLanguage.startsWith("fr")) {
+      setLocaleState("fr");
+    }
+  }, []);
+
+  useEffect(() => {
+    setActiveLocale(locale);
+    document.documentElement.lang = localeToIntl[locale];
+    window.localStorage.setItem(LOCALE_STORAGE_KEY, locale);
+  }, [locale]);
+
+  const setLocale = useCallback((nextLocale: AppLocale) => {
+    setLocaleState(nextLocale);
+  }, []);
+
+  const value = useMemo<I18nContextValue>(
+    () => ({
+      locale,
+      setLocale,
+      messages: dictionaries[locale],
+    }),
+    [locale, setLocale]
+  );
+
+  return <I18nContext.Provider value={value}>{children}</I18nContext.Provider>;
+}
+
+export function useI18n() {
+  const context = useContext(I18nContext);
+
+  if (!context) {
+    throw new Error("useI18n must be used within an I18nProvider");
+  }
+
+  return context;
+}

--- a/src/contexts/index.ts
+++ b/src/contexts/index.ts
@@ -1,3 +1,4 @@
 export { WalletProvider, useWallet, useWalletConfig } from './WalletProvider';
 export { AuthProvider, useAuth } from './AuthContext';
+export { I18nProvider, useI18n } from './I18nContext';
 export type { Balance, PaymentOptions } from './WalletProvider';

--- a/src/features/landing/CtaSection.tsx
+++ b/src/features/landing/CtaSection.tsx
@@ -1,49 +1,52 @@
+"use client";
+
 import Link from "next/link";
 import { Button } from "@/components/ui/Button";
+import { useI18n } from "@/contexts";
 
 export function CtaSection() {
+  const { messages } = useI18n();
+
   return (
     <section className="relative overflow-hidden py-24">
       {/* Background glow */}
       <div className="pointer-events-none absolute inset-0">
-        <div className="absolute left-1/2 top-1/2 h-[400px] w-[800px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-sky-500/6 blur-[120px]" />
+        <div className="absolute left-1/2 top-1/2 h-100 w-200 -translate-x-1/2 -translate-y-1/2 rounded-full bg-sky-500/6 blur-[120px]" />
       </div>
 
       <div className="relative mx-auto max-w-2xl px-6 text-center">
         <span className="inline-block rounded-full border border-sky-500/30 bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-400">
-          Get started today
+          {messages.cta.badge}
         </span>
 
         {/* Spec: 36px heading */}
         <h2 className="mt-5 text-4xl font-bold leading-tight text-slate-50 md:text-5xl">
-          Ready to put your USDC to work?
+          {messages.cta.title}
         </h2>
 
         <p className="mx-auto mt-5 max-w-lg text-base leading-relaxed text-slate-400">
-          Join thousands earning passive yield on Stellar DeFi. Connect your
-          Freighter wallet and let NeuroWealth handle the rest.
+          {messages.cta.description}
         </p>
 
         <div className="mt-10 flex flex-wrap justify-center gap-4">
           {/* CTA: Connect Wallet (primary) */}
           <Link href="#overview">
-            <Button size="lg">Connect Wallet</Button>
+            <Button size="lg">{messages.cta.connectWallet}</Button>
           </Link>
 
           {/* CTA: Open Dashboard (secondary) */}
           <Link href="/dashboard">
             <Button variant="secondary" size="lg">
-              Open Dashboard
+              {messages.cta.openDashboard}
             </Button>
           </Link>
         </div>
 
         {/* Trust indicators */}
         <div className="mt-12 flex flex-wrap items-center justify-center gap-6 text-xs text-slate-500">
-          <span>&#x2714; Non-custodial</span>
-          <span>&#x2714; Audited contracts</span>
-          <span>&#x2714; No lock-ups</span>
-          <span>&#x2714; Open source</span>
+          {messages.cta.trust.map((item) => (
+            <span key={item}>{item}</span>
+          ))}
         </div>
       </div>
     </section>

--- a/src/features/landing/FeaturesSection.tsx
+++ b/src/features/landing/FeaturesSection.tsx
@@ -1,70 +1,30 @@
-import { Card } from "@/components/ui/Card";
+"use client";
 
-const features = [
-  {
-    icon: "🤖",
-    title: "AI Agent",
-    desc: "Autonomous 24/7 yield optimization across Stellar DeFi protocols.",
-    accent: "text-sky-400",
-    bg: "bg-sky-500/10",
-  },
-  {
-    icon: "💬",
-    title: "Natural Language",
-    desc: "Chat to deposit, withdraw, and check balances — no DeFi knowledge needed.",
-    accent: "text-emerald-400",
-    bg: "bg-emerald-500/10",
-  },
-  {
-    icon: "📈",
-    title: "Auto-Rebalancing",
-    desc: "The agent shifts funds to the best opportunities automatically, hourly.",
-    accent: "text-sky-400",
-    bg: "bg-sky-500/10",
-  },
-  {
-    icon: "🔐",
-    title: "Non-Custodial",
-    desc: "Your funds live in audited Soroban smart contracts. Always yours.",
-    accent: "text-emerald-400",
-    bg: "bg-emerald-500/10",
-  },
-  {
-    icon: "⚡",
-    title: "Instant Withdrawals",
-    desc: "No lock-ups, no penalties. Withdraw anytime in seconds.",
-    accent: "text-amber-400",
-    bg: "bg-amber-500/10",
-  },
-  {
-    icon: "🌍",
-    title: "Global Access",
-    desc: "No geographic restrictions, no bank account required.",
-    accent: "text-sky-400",
-    bg: "bg-sky-500/10",
-  },
-];
+import { Card } from "@/components/ui/Card";
+import { useI18n } from "@/contexts";
 
 export function FeaturesSection() {
+  const { messages } = useI18n();
+
   return (
     <section id="features" className="mx-auto max-w-6xl px-6 py-24">
       {/* Section header */}
       <div className="mb-14 text-center">
         <span className="inline-block rounded-full border border-sky-500/30 bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-400">
-          Features
+          {messages.features.badge}
         </span>
         {/* Spec: 30px heading */}
         <h2 className="mt-4 text-3xl font-bold text-slate-50">
-          Everything you need
+          {messages.features.title}
         </h2>
         <p className="mt-3 text-base text-slate-400">
-          Simple on the surface, powerful underneath.
+          {messages.features.description}
         </p>
       </div>
 
       {/* Spec: Card — border #1F2937 (gray-800), shadow, radius 12px */}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-        {features.map((f) => (
+        {messages.features.items.map((f) => (
           <Card key={f.title} className="flex flex-col gap-4">
             {/* Icon badge */}
             <div

--- a/src/features/landing/HeroActions.tsx
+++ b/src/features/landing/HeroActions.tsx
@@ -3,8 +3,10 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Button } from "@/components/ui/Button";
+import { useI18n } from "@/contexts";
 
 export function HeroActions() {
+  const { messages } = useI18n();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
@@ -16,13 +18,13 @@ export function HeroActions() {
       const freighter = await import("@stellar/freighter-api");
       const isConnected = await freighter.isConnected();
       if (!isConnected) {
-        setError("Freighter wallet not found. Please install it.");
+        setError(messages.heroActions.errorNoWallet);
         return;
       }
       await freighter.getAddress();
       setConnected(true);
     } catch {
-      setError("Failed to connect. Please try again.");
+      setError(messages.heroActions.errorFailedConnect);
     } finally {
       setLoading(false);
     }
@@ -33,25 +35,25 @@ export function HeroActions() {
       <div className="flex flex-wrap justify-center gap-3">
         {connected ? (
           <Link href="/dashboard">
-            <Button size="lg">Open Dashboard &rarr;</Button>
+            <Button size="lg">{messages.heroActions.openDashboardArrow}</Button>
           </Link>
         ) : (
           <Button size="lg" onClick={connectWallet} disabled={loading}>
-            {loading ? "Connecting..." : "Connect Wallet"}
+            {loading ? messages.heroActions.connecting : messages.heroActions.connectWallet}
           </Button>
         )}
 
         {!connected && (
           <Link href="/dashboard">
             <Button variant="secondary" size="lg">
-              Open Dashboard
+              {messages.heroActions.openDashboard}
             </Button>
           </Link>
         )}
 
         <Link href="#features">
           <Button variant="ghost" size="lg">
-            Learn More ↓
+            {messages.heroActions.learnMore}
           </Button>
         </Link>
       </div>

--- a/src/features/landing/HeroSection.tsx
+++ b/src/features/landing/HeroSection.tsx
@@ -1,8 +1,13 @@
 // Spec palette: Primary #0EA5E9 (sky-500), Accent #10B981 (emerald-500)
 // Page bg #0B1220, Text #F8FAFC, Muted #94A3B8
+"use client";
+
 import { HeroActions } from "./HeroActions";
+import { useI18n } from "@/contexts";
 
 export function HeroSection() {
+  const { messages } = useI18n();
+
   return (
     <section
       id="overview"
@@ -17,20 +22,19 @@ export function HeroSection() {
       <div className="relative max-w-3xl">
         {/* Badge */}
         <span className="mb-6 inline-block rounded-full border border-sky-500/30 bg-sky-500/10 px-4 py-1.5 text-xs font-medium tracking-wide text-sky-400">
-          Powered by Stellar &middot; Built with AI
+          {messages.hero.badge}
         </span>
 
         {/* Headline — spec: 36px / line-height 1.4–1.6 */}
         <h1 className="mt-4 text-4xl font-bold leading-tight tracking-tight text-slate-50 sm:text-5xl md:text-6xl">
-          Your money, working{" "}
-          <span className="text-sky-400">24/7</span> on autopilot
+          {messages.hero.titleBeforeAccent}{" "}
+          <span className="text-sky-400">{messages.hero.titleAccent}</span>{" "}
+          {messages.hero.titleAfterAccent}
         </h1>
 
         {/* Sub — spec: 16px, muted #94A3B8 */}
         <p className="mx-auto mt-6 max-w-xl text-base leading-relaxed text-slate-400 sm:text-lg">
-          NeuroWealth is an autonomous AI agent that finds and deploys your USDC
-          into the highest-yielding opportunities on Stellar DeFi &mdash;
-          automatically, every hour.
+          {messages.hero.description}
         </p>
 
         {/* CTAs: Connect Wallet | Open Dashboard | Learn More */}
@@ -40,11 +44,7 @@ export function HeroSection() {
 
         {/* Stats row — spec: font-mono for numeric text, emerald-500 accent */}
         <div className="mt-16 grid grid-cols-3 gap-6 border-t border-gray-800 pt-10">
-          {[
-            { label: "Avg. APY", value: "8.4%" },
-            { label: "Finality", value: "~5s" },
-            { label: "Tx Fee", value: "<$0.01" },
-          ].map((s) => (
+          {messages.hero.stats.map((s) => (
             <div key={s.label}>
               {/* Spec: Roboto Mono for numeric displays */}
               <p className="font-mono text-2xl font-bold text-emerald-400">

--- a/src/features/landing/HomeFooter.tsx
+++ b/src/features/landing/HomeFooter.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import Link from "next/link";
+import { useI18n } from "@/contexts";
+
+export function HomeFooter() {
+  const { messages } = useI18n();
+
+  return (
+    <footer className="border-t border-gray-800 py-8 text-center text-sm text-slate-600">
+      <span>
+        &copy; {new Date().getFullYear()} NeuroWealth &middot; {messages.footer.builtOn}
+      </span>
+      <span className="mx-2">&middot;</span>
+      <Link
+        href="/docs/tokens"
+        className="font-medium text-slate-400 transition hover:text-sky-300"
+      >
+        {messages.footer.designTokens}
+      </Link>
+    </footer>
+  );
+}

--- a/src/features/landing/HowItWorksSection.tsx
+++ b/src/features/landing/HowItWorksSection.tsx
@@ -1,54 +1,37 @@
-const steps = [
-  {
-    n: "01",
-    title: "Deposit USDC",
-    desc: "Connect your Freighter wallet and deposit USDC into the NeuroWealth vault.",
-  },
-  {
-    n: "02",
-    title: "AI Deploys Funds",
-    desc: "The agent detects your deposit and immediately deploys to the best protocol.",
-  },
-  {
-    n: "03",
-    title: "Yield Accumulates",
-    desc: "Earnings compound 24/7. The agent rebalances hourly if better rates appear.",
-  },
-  {
-    n: "04",
-    title: "Withdraw Anytime",
-    desc: "Request a withdrawal — funds arrive in your wallet within seconds.",
-  },
-];
+"use client";
+
+import { useI18n } from "@/contexts";
 
 export function HowItWorksSection() {
+  const { messages } = useI18n();
+
   return (
     <section id="how-it-works" className="bg-gray-900/40 py-24">
       <div className="mx-auto max-w-6xl px-6">
         {/* Header */}
         <div className="mb-14 text-center">
           <span className="inline-block rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-400">
-            How it works
+            {messages.howItWorks.badge}
           </span>
           {/* Spec: 30px heading */}
           <h2 className="mt-4 text-3xl font-bold text-slate-50">
-            Four steps to passive yield
+            {messages.howItWorks.title}
           </h2>
           <p className="mt-3 text-base text-slate-400">
-            Get started in minutes, earn around the clock.
+            {messages.howItWorks.description}
           </p>
         </div>
 
         <div className="grid gap-8 md:grid-cols-4">
-          {steps.map((s, i) => (
+          {messages.howItWorks.steps.map((s, i) => (
             <div key={s.n} className="relative flex flex-col gap-4">
               {/* Connector line */}
-              {i < steps.length - 1 && (
+              {i < messages.howItWorks.steps.length - 1 && (
                 <div className="absolute left-10 top-10 hidden h-px w-full bg-linear-to-r from-sky-500/40 to-transparent md:block" />
               )}
 
               {/* Step badge — spec primary sky-500 */}
-              <div className="flex h-[52px] w-[52px] items-center justify-center rounded-lg border border-sky-500/30 bg-sky-500/10 font-mono text-lg font-bold text-sky-400">
+              <div className="flex h-13 w-13 items-center justify-center rounded-lg border border-sky-500/30 bg-sky-500/10 font-mono text-lg font-bold text-sky-400">
                 {s.n}
               </div>
 

--- a/src/features/landing/SecuritySection.tsx
+++ b/src/features/landing/SecuritySection.tsx
@@ -1,12 +1,11 @@
+"use client";
+
 import { ReactNode } from "react";
 import { Card } from "@/components/ui/Card";
+import { useI18n } from "@/contexts";
 
 interface SecurityFeature {
   icon: ReactNode;
-  title: string;
-  stat: string;
-  statLabel: string;
-  desc: string;
 }
 
 const features: SecurityFeature[] = [
@@ -28,10 +27,6 @@ const features: SecurityFeature[] = [
         <polyline points="9 12 11 14 15 10" />
       </svg>
     ),
-    title: "Non-Custodial",
-    stat: "100%",
-    statLabel: "Your keys, your coins",
-    desc: "Your USDC stays in audited Soroban smart contracts that only you can authorize. We never hold or access your private keys.",
   },
   {
     icon: (
@@ -52,10 +47,6 @@ const features: SecurityFeature[] = [
         <polyline points="9 15 11 17 15 13" />
       </svg>
     ),
-    title: "Audited Contracts",
-    stat: "0",
-    statLabel: "Security incidents",
-    desc: "All smart contracts undergo rigorous third-party security audits before mainnet deployment. Source code is publicly verifiable on-chain.",
   },
   {
     icon: (
@@ -75,10 +66,6 @@ const features: SecurityFeature[] = [
         <polyline points="8 6 2 12 8 18" />
       </svg>
     ),
-    title: "Open Source",
-    stat: "100%",
-    statLabel: "Transparent code",
-    desc: "Every line of code is open source and community-reviewed. No black boxes — verify exactly what the protocol does with your funds.",
   },
   {
     icon: (
@@ -99,32 +86,33 @@ const features: SecurityFeature[] = [
         <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
       </svg>
     ),
-    title: "Stellar Network",
-    stat: "10+",
-    statLabel: "Years of proven uptime",
-    desc: "Built on Stellar's battle-tested blockchain with a decade of proven reliability, instant finality (~5s), and sub-cent transaction fees.",
   },
 ];
 
 export function SecuritySection() {
+  const { messages } = useI18n();
+
   return (
     <section id="security" className="mx-auto max-w-6xl px-6 py-24">
       {/* Header */}
       <div className="mb-14 text-center">
         <span className="inline-block rounded-full border border-sky-500/30 bg-sky-500/10 px-3 py-1 text-xs font-medium text-sky-400">
-          Security
+          {messages.security.badge}
         </span>
         <h2 className="mt-4 text-3xl font-bold text-slate-50">
-          Built to be trusted
+          {messages.security.title}
         </h2>
         <p className="mt-3 text-base text-slate-400">
-          Security is not an afterthought — it is the foundation.
+          {messages.security.description}
         </p>
       </div>
 
       <div className="grid gap-6 sm:grid-cols-2">
-        {features.map((f) => (
-          <Card key={f.title} className="flex gap-5">
+        {features.map((f, index) => {
+          const text = messages.security.items[index];
+
+          return (
+            <Card key={text.title} className="flex gap-5">
             {/* Icon */}
             <div className="shrink-0 flex h-12 w-12 items-center justify-center rounded-lg border border-sky-500/30 bg-sky-500/10 text-sky-400">
               {f.icon}
@@ -132,15 +120,16 @@ export function SecuritySection() {
 
             <div className="flex flex-col gap-1.5">
               <div className="flex items-baseline gap-3">
-                <h3 className="font-semibold text-slate-50">{f.title}</h3>
+                <h3 className="font-semibold text-slate-50">{text.title}</h3>
                 <span className="font-mono text-xs text-emerald-400">
-                  {f.stat} &middot; {f.statLabel}
+                  {text.stat} &middot; {text.statLabel}
                 </span>
               </div>
-              <p className="text-sm leading-relaxed text-slate-400">{f.desc}</p>
+              <p className="text-sm leading-relaxed text-slate-400">{text.desc}</p>
             </div>
           </Card>
-        ))}
+          );
+        })}
       </div>
     </section>
   );

--- a/src/features/landing/StrategiesSection.tsx
+++ b/src/features/landing/StrategiesSection.tsx
@@ -1,55 +1,29 @@
+"use client";
+
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
-
-const strategies = [
-  {
-    name: "Conservative",
-    apy: "3–6%",
-    risk: "Low",
-    desc: "Stablecoin lending on Blend. Steady, predictable returns with minimal exposure.",
-    accentText: "text-sky-400",
-    border: "border-sky-500/20",
-    btnVariant: "secondary" as const,
-  },
-  {
-    name: "Balanced",
-    apy: "6–10%",
-    risk: "Medium",
-    desc: "Mix of lending and DEX liquidity provision for better yield without excessive risk.",
-    accentText: "text-emerald-400",
-    border: "border-emerald-500/30",
-    btnVariant: "primary" as const,
-    featured: true,
-  },
-  {
-    name: "Growth",
-    apy: "10–15%",
-    risk: "Higher",
-    desc: "Aggressive multi-protocol deployment for maximum returns.",
-    accentText: "text-amber-400",
-    border: "border-amber-500/20",
-    btnVariant: "secondary" as const,
-  },
-];
+import { useI18n } from "@/contexts";
 
 export function StrategiesSection() {
+  const { messages } = useI18n();
+
   return (
     <section id="strategies" className="mx-auto max-w-6xl px-6 py-24">
       {/* Header */}
       <div className="mb-14 text-center">
         <span className="inline-block rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-medium text-emerald-400">
-          Strategies
+          {messages.strategies.badge}
         </span>
         <h2 className="mt-4 text-3xl font-bold text-slate-50">
-          Choose your strategy
+          {messages.strategies.title}
         </h2>
         <p className="mt-3 text-base text-slate-400">
-          Pick your risk appetite. The AI handles the rest.
+          {messages.strategies.description}
         </p>
       </div>
 
       <div className="grid gap-6 md:grid-cols-3 md:items-start">
-        {strategies.map((s) => (
+        {messages.strategies.items.map((s) => (
           <Card
             key={s.name}
             glow={s.featured}
@@ -59,7 +33,7 @@ export function StrategiesSection() {
           >
             {s.featured && (
               <span className="self-start rounded-full bg-emerald-500/20 px-3 py-0.5 text-xs font-medium text-emerald-400">
-                Most popular
+                {messages.strategies.mostPopular}
               </span>
             )}
 
@@ -69,7 +43,7 @@ export function StrategiesSection() {
               <p className="mt-1 font-mono text-3xl font-bold text-slate-50">
                 {s.apy}
               </p>
-              <p className="text-xs text-slate-500">APY &middot; {s.risk} risk</p>
+              <p className="text-xs text-slate-500">{messages.strategies.apyRiskLabel.replace("{{risk}}", s.risk)}</p>
             </div>
 
             <p className="flex-1 text-sm leading-relaxed text-slate-400">
@@ -77,7 +51,7 @@ export function StrategiesSection() {
             </p>
 
             <Button variant={s.btnVariant} className="w-full">
-              Select {s.name}
+              {messages.strategies.selectPrefix} {s.name}
             </Button>
           </Card>
         ))}

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -1,35 +1,38 @@
-const currencyFormatter = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
+import { getActiveIntlLocale } from "@/lib/i18n/locale-state";
+import { dictionaries } from "@/lib/i18n/messages";
+import { getActiveLocale } from "@/lib/i18n/locale-state";
 
-const percentFormatter = new Intl.NumberFormat("en-US", {
-  minimumFractionDigits: 1,
-  maximumFractionDigits: 1,
-});
+function getCurrencyFormatter() {
+  return new Intl.NumberFormat(getActiveIntlLocale(), {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
 
-const timestampFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  hour: "numeric",
-  minute: "2-digit",
-});
+function getPercentFormatter() {
+  return new Intl.NumberFormat(getActiveIntlLocale(), {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+}
 
-const syncFormatter = new Intl.DateTimeFormat("en-US", {
-  month: "short",
-  day: "numeric",
-  hour: "numeric",
-  minute: "2-digit",
-});
+function getTimestampFormatter() {
+  return new Intl.DateTimeFormat(getActiveIntlLocale(), {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
 
 export function formatCurrency(value: number): string {
-  return currencyFormatter.format(value);
+  return getCurrencyFormatter().format(value);
 }
 
 export function formatSignedCurrency(value: number): string {
-  const absoluteValue = currencyFormatter.format(Math.abs(value));
+  const absoluteValue = getCurrencyFormatter().format(Math.abs(value));
 
   if (value > 0) {
     return `+${absoluteValue}`;
@@ -43,11 +46,11 @@ export function formatSignedCurrency(value: number): string {
 }
 
 export function formatPercent(value: number): string {
-  return `${percentFormatter.format(value)}%`;
+  return `${getPercentFormatter().format(value)}%`;
 }
 
 export function formatSignedPercent(value: number): string {
-  const absoluteValue = `${percentFormatter.format(Math.abs(value))}%`;
+  const absoluteValue = `${getPercentFormatter().format(Math.abs(value))}%`;
 
   if (value > 0) {
     return `+${absoluteValue}`;
@@ -61,9 +64,10 @@ export function formatSignedPercent(value: number): string {
 }
 
 export function formatTimestamp(value: string): string {
-  return timestampFormatter.format(new Date(value));
+  return getTimestampFormatter().format(new Date(value));
 }
 
 export function formatSyncLabel(value: string): string {
-  return `Updated ${syncFormatter.format(new Date(value))}`;
+  const prefix = dictionaries[getActiveLocale()].formatters.updatedPrefix;
+  return `${prefix} ${getTimestampFormatter().format(new Date(value))}`;
 }

--- a/src/lib/i18n/locale-state.ts
+++ b/src/lib/i18n/locale-state.ts
@@ -1,0 +1,15 @@
+import { AppLocale, localeToIntl } from "./messages";
+
+let activeLocale: AppLocale = "en";
+
+export function setActiveLocale(locale: AppLocale) {
+  activeLocale = locale;
+}
+
+export function getActiveLocale(): AppLocale {
+  return activeLocale;
+}
+
+export function getActiveIntlLocale(): string {
+  return localeToIntl[activeLocale];
+}

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -1,0 +1,533 @@
+export type AppLocale = "en" | "fr";
+
+export interface LandingFeatureItem {
+  icon: string;
+  title: string;
+  desc: string;
+  accent: string;
+  bg: string;
+}
+
+export interface HowItWorksItem {
+  n: string;
+  title: string;
+  desc: string;
+}
+
+export interface StrategyItem {
+  name: string;
+  apy: string;
+  risk: string;
+  desc: string;
+  accentText: string;
+  border: string;
+  btnVariant: "primary" | "secondary";
+  featured?: boolean;
+}
+
+export interface SecurityFeatureItem {
+  title: string;
+  stat: string;
+  statLabel: string;
+  desc: string;
+}
+
+export interface AppMessages {
+  locale: {
+    label: string;
+    switcherLabel: string;
+    options: Record<AppLocale, string>;
+  };
+  navbar: {
+    features: string;
+    howItWorks: string;
+    strategies: string;
+    help: string;
+    account: string;
+    signOut: string;
+    signIn: string;
+  };
+  hero: {
+    badge: string;
+    titleBeforeAccent: string;
+    titleAccent: string;
+    titleAfterAccent: string;
+    description: string;
+    stats: Array<{ label: string; value: string }>;
+  };
+  heroActions: {
+    openDashboardArrow: string;
+    connectWallet: string;
+    connecting: string;
+    openDashboard: string;
+    learnMore: string;
+    errorNoWallet: string;
+    errorFailedConnect: string;
+  };
+  features: {
+    badge: string;
+    title: string;
+    description: string;
+    items: LandingFeatureItem[];
+  };
+  howItWorks: {
+    badge: string;
+    title: string;
+    description: string;
+    steps: HowItWorksItem[];
+  };
+  strategies: {
+    badge: string;
+    title: string;
+    description: string;
+    mostPopular: string;
+    apyRiskLabel: string;
+    selectPrefix: string;
+    items: StrategyItem[];
+  };
+  security: {
+    badge: string;
+    title: string;
+    description: string;
+    items: SecurityFeatureItem[];
+  };
+  cta: {
+    badge: string;
+    title: string;
+    description: string;
+    connectWallet: string;
+    openDashboard: string;
+    trust: string[];
+  };
+  footer: {
+    builtOn: string;
+    designTokens: string;
+  };
+  formatters: {
+    updatedPrefix: string;
+  };
+}
+
+export const localeToIntl: Record<AppLocale, string> = {
+  en: "en-US",
+  fr: "fr-FR",
+};
+
+export const dictionaries: Record<AppLocale, AppMessages> = {
+  en: {
+    locale: {
+      label: "Language",
+      switcherLabel: "Switch language",
+      options: {
+        en: "English",
+        fr: "Français",
+      },
+    },
+    navbar: {
+      features: "Features",
+      howItWorks: "How it works",
+      strategies: "Strategies",
+      help: "Help",
+      account: "Account",
+      signOut: "Sign Out",
+      signIn: "Sign In",
+    },
+    hero: {
+      badge: "Powered by Stellar · Built with AI",
+      titleBeforeAccent: "Your money, working",
+      titleAccent: "24/7",
+      titleAfterAccent: "on autopilot",
+      description:
+        "NeuroWealth is an autonomous AI agent that finds and deploys your USDC into the highest-yielding opportunities on Stellar DeFi — automatically, every hour.",
+      stats: [
+        { label: "Avg. APY", value: "8.4%" },
+        { label: "Finality", value: "~5s" },
+        { label: "Tx Fee", value: "<$0.01" },
+      ],
+    },
+    heroActions: {
+      openDashboardArrow: "Open Dashboard →",
+      connectWallet: "Connect Wallet",
+      connecting: "Connecting...",
+      openDashboard: "Open Dashboard",
+      learnMore: "Learn More ↓",
+      errorNoWallet: "Freighter wallet not found. Please install it.",
+      errorFailedConnect: "Failed to connect. Please try again.",
+    },
+    features: {
+      badge: "Features",
+      title: "Everything you need",
+      description: "Simple on the surface, powerful underneath.",
+      items: [
+        {
+          icon: "🤖",
+          title: "AI Agent",
+          desc: "Autonomous 24/7 yield optimization across Stellar DeFi protocols.",
+          accent: "text-sky-400",
+          bg: "bg-sky-500/10",
+        },
+        {
+          icon: "💬",
+          title: "Natural Language",
+          desc: "Chat to deposit, withdraw, and check balances — no DeFi knowledge needed.",
+          accent: "text-emerald-400",
+          bg: "bg-emerald-500/10",
+        },
+        {
+          icon: "📈",
+          title: "Auto-Rebalancing",
+          desc: "The agent shifts funds to the best opportunities automatically, hourly.",
+          accent: "text-sky-400",
+          bg: "bg-sky-500/10",
+        },
+        {
+          icon: "🔐",
+          title: "Non-Custodial",
+          desc: "Your funds live in audited Soroban smart contracts. Always yours.",
+          accent: "text-emerald-400",
+          bg: "bg-emerald-500/10",
+        },
+        {
+          icon: "⚡",
+          title: "Instant Withdrawals",
+          desc: "No lock-ups, no penalties. Withdraw anytime in seconds.",
+          accent: "text-amber-400",
+          bg: "bg-amber-500/10",
+        },
+        {
+          icon: "🌍",
+          title: "Global Access",
+          desc: "No geographic restrictions, no bank account required.",
+          accent: "text-sky-400",
+          bg: "bg-sky-500/10",
+        },
+      ],
+    },
+    howItWorks: {
+      badge: "How it works",
+      title: "Four steps to passive yield",
+      description: "Get started in minutes, earn around the clock.",
+      steps: [
+        {
+          n: "01",
+          title: "Deposit USDC",
+          desc: "Connect your Freighter wallet and deposit USDC into the NeuroWealth vault.",
+        },
+        {
+          n: "02",
+          title: "AI Deploys Funds",
+          desc: "The agent detects your deposit and immediately deploys to the best protocol.",
+        },
+        {
+          n: "03",
+          title: "Yield Accumulates",
+          desc: "Earnings compound 24/7. The agent rebalances hourly if better rates appear.",
+        },
+        {
+          n: "04",
+          title: "Withdraw Anytime",
+          desc: "Request a withdrawal — funds arrive in your wallet within seconds.",
+        },
+      ],
+    },
+    strategies: {
+      badge: "Strategies",
+      title: "Choose your strategy",
+      description: "Pick your risk appetite. The AI handles the rest.",
+      mostPopular: "Most popular",
+      apyRiskLabel: "APY · {{risk}} risk",
+      selectPrefix: "Select",
+      items: [
+        {
+          name: "Conservative",
+          apy: "3–6%",
+          risk: "Low",
+          desc: "Stablecoin lending on Blend. Steady, predictable returns with minimal exposure.",
+          accentText: "text-sky-400",
+          border: "border-sky-500/20",
+          btnVariant: "secondary",
+        },
+        {
+          name: "Balanced",
+          apy: "6–10%",
+          risk: "Medium",
+          desc: "Mix of lending and DEX liquidity provision for better yield without excessive risk.",
+          accentText: "text-emerald-400",
+          border: "border-emerald-500/30",
+          btnVariant: "primary",
+          featured: true,
+        },
+        {
+          name: "Growth",
+          apy: "10–15%",
+          risk: "Higher",
+          desc: "Aggressive multi-protocol deployment for maximum returns.",
+          accentText: "text-amber-400",
+          border: "border-amber-500/20",
+          btnVariant: "secondary",
+        },
+      ],
+    },
+    security: {
+      badge: "Security",
+      title: "Built to be trusted",
+      description: "Security is not an afterthought — it is the foundation.",
+      items: [
+        {
+          title: "Non-Custodial",
+          stat: "100%",
+          statLabel: "Your keys, your coins",
+          desc: "Your USDC stays in audited Soroban smart contracts that only you can authorize. We never hold or access your private keys.",
+        },
+        {
+          title: "Audited Contracts",
+          stat: "0",
+          statLabel: "Security incidents",
+          desc: "All smart contracts undergo rigorous third-party security audits before mainnet deployment. Source code is publicly verifiable on-chain.",
+        },
+        {
+          title: "Open Source",
+          stat: "100%",
+          statLabel: "Transparent code",
+          desc: "Every line of code is open source and community-reviewed. No black boxes — verify exactly what the protocol does with your funds.",
+        },
+        {
+          title: "Stellar Network",
+          stat: "10+",
+          statLabel: "Years of proven uptime",
+          desc: "Built on Stellar's battle-tested blockchain with a decade of proven reliability, instant finality (~5s), and sub-cent transaction fees.",
+        },
+      ],
+    },
+    cta: {
+      badge: "Get started today",
+      title: "Ready to put your USDC to work?",
+      description:
+        "Join thousands earning passive yield on Stellar DeFi. Connect your Freighter wallet and let NeuroWealth handle the rest.",
+      connectWallet: "Connect Wallet",
+      openDashboard: "Open Dashboard",
+      trust: [
+        "✔ Non-custodial",
+        "✔ Audited contracts",
+        "✔ No lock-ups",
+        "✔ Open source",
+      ],
+    },
+    footer: {
+      builtOn: "Built on Stellar",
+      designTokens: "Design Tokens",
+    },
+    formatters: {
+      updatedPrefix: "Updated",
+    },
+  },
+  fr: {
+    locale: {
+      label: "Langue",
+      switcherLabel: "Changer de langue",
+      options: {
+        en: "Anglais",
+        fr: "Français",
+      },
+    },
+    navbar: {
+      features: "Fonctionnalités",
+      howItWorks: "Comment ça marche",
+      strategies: "Stratégies",
+      help: "Aide",
+      account: "Compte",
+      signOut: "Se déconnecter",
+      signIn: "Se connecter",
+    },
+    hero: {
+      badge: "Propulsé par Stellar · Construit avec l’IA",
+      titleBeforeAccent: "Votre argent travaille",
+      titleAccent: "24h/24",
+      titleAfterAccent: "en pilote automatique",
+      description:
+        "NeuroWealth est un agent IA autonome qui place votre USDC dans les meilleures opportunités de rendement de l’écosystème DeFi Stellar — automatiquement, avec optimisation horaire.",
+      stats: [
+        { label: "APY moy.", value: "8,4 %" },
+        { label: "Finalité", value: "~5 s" },
+        { label: "Frais tx", value: "<0,01 $" },
+      ],
+    },
+    heroActions: {
+      openDashboardArrow: "Ouvrir le tableau de bord →",
+      connectWallet: "Connecter le wallet",
+      connecting: "Connexion en cours...",
+      openDashboard: "Ouvrir le tableau de bord",
+      learnMore: "En savoir plus ↓",
+      errorNoWallet:
+        "Wallet Freighter introuvable. Veuillez l’installer.",
+      errorFailedConnect:
+        "Échec de la connexion. Veuillez réessayer.",
+    },
+    features: {
+      badge: "Fonctionnalités",
+      title: "Tout ce dont vous avez besoin",
+      description: "Simple en surface, puissant en profondeur.",
+      items: [
+        {
+          icon: "🤖",
+          title: "Agent IA autonome",
+          desc: "Optimisation du rendement 24h/24 et 7j/7 sur plusieurs protocoles DeFi Stellar.",
+          accent: "text-sky-400",
+          bg: "bg-sky-500/10",
+        },
+        {
+          icon: "💬",
+          title: "Langage naturel",
+          desc: "Déposer, retirer et vérifier vos soldes par chat — sans expertise DeFi.",
+          accent: "text-emerald-400",
+          bg: "bg-emerald-500/10",
+        },
+        {
+          icon: "📈",
+          title: "Rééquilibrage automatique",
+          desc: "L’agent réalloue vos fonds automatiquement vers les meilleures opportunités.",
+          accent: "text-sky-400",
+          bg: "bg-sky-500/10",
+        },
+        {
+          icon: "🔐",
+          title: "Non-custodial",
+          desc: "Vos fonds restent dans des smart contracts Soroban audités. Vous gardez le contrôle.",
+          accent: "text-emerald-400",
+          bg: "bg-emerald-500/10",
+        },
+        {
+          icon: "⚡",
+          title: "Retraits instantanés",
+          desc: "Aucun blocage, aucune pénalité. Retirez vos fonds à tout moment en quelques secondes.",
+          accent: "text-amber-400",
+          bg: "bg-amber-500/10",
+        },
+        {
+          icon: "🌍",
+          title: "Accès global",
+          desc: "Sans restriction géographique et sans compte bancaire traditionnel.",
+          accent: "text-sky-400",
+          bg: "bg-sky-500/10",
+        },
+      ],
+    },
+    howItWorks: {
+      badge: "Comment ça marche",
+      title: "Quatre étapes vers le rendement passif",
+      description: "Commencez en quelques minutes, gagnez en continu.",
+      steps: [
+        {
+          n: "01",
+          title: "Déposer des USDC",
+          desc: "Connectez votre wallet Freighter et déposez des USDC dans le vault NeuroWealth.",
+        },
+        {
+          n: "02",
+          title: "L’IA déploie les fonds",
+          desc: "L’agent détecte votre dépôt et l’alloue immédiatement au meilleur protocole.",
+        },
+        {
+          n: "03",
+          title: "Les rendements s’accumulent",
+          desc: "Les gains se composent 24h/24. L’agent rééquilibre dès qu’un meilleur taux apparaît.",
+        },
+        {
+          n: "04",
+          title: "Retirer à tout moment",
+          desc: "Demandez un retrait — les fonds arrivent dans votre wallet en quelques secondes.",
+        },
+      ],
+    },
+    strategies: {
+      badge: "Stratégies",
+      title: "Choisissez votre stratégie",
+      description: "Définissez votre niveau de risque. L’IA gère le reste.",
+      mostPopular: "La plus populaire",
+      apyRiskLabel: "APY · risque {{risk}}",
+      selectPrefix: "Choisir",
+      items: [
+        {
+          name: "Prudente",
+          apy: "3–6 %",
+          risk: "faible",
+          desc: "Prêts en stablecoins sur Blend pour des rendements stables et prévisibles.",
+          accentText: "text-sky-400",
+          border: "border-sky-500/20",
+          btnVariant: "secondary",
+        },
+        {
+          name: "Équilibrée",
+          apy: "6–10 %",
+          risk: "moyen",
+          desc: "Combinaison de lending et de liquidité DEX pour un bon équilibre risque/rendement.",
+          accentText: "text-emerald-400",
+          border: "border-emerald-500/30",
+          btnVariant: "primary",
+          featured: true,
+        },
+        {
+          name: "Croissance",
+          apy: "10–15 %",
+          risk: "élevé",
+          desc: "Allocation agressive multi-protocole pour maximiser le potentiel de rendement.",
+          accentText: "text-amber-400",
+          border: "border-amber-500/20",
+          btnVariant: "secondary",
+        },
+      ],
+    },
+    security: {
+      badge: "Sécurité",
+      title: "Conçu pour inspirer confiance",
+      description: "La sécurité n’est pas une option — c’est la base.",
+      items: [
+        {
+          title: "Non-custodial",
+          stat: "100 %",
+          statLabel: "Vos clés, vos fonds",
+          desc: "Vos USDC restent dans des smart contracts Soroban audités que vous seul pouvez autoriser.",
+        },
+        {
+          title: "Contrats audités",
+          stat: "0",
+          statLabel: "incident de sécurité",
+          desc: "Tous les smart contracts passent des audits de sécurité tiers avant déploiement mainnet.",
+        },
+        {
+          title: "Open Source",
+          stat: "100 %",
+          statLabel: "code transparent",
+          desc: "Chaque ligne de code est ouverte et vérifiable par la communauté — sans boîte noire.",
+        },
+        {
+          title: "Réseau Stellar",
+          stat: "10+",
+          statLabel: "ans de disponibilité prouvée",
+          desc: "Basé sur la blockchain Stellar, avec finalité rapide et frais de transaction très faibles.",
+        },
+      ],
+    },
+    cta: {
+      badge: "Commencez dès aujourd’hui",
+      title: "Prêt à faire travailler vos USDC ?",
+      description:
+        "Rejoignez des milliers d’utilisateurs qui génèrent un rendement passif sur la DeFi Stellar.",
+      connectWallet: "Connecter le wallet",
+      openDashboard: "Ouvrir le tableau de bord",
+      trust: [
+        "✔ Non-custodial",
+        "✔ Contrats audités",
+        "✔ Aucun blocage",
+        "✔ Open source",
+      ],
+    },
+    footer: {
+      builtOn: "Construit sur Stellar",
+      designTokens: "Tokens de design",
+    },
+    formatters: {
+      updatedPrefix: "Mis à jour",
+    },
+  },
+};


### PR DESCRIPTION
- Create design token docs with visual swatches
- Add typography, spacing, shadows, and radii examples
- Include do/don't usage patterns
- Add accessibility notes for color usage
- Externalize UI strings into translation dictionaries
- Add accessible locale switcher with mock language packs
- Implement locale-aware date and number formatting
- Validate layout stability for long translated strings

Closes #77 
closes #78 