### PR TITLE
Fix route metadata coverage, user type drift, audit triage, and unit tests

### DIFF
--- a/docs/security/npm-audit-policy.md
+++ b/docs/security/npm-audit-policy.md
@@ -1,0 +1,43 @@
+# npm audit triage policy for Stellar and wallet dependencies
+
+## Snapshot
+
+- Reviewed on: `2026-04-24`
+- Command: `corepack yarn audit --json`
+- Summary: `3 critical`, `10 high`, `11 moderate`, `6 low`
+- Current direct framework risk is concentrated in `next@14.2.3`
+- Current wallet-stack risk is concentrated under `@creit.tech/stellar-wallets-kit@1.9.5`
+- `yarn.lock` still pulls `@walletconnect/modal@2.6.2` and `@walletconnect/sign-client@2.11.2`, but this audit snapshot did not report separate `@walletconnect/*` advisories. The actionable wallet findings came from sibling transitive packages in the same SDK tree.
+
+## Policy
+
+- Do not run `npm audit fix --force` or any equivalent breaking upgrade without maintainer sign-off.
+- Treat direct dependencies with patched releases as `must-fix`, especially framework and auth-routing packages.
+- Treat transitive wallet findings as one of: `must-fix now`, `accepted temporary risk`, or `monitor only`. Every accepted risk needs a reason and a review date.
+- Prefer this order of remediation:
+  1. Patch or minor upgrade the direct dependency.
+  2. Add a targeted override or resolution only after build, typecheck, tests, and wallet smoke checks pass.
+  3. If no safe override exists, open or link an upstream issue and schedule a review instead of forcing the tree.
+
+## Current decisions
+
+| Package path | Severity | Decision | Reason | Next action |
+| --- | --- | --- | --- | --- |
+| `next@14.2.3` | `critical/high/moderate/low` | `must-fix` | This is a direct dependency and the audit reports multiple patched releases on the stable `14.2.x` line, including `14.2.35`. | Open a follow-up upgrade PR to `next@14.2.35` and rerun build plus auth route QA. |
+| `next > postcss@8.4.31` | `moderate` | `must-fix with Next upgrade` | The reported `postcss` issue is coming through `next`, so a framework upgrade is safer than overriding `postcss` alone. | Resolve together with the `next` upgrade PR. |
+| `@creit.tech/stellar-wallets-kit > @trezor/connect-web > @trezor/connect > @trezor/protobuf > protobufjs@7.4.0` and `... > @trezor/transport > @trezor/protobuf > protobufjs@7.4.0` | `critical` | `accepted temporary risk` | The advisory requires attacker-controlled protobuf definitions. This app does not define or decode custom protobuf schemas itself, but the dependency sits in a security-sensitive wallet tree and should not be ignored. | Keep wallet scope limited, ask upstream maintainers for a patched tree or compatible override, and review again within 7 days. |
+| `@creit.tech/stellar-wallets-kit > @hot-wallet/sdk > @solana/web3.js > jayson > uuid` and `... > rpc-websockets > uuid` | `moderate` | `accepted temporary risk` | The finding is a buffer-bounds issue in transitive UUID helpers, not a directly invoked application surface in the current Stellar flows. | Recheck on the next wallet SDK bump and prefer an upstream dependency refresh over a forced override. |
+| `@creit.tech/stellar-wallets-kit > ... > elliptic@6.6.1` | `low` | `monitor only` | The advisory currently lists no patched version recommendation. Forcing replacements here is higher risk than the reported low-severity issue. | Track upstream maintainer guidance and rerun audit on each wallet SDK update. |
+
+## Review cadence
+
+- Re-run `yarn audit --json` on every dependency upgrade PR that touches `next`, wallet SDKs, or auth/middleware code.
+- Re-review accepted wallet risks within 7 days while `@creit.tech/stellar-wallets-kit` remains in use.
+- Do a full audit at least monthly until the direct `next` findings are cleared.
+
+## PR QA checklist for dependency triage changes
+
+- `yarn typecheck`
+- `yarn test`
+- `yarn build`
+- Smoke test `/login`, `/dashboard`, `/dashboard/settings/security`, and wallet-connect entry points after any dependency upgrade

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint --max-warnings 100",
+    "typecheck": "tsc --noEmit",
+    "test": "TZ=UTC node --import tsx --test \"src/**/*.test.ts\"",
     "qa:visual-baseline": "node scripts/capture-visual-baselines.mjs"
   },
   "dependencies": {
@@ -38,6 +40,7 @@
     "playwright": "^1.58.2",
     "postcss": "^8.5.8",
     "tailwindcss": "^4.2.2",
+    "tsx": "^4.20.6",
     "typescript": "^5"
   }
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -32,8 +32,8 @@ export default function LoginPage() {
       const mockToken = "GBTKU_DEMO_TOKEN_X3QR";
       signIn(mockToken, {
         id: "demo-user",
-        address: "GBTKU...X3QR",
         displayName: "Demo User",
+        walletAddress: "GDEMO...XLM",
         avatarInitials: "DU",
       });
       router.replace(from);

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -96,11 +96,11 @@ export function Navbar() {
             <div className="flex items-center gap-3 ml-2 pl-4 border-l border-white/10">
               <div className="flex flex-col items-end">
                 <span className="text-[10px] text-slate-500 uppercase font-bold leading-none">{messages.navbar.account}</span>
-                <span className="text-xs text-white font-medium">{user.name}</span>
+                <span className="text-xs text-white font-medium">{user.displayName}</span>
               </div>
               <button
                 onClick={signOut}
-                aria-label={`Sign out of ${user.name}'s account`}
+                aria-label={`Sign out of ${user.displayName}'s account`}
                 className="text-[10px] text-slate-500 hover:text-red-400 transition-colors uppercase font-bold"
               >
                 {messages.navbar.signOut}

--- a/src/components/dashboard/MobileBottomNav.tsx
+++ b/src/components/dashboard/MobileBottomNav.tsx
@@ -2,22 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import {
-  BarChart2,
-  History,
-  LayoutDashboard,
-  Settings,
-  TrendingUp,
-} from "lucide-react";
+import { dashboardNavigation } from "@/lib/routeMetadata";
 import { cn } from "@/lib/utils";
-
-const NAV_ITEMS = [
-  { href: "/dashboard", label: "Home", icon: LayoutDashboard, exact: true },
-  { href: "/dashboard/portfolio", label: "Portfolio", icon: BarChart2, exact: false },
-  { href: "/dashboard/activity", label: "Activity", icon: History, exact: false },
-  { href: "/dashboard/strategy", label: "Strategy", icon: TrendingUp, exact: false },
-  { href: "/dashboard/settings", label: "Settings", icon: Settings, exact: false },
-] as const;
 
 export default function MobileBottomNav() {
   const pathname = usePathname();
@@ -32,7 +18,7 @@ export default function MobileBottomNav() {
       aria-label="Mobile navigation"
     >
       <ul className="flex items-center justify-around h-16" role="list">
-        {NAV_ITEMS.map(({ href, label, icon: Icon, exact }) => {
+        {dashboardNavigation.map(({ href, mobileLabel, icon: Icon, exact }) => {
           const active = isActive(href, exact);
           return (
             <li key={href} className="flex-1">
@@ -48,7 +34,7 @@ export default function MobileBottomNav() {
                   className={cn("w-5 h-5", active && "stroke-[2.25]")}
                   aria-hidden="true"
                 />
-                <span>{label}</span>
+                <span>{mobileLabel}</span>
               </Link>
             </li>
           );

--- a/src/components/dashboard/Sidebar.tsx
+++ b/src/components/dashboard/Sidebar.tsx
@@ -2,27 +2,11 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import {
-  BarChart2,
-  History,
-  LayoutDashboard,
-  LogOut,
-  Settings,
-  TrendingUp,
-  Zap,
-} from "lucide-react";
+import { LogOut, Zap } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
+import { dashboardNavigation } from "@/lib/routeMetadata";
+import { getUserAddressLabel, getUserInitials } from "@/lib/user";
 import { cn } from "@/lib/utils";
-
-// ── Nav items ─────────────────────────────────────────────────────────────────
-
-const NAV_ITEMS = [
-  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard, exact: true },
-  { href: "/dashboard/portfolio", label: "Portfolio", icon: BarChart2, exact: false },
-  { href: "/dashboard/activity", label: "Activity", icon: History, exact: false },
-  { href: "/dashboard/strategy", label: "Strategy", icon: TrendingUp, exact: false },
-  { href: "/dashboard/settings", label: "Settings", icon: Settings, exact: false },
-] as const;
 
 // ── Sidebar component ─────────────────────────────────────────────────────────
 
@@ -52,7 +36,7 @@ export default function Sidebar() {
         <p className="px-3 mb-2 text-xs font-semibold text-text-muted uppercase tracking-wider">
           Menu
         </p>
-        {NAV_ITEMS.map(({ href, label, icon: Icon, exact }) => (
+        {dashboardNavigation.map(({ href, label, icon: Icon, exact }) => (
           <Link
             key={href}
             href={href}
@@ -75,13 +59,15 @@ export default function Sidebar() {
             className="w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center text-xs font-semibold text-primary shrink-0"
             aria-hidden="true"
           >
-            {user?.avatarInitials ?? "??"}
+            {user?.avatarInitials ?? getUserInitials(user?.displayName ?? "")}
           </div>
           <div className="flex-1 min-w-0">
             <p className="text-sm font-medium text-text-primary truncate">
               {user?.displayName ?? "User"}
             </p>
-            <p className="text-xs text-text-muted truncate">{user?.address}</p>
+            <p className="text-xs text-text-muted truncate">
+              {getUserAddressLabel(user ?? {})}
+            </p>
           </div>
         </div>
         <button

--- a/src/components/dashboard/TopHeader.tsx
+++ b/src/components/dashboard/TopHeader.tsx
@@ -3,20 +3,13 @@
 import { Bell } from "lucide-react";
 import { useAuth } from "@/context/AuthContext";
 import { usePathname } from "next/navigation";
-
-// Map routes to display titles
-const ROUTE_TITLES: Record<string, string> = {
-  "/dashboard": "Dashboard",
-  "/dashboard/portfolio": "Portfolio",
-  "/dashboard/activity": "Activity",
-  "/dashboard/strategy": "Strategy",
-  "/dashboard/settings": "Settings",
-};
+import { getRouteLabel } from "@/lib/routeMetadata";
+import { getUserInitials } from "@/lib/user";
 
 export default function TopHeader() {
   const pathname = usePathname();
   const { user } = useAuth();
-  const title = ROUTE_TITLES[pathname] ?? "Dashboard";
+  const title = getRouteLabel(pathname);
 
   return (
     <header
@@ -58,7 +51,7 @@ export default function TopHeader() {
           className="md:hidden w-8 h-8 rounded-full bg-primary/20 flex items-center justify-center text-xs font-semibold text-primary"
           aria-hidden="true"
         >
-          {user?.avatarInitials ?? "??"}
+          {user?.avatarInitials ?? getUserInitials(user?.displayName ?? "")}
         </div>
       </div>
     </header>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from "react";
 import type { AuthState, User } from "@/types";
+import { getUserInitials } from "@/lib/user";
 
 // ── Cookie helpers ────────────────────────────────────────────────────────────
 
@@ -41,11 +42,15 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 // In production this would call /api/auth/me with the stored token.
 
 function mockUserFromToken(token: string): User {
+  const walletAddress = /^G[A-Z2-7]{20,}$/.test(token)
+    ? token
+    : "GDEMO...XLM";
+
   return {
     id: "mock-user-1",
-    address: token.startsWith("G") ? token : "GBTKU...X3QR",
     displayName: "Demo User",
-    avatarInitials: "DU",
+    walletAddress,
+    avatarInitials: getUserInitials("Demo User"),
   };
 }
 

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,7 +7,7 @@ import React, {
   useEffect,
   useCallback,
 } from "react";
-import { User, AuthSession, mockAuth } from "@/lib/mock-auth";
+import { AuthSession, mockAuth } from "@/lib/mock-auth";
 
 import { useRouter } from "next/navigation";
 import {
@@ -15,6 +15,7 @@ import {
   SESSION_STORAGE_KEY,
   SIGN_IN_PATH,
 } from "@/lib/auth-constants";
+import type { User } from "@/types";
 
 interface AuthContextType {
   user: User | null;

--- a/src/hooks/useDateFilter.test.ts
+++ b/src/hooks/useDateFilter.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  filterByDateRange,
+  filterByTimeRange,
+  type DateFilterable,
+} from "@/hooks/useDateFilter";
+
+const sampleDates: Array<DateFilterable & { id: string }> = [
+  { id: "older", date: "2026-01-02T10:00:00.000Z" },
+  { id: "middle", date: new Date("2026-01-03T12:00:00.000Z") },
+  { id: "newer", date: "2026-01-04T18:30:00.000Z" },
+  { id: "invalid", date: "not-a-date" },
+];
+
+test("filterByDateRange keeps items inside the selected day bounds", () => {
+  const filtered = filterByDateRange(sampleDates, {
+    start: new Date("2026-01-03T00:00:00.000Z"),
+    end: new Date("2026-01-04T00:00:00.000Z"),
+  });
+
+  assert.deepEqual(
+    filtered.map((item) => item.id),
+    ["middle", "newer", "invalid"],
+  );
+});
+
+test("filterByDateRange returns the original list when no bounds are set", () => {
+  const filtered = filterByDateRange(sampleDates, { start: null, end: null });
+  assert.equal(filtered, sampleDates);
+});
+
+test("filterByTimeRange applies inclusive minute bounds", () => {
+  const filtered = filterByTimeRange(
+    [
+      { id: "early", time: "08:15" },
+      { id: "window-start", time: "09:00" },
+      { id: "window-end", time: "11:30" },
+      { id: "late", time: "12:05" },
+    ],
+    { hours: 9, minutes: 0 },
+    { hours: 11, minutes: 30 },
+  );
+
+  assert.deepEqual(
+    filtered.map((item) => item.id),
+    ["window-start", "window-end"],
+  );
+});

--- a/src/hooks/useDateFilter.ts
+++ b/src/hooks/useDateFilter.ts
@@ -8,6 +8,43 @@ export interface DateFilterable {
   [key: string]: unknown;
 }
 
+export function filterByDateRange<T extends DateFilterable>(
+  data: T[],
+  range: DateRange,
+): T[] {
+  if (!range.start && !range.end) return data;
+
+  return data.filter((item) => {
+    const dateValue = item.date instanceof Date ? item.date : new Date(item.date);
+    if (isNaN(dateValue.getTime())) return true;
+
+    const timestamp = dateValue.getTime();
+    const startOk =
+      !range.start || timestamp >= new Date(range.start).setHours(0, 0, 0, 0);
+    const endOk =
+      !range.end || timestamp <= new Date(range.end).setHours(23, 59, 59, 999);
+
+    return startOk && endOk;
+  });
+}
+
+export function filterByTimeRange<T extends { time: string }>(
+  data: T[],
+  from: { hours: number; minutes: number } | null,
+  to: { hours: number; minutes: number } | null,
+): T[] {
+  if (!from && !to) return data;
+
+  return data.filter((item) => {
+    const [hours, minutes] = item.time.split(":").map(Number);
+    const itemMinutes = hours * 60 + minutes;
+    const fromMinutes = from ? from.hours * 60 + from.minutes : 0;
+    const toMinutes = to ? to.hours * 60 + to.minutes : 1439;
+
+    return itemMinutes >= fromMinutes && itemMinutes <= toMinutes;
+  });
+}
+
 /**
  * useDateFilter — filters any dataset by a DateRange.
  * Pass your full dataset and a range; get back filtered items.
@@ -19,25 +56,16 @@ export function useDateFilter<T extends DateFilterable>(
   data: T[],
   range: DateRange
 ): { filtered: T[]; count: number; hasFilter: boolean } {
-  const filtered = useMemo(() => {
-    if (!range.start && !range.end) return data;
-    return data.filter((item) => {
-      const d = item.date instanceof Date ? item.date : new Date(item.date);
-      if (isNaN(d.getTime())) return true;
-      const t = d.getTime();
-      // ✅ Clone before calling .setHours() to avoid mutating the original Date objects
-      const startOk =
-        !range.start || t >= new Date(range.start).setHours(0, 0, 0, 0);
-      const endOk =
-        !range.end || t <= new Date(range.end).setHours(23, 59, 59, 999);
-      return startOk && endOk;
-    });
-  }, [data, range.start, range.end]);
+  const { start, end } = range;
+  const filtered = useMemo(
+    () => filterByDateRange(data, { start, end }),
+    [data, start, end],
+  );
 
   return {
     filtered,
     count: filtered.length,
-    hasFilter: !!(range.start || range.end),
+    hasFilter: !!(start || end),
   };
 }
 
@@ -50,14 +78,5 @@ export function useTimeFilter<T extends { time: string }>(
   from: { hours: number; minutes: number } | null,
   to: { hours: number; minutes: number } | null
 ): T[] {
-  return useMemo(() => {
-    if (!from && !to) return data;
-    return data.filter((item) => {
-      const [h, m] = item.time.split(":").map(Number);
-      const mins = h * 60 + m;
-      const fromMins = from ? from.hours * 60 + from.minutes : 0;
-      const toMins = to ? to.hours * 60 + to.minutes : 1439;
-      return mins >= fromMins && mins <= toMins;
-    });
-  }, [data, from, to]);
+  return useMemo(() => filterByTimeRange(data, from, to), [data, from, to]);
 }

--- a/src/hooks/useTransactionList.test.ts
+++ b/src/hooks/useTransactionList.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  MOCK_TRANSACTIONS,
+  buildFilterOptions,
+  filterTransactions,
+  paginateTransactions,
+} from "@/hooks/useTransactionList";
+
+test("buildFilterOptions counts each filter group from the data set", () => {
+  const options = buildFilterOptions(MOCK_TRANSACTIONS);
+  const completed = options.find((option) => option.id === "status:completed");
+  const deposit = options.find((option) => option.id === "type:deposit");
+
+  assert.ok(completed);
+  assert.equal(
+    completed.count,
+    MOCK_TRANSACTIONS.filter((transaction) => transaction.status === "completed")
+      .length,
+  );
+
+  assert.ok(deposit);
+  assert.equal(
+    deposit.count,
+    MOCK_TRANSACTIONS.filter((transaction) => transaction.type === "deposit")
+      .length,
+  );
+});
+
+test("filterTransactions combines status and type filters", () => {
+  const filtered = filterTransactions(MOCK_TRANSACTIONS, [
+    "status:completed",
+    "type:deposit",
+  ]);
+
+  assert.ok(filtered.length > 0);
+  assert.ok(
+    filtered.every(
+      (transaction) =>
+        transaction.status === "completed" &&
+        transaction.type === "deposit",
+    ),
+  );
+});
+
+test("paginateTransactions slices the requested page", () => {
+  const pageOne = paginateTransactions(MOCK_TRANSACTIONS, 1, 5);
+  const pageTwo = paginateTransactions(MOCK_TRANSACTIONS, 2, 5);
+
+  assert.equal(pageOne.length, 5);
+  assert.equal(pageTwo.length, 5);
+  assert.notDeepEqual(pageOne, pageTwo);
+  assert.deepEqual(pageTwo, MOCK_TRANSACTIONS.slice(5, 10));
+});

--- a/src/hooks/useTransactionList.ts
+++ b/src/hooks/useTransactionList.ts
@@ -16,6 +16,40 @@ export interface Transaction {
   wallet: string;
 }
 
+export function filterTransactions(
+  transactions: Transaction[],
+  selectedFilters: string[],
+): Transaction[] {
+  if (selectedFilters.length === 0) {
+    return transactions;
+  }
+
+  const statusFilters = selectedFilters
+    .filter((filter) => filter.startsWith("status:"))
+    .map((filter) => filter.replace("status:", ""));
+  const typeFilters = selectedFilters
+    .filter((filter) => filter.startsWith("type:"))
+    .map((filter) => filter.replace("type:", ""));
+
+  return transactions.filter((transaction) => {
+    const statusOk =
+      statusFilters.length === 0 || statusFilters.includes(transaction.status);
+    const typeOk =
+      typeFilters.length === 0 || typeFilters.includes(transaction.type);
+
+    return statusOk && typeOk;
+  });
+}
+
+export function paginateTransactions(
+  transactions: Transaction[],
+  page: number,
+  itemsPerPage: number,
+): Transaction[] {
+  const start = (page - 1) * itemsPerPage;
+  return transactions.slice(start, start + itemsPerPage);
+}
+
 // Seeded mock data
 const STATUSES: TxStatus[] = ["completed", "pending", "failed", "cancelled"];
 const TYPES: TxType[] = ["transfer", "deposit", "withdrawal", "swap"];
@@ -62,21 +96,15 @@ export function useTransactionList(itemsPerPage = 8) {
   const [selectedFilters, setSelectedFilters] = useState<string[]>([]);
   const [page, setPage] = useState(1);
 
-  const filtered = useMemo(() => {
-    if (selectedFilters.length === 0) return MOCK_TRANSACTIONS;
-    return MOCK_TRANSACTIONS.filter((tx) => {
-      const statusFilters = selectedFilters.filter((f) => f.startsWith("status:")).map((f) => f.replace("status:", ""));
-      const typeFilters = selectedFilters.filter((f) => f.startsWith("type:")).map((f) => f.replace("type:", ""));
-      const statusOk = statusFilters.length === 0 || statusFilters.includes(tx.status);
-      const typeOk = typeFilters.length === 0 || typeFilters.includes(tx.type);
-      return statusOk && typeOk;
-    });
-  }, [selectedFilters]);
+  const filtered = useMemo(
+    () => filterTransactions(MOCK_TRANSACTIONS, selectedFilters),
+    [selectedFilters],
+  );
 
-  const paged = useMemo(() => {
-    const start = (page - 1) * itemsPerPage;
-    return filtered.slice(start, start + itemsPerPage);
-  }, [filtered, page, itemsPerPage]);
+  const paged = useMemo(
+    () => paginateTransactions(filtered, page, itemsPerPage),
+    [filtered, page, itemsPerPage],
+  );
 
   const handleFilterChange = (next: string[]) => {
     setSelectedFilters(next);

--- a/src/lib/formatters.test.ts
+++ b/src/lib/formatters.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { setActiveLocale } from "@/lib/i18n/locale-state";
+import {
+  formatCurrency,
+  formatPercent,
+  formatSignedCurrency,
+  formatSignedPercent,
+  formatSyncLabel,
+} from "@/lib/formatters";
+
+test("formatCurrency and formatSignedCurrency follow the active locale", () => {
+  setActiveLocale("en");
+  assert.equal(formatCurrency(1234.5), "$1,234.50");
+  assert.equal(formatSignedCurrency(1234.5), "+$1,234.50");
+  assert.equal(formatSignedCurrency(-1234.5), "-$1,234.50");
+
+  setActiveLocale("fr");
+  assert.equal(
+    formatCurrency(1234.5),
+    new Intl.NumberFormat("fr-FR", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(1234.5),
+  );
+});
+
+test("formatPercent helpers keep signs stable", () => {
+  setActiveLocale("en");
+  assert.equal(formatPercent(8.44), "8.4%");
+  assert.equal(formatSignedPercent(8.44), "+8.4%");
+  assert.equal(formatSignedPercent(-8.44), "-8.4%");
+  assert.equal(formatSignedPercent(0), "0.0%");
+});
+
+test("formatSyncLabel switches its prefix with the active locale", () => {
+  const value = "2026-01-02T15:04:00.000Z";
+
+  setActiveLocale("en");
+  assert.match(formatSyncLabel(value), /^Updated /);
+
+  setActiveLocale("fr");
+  assert.match(formatSyncLabel(value), /^Mis à jour /);
+});

--- a/src/lib/mock-auth.ts
+++ b/src/lib/mock-auth.ts
@@ -7,15 +7,11 @@
  */
 
 import { SESSION_STORAGE_KEY } from "./auth-constants";
-
-export interface User {
-  id: string;
-  email: string;
-  name: string;
-  avatar?: string;
-  walletAddress?: string;
-  createdAt: string;
-}
+import {
+  adaptMockAuthUser,
+  type MockAuthUserRecord,
+} from "./user";
+import type { User } from "@/types";
 
 export interface AuthSession {
   user: User;
@@ -23,7 +19,7 @@ export interface AuthSession {
   expiresAt: number;
 }
 
-const MOCK_USERS: Record<string, { password: string; user: User }> = {
+const MOCK_USERS: Record<string, { password: string; user: MockAuthUserRecord }> = {
   "demo@neurowealth.app": {
     password: "demo123",
     user: {
@@ -41,6 +37,51 @@ function generateToken(): string {
   return `mock_token_${Math.random().toString(36).slice(2)}`;
 }
 
+function isLegacyMockAuthUserRecord(value: unknown): value is MockAuthUserRecord {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const candidate = value as Partial<MockAuthUserRecord>;
+  return (
+    typeof candidate.id === "string" &&
+    typeof candidate.email === "string" &&
+    typeof candidate.name === "string"
+  );
+}
+
+function normalizeSession(value: unknown): AuthSession | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const candidate = value as Partial<AuthSession> & {
+    user?: User | MockAuthUserRecord;
+  };
+
+  if (typeof candidate.token !== "string" || typeof candidate.expiresAt !== "number") {
+    return null;
+  }
+
+  if (!candidate.user) {
+    return null;
+  }
+
+  const user = isLegacyMockAuthUserRecord(candidate.user)
+    ? adaptMockAuthUser(candidate.user)
+    : (candidate.user as User);
+
+  if (!user.id || !user.displayName) {
+    return null;
+  }
+
+  return {
+    user,
+    token: candidate.token,
+    expiresAt: candidate.expiresAt,
+  };
+}
+
 export const mockAuth = {
   /** Read the current session from localStorage (client-only). */
   getSession(): AuthSession | null {
@@ -48,7 +89,11 @@ export const mockAuth = {
     try {
       const raw = localStorage.getItem(SESSION_STORAGE_KEY);
       if (!raw) return null;
-      const session: AuthSession = JSON.parse(raw);
+      const session = normalizeSession(JSON.parse(raw));
+      if (!session) {
+        localStorage.removeItem(SESSION_STORAGE_KEY);
+        return null;
+      }
       if (Date.now() > session.expiresAt) {
         localStorage.removeItem(SESSION_STORAGE_KEY);
         return null;
@@ -71,7 +116,7 @@ export const mockAuth = {
       throw new Error("Invalid email or password");
     }
     const session: AuthSession = {
-      user: record.user,
+      user: adaptMockAuthUser(record.user),
       token: generateToken(),
       expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000, // 7 days
     };
@@ -90,7 +135,7 @@ export const mockAuth = {
     if (MOCK_USERS[email.toLowerCase()]) {
       throw new Error("An account with this email already exists");
     }
-    const user: User = {
+    const user: MockAuthUserRecord = {
       id: `usr_${Math.random().toString(36).slice(2)}`,
       email: email.toLowerCase(),
       name,
@@ -98,7 +143,7 @@ export const mockAuth = {
     };
     MOCK_USERS[email.toLowerCase()] = { password, user };
     const session: AuthSession = {
-      user,
+      user: adaptMockAuthUser(user),
       token: generateToken(),
       expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
     };

--- a/src/lib/mock-services.ts
+++ b/src/lib/mock-services.ts
@@ -34,6 +34,7 @@ import {
   type TransactionFieldErrors,
 } from "./transactions";
 import type { AuthSession } from "./mock-auth";
+import { adaptMockAuthUser } from "./user";
 
 // ─── Shared error model ───────────────────────────────────────────────────────
 
@@ -113,12 +114,12 @@ export const mockAuthService: AuthService = {
     }
 
     const session: AuthSession = {
-      user: {
+      user: adaptMockAuthUser({
         id: "u1",
         email,
         name: email.split("@")[0],
         createdAt: new Date().toISOString(),
-      },
+      }),
       token: "mock-jwt-" + Math.random().toString(36).slice(2, 9),
       expiresAt: Date.now() + 1000 * 60 * 60 * 24 * 7,
     };
@@ -147,12 +148,12 @@ export const mockAuthService: AuthService = {
     }
 
     const session: AuthSession = {
-      user: {
+      user: adaptMockAuthUser({
         id: "u" + Math.random().toString(36).slice(2, 9),
         email,
         name,
         createdAt: new Date().toISOString(),
-      },
+      }),
       token: "mock-jwt-" + Math.random().toString(36).slice(2, 9),
       expiresAt: Date.now() + 1000 * 60 * 60 * 24 * 7,
     };

--- a/src/lib/routeMetadata.test.ts
+++ b/src/lib/routeMetadata.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildBreadcrumbsFromPath,
+  getRouteLabel,
+  routeMetadata,
+} from "@/lib/routeMetadata";
+
+function collectDashboardPageRoutes(directory: string): string[] {
+  const routes: string[] = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      routes.push(...collectDashboardPageRoutes(entryPath));
+      continue;
+    }
+
+    if (!entry.isFile() || entry.name !== "page.tsx") {
+      continue;
+    }
+
+    const relativeDir = path.relative(
+      path.join(process.cwd(), "src/app"),
+      path.dirname(entryPath),
+    );
+
+    const segments = relativeDir
+      .split(path.sep)
+      .filter(Boolean)
+      .filter((segment) => !segment.startsWith("("));
+
+    routes.push(`/${segments.join("/")}`);
+  }
+
+  return routes.sort();
+}
+
+test("routeMetadata covers every dashboard page route and avoids stale entries", () => {
+  const dashboardRoutes = collectDashboardPageRoutes(
+    path.join(process.cwd(), "src/app/dashboard"),
+  );
+
+  const missing = dashboardRoutes.filter((route) => !routeMetadata[route]);
+  const stale = Object.keys(routeMetadata)
+    .filter((route) => route.startsWith("/dashboard"))
+    .filter((route) => !dashboardRoutes.includes(route))
+    .sort();
+
+  assert.deepEqual(missing, []);
+  assert.deepEqual(stale, []);
+});
+
+test("route labels and breadcrumbs come from the shared route metadata", () => {
+  assert.equal(getRouteLabel("/dashboard/settings/security"), "Security");
+  assert.equal(getRouteLabel("/dashboard/missing"), "Dashboard");
+
+  const breadcrumbs = buildBreadcrumbsFromPath("/dashboard/settings/security");
+  assert.deepEqual(
+    breadcrumbs.map((item) => item.label),
+    ["Home", "Dashboard", "Settings", "Security"],
+  );
+});

--- a/src/lib/routeMetadata.tsx
+++ b/src/lib/routeMetadata.tsx
@@ -1,138 +1,111 @@
-"use client";
-
 import React from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  Activity,
+  Bell,
+  Blocks,
+  BookOpenText,
+  Gauge,
+  History,
+  LayoutDashboard,
+  LogIn,
+  Newspaper,
+  Settings,
+  Shield,
+  SlidersHorizontal,
+  UserRound,
+  Wallet,
+} from "lucide-react";
 import type { RouteMetadata } from "@/types/breadcrumb.types";
+interface AppRouteDefinition {
+  href: string;
+  label: string;
+  icon?: LucideIcon;
+  dashboardNav?: {
+    exact?: boolean;
+    mobileLabel?: string;
+  };
+}
 
-// Mock icons as simple SVG components
-export const HomeIcon = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
-    <polyline points="9 22 9 12 15 12 15 22" />
-  </svg>
-);
+interface DashboardNavigationItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  exact: boolean;
+  mobileLabel: string;
+}
 
-export const DashboardIcon = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <rect x="3" y="3" width="7" height="7" />
-    <rect x="14" y="3" width="7" height="7" />
-    <rect x="14" y="14" width="7" height="7" />
-    <rect x="3" y="14" width="7" height="7" />
-  </svg>
-);
+function renderRouteIcon(Icon?: LucideIcon): React.ReactNode | undefined {
+  return Icon ? <Icon size={14} strokeWidth={2} /> : undefined;
+}
 
-export const WalletIcon = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M20 12V22H4a2 2 0 01-2-2V6a2 2 0 012-2h16v4" />
-    <path d="M22 12a2 2 0 00-2-2h-2a2 2 0 00-2 2v0a2 2 0 002 2h2a2 2 0 002-2z" />
-  </svg>
-);
-
-export const AuditIcon = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
-    <polyline points="14 2 14 8 20 8" />
-    <line x1="16" y1="13" x2="8" y2="13" />
-    <line x1="16" y1="17" x2="8" y2="17" />
-    <polyline points="10 9 9 9 8 9" />
-  </svg>
-);
-
-export const SettingsIcon = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <circle cx="12" cy="12" r="3" />
-    <path d="M19.07 4.93a10 10 0 010 14.14M4.93 4.93a10 10 0 000 14.14" />
-    <path d="M12 2a10 10 0 010 20" />
-  </svg>
-);
-
-export const TransactionsIcon = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <polyline points="17 1 21 5 17 9" />
-    <path d="M3 11V9a4 4 0 014-4h14" />
-    <polyline points="7 23 3 19 7 15" />
-    <path d="M21 13v2a4 4 0 01-4 4H3" />
-  </svg>
-);
-
-// Mock route metadata registry
-export const routeMetadata: Record<string, RouteMetadata> = {
-  "/": { label: "Home", icon: <HomeIcon />, href: "/" },
-  "/dashboard": {
-    label: "Dashboard",
-    icon: <DashboardIcon />,
+const appRouteDefinitions: AppRouteDefinition[] = [
+  { href: "/", label: "Home", icon: LayoutDashboard },
+  {
     href: "/dashboard",
+    label: "Dashboard",
+    icon: Gauge,
+    dashboardNav: { exact: true, mobileLabel: "Home" },
   },
-  "/wallet": { label: "Wallet", icon: <WalletIcon />, href: "/wallet" },
-  "/wallet/connect": { label: "Connect Wallet", href: "/wallet/connect" },
-  "/wallet/transactions": {
-    label: "Transactions",
-    icon: <TransactionsIcon />,
-    href: "/wallet/transactions",
-  },
-  "/wallet/transactions/detail": {
-    label: "Transaction Detail",
-    href: "/wallet/transactions/detail",
-  },
-  "/audit": { label: "Audit", icon: <AuditIcon />, href: "/audit" },
-  "/audit/reports": { label: "Reports", href: "/audit/reports" },
-  "/audit/reports/2024": { label: "2024 Report", href: "/audit/reports/2024" },
-  "/settings": { label: "Settings", icon: <SettingsIcon />, href: "/settings" },
-  "/settings/profile": { label: "Profile", href: "/settings/profile" },
-};
+  { href: "/dashboard/activity", label: "Activity", icon: Activity, dashboardNav: {} },
+  { href: "/dashboard/async-states", label: "Async States", icon: Blocks },
+  { href: "/dashboard/audit", label: "Audit Trail", icon: Newspaper },
+  { href: "/dashboard/history", label: "History", icon: History },
+  { href: "/dashboard/notifications", label: "Notifications", icon: Bell },
+  { href: "/dashboard/portfolio", label: "Portfolio", icon: Wallet, dashboardNav: {} },
+  { href: "/dashboard/sandbox", label: "Sandbox", icon: SlidersHorizontal },
+  { href: "/dashboard/settings", label: "Settings", icon: Settings, dashboardNav: {} },
+  { href: "/dashboard/settings/notifications", label: "Notifications", icon: Bell },
+  { href: "/dashboard/settings/preferences", label: "Preferences", icon: SlidersHorizontal },
+  { href: "/dashboard/settings/security", label: "Security", icon: Shield },
+  { href: "/dashboard/strategy", label: "Strategy", icon: BookOpenText, dashboardNav: {} },
+  { href: "/dashboard/transactions", label: "Transactions", icon: History },
+  { href: "/docs/tokens", label: "Design Tokens", icon: Blocks },
+  { href: "/login", label: "Login", icon: LogIn },
+  { href: "/onboarding", label: "Onboarding", icon: BookOpenText },
+  { href: "/profile", label: "Profile", icon: UserRound },
+  { href: "/settings", label: "Settings", icon: Settings },
+  { href: "/signin", label: "Sign In", icon: LogIn },
+  { href: "/signup", label: "Sign Up", icon: LogIn },
+  { href: "/unauthorized", label: "Unauthorized", icon: Shield },
+  { href: "/forbidden", label: "Forbidden", icon: Shield },
+];
+
+function isDashboardNavigationRoute(
+  definition: AppRouteDefinition,
+): definition is AppRouteDefinition &
+  Required<Pick<AppRouteDefinition, "icon" | "dashboardNav">> {
+  return Boolean(definition.icon && definition.dashboardNav);
+}
+
+export const routeMetadata: Record<string, RouteMetadata> = Object.fromEntries(
+  appRouteDefinitions.map(({ href, label, icon }) => [
+    href,
+    {
+      label,
+      href,
+      icon: renderRouteIcon(icon),
+    },
+  ]),
+);
+
+export const dashboardNavigation: DashboardNavigationItem[] = appRouteDefinitions
+  .filter(isDashboardNavigationRoute)
+  .map(({ href, label, icon, dashboardNav }) => ({
+    href,
+    label,
+    icon,
+    exact: dashboardNav?.exact ?? false,
+    mobileLabel: dashboardNav?.mobileLabel ?? label,
+  }));
+
+export function getRouteMetadata(pathname: string): RouteMetadata | undefined {
+  return routeMetadata[pathname];
+}
+
+export function getRouteLabel(pathname: string, fallback = "Dashboard"): string {
+  return getRouteMetadata(pathname)?.label ?? fallback;
+}
 
 // Helper: build breadcrumb items from a pathname string
 export function buildBreadcrumbsFromPath(
@@ -140,7 +113,7 @@ export function buildBreadcrumbsFromPath(
 ): import("@/types/breadcrumb.types").BreadcrumbItem[] {
   const segments = pathname.split("/").filter(Boolean);
   const items: import("@/types/breadcrumb.types").BreadcrumbItem[] = [
-    { label: "Home", href: "/", icon: <HomeIcon /> },
+    { label: "Home", href: "/", icon: routeMetadata["/"]?.icon },
   ];
 
   let cumulative = "";

--- a/src/lib/user.ts
+++ b/src/lib/user.ts
@@ -1,0 +1,113 @@
+import type { ApiResponse } from "@/lib/api-response";
+import type { User } from "@/types";
+
+export interface MockAuthUserRecord {
+  id: string;
+  email: string;
+  name: string;
+  avatar?: string;
+  walletAddress?: string;
+  createdAt: string;
+}
+
+export interface ApiUserRecord {
+  id: string;
+  email?: string | null;
+  name?: string | null;
+  displayName?: string | null;
+  avatar?: string | null;
+  avatarUrl?: string | null;
+  walletAddress?: string | null;
+  address?: string | null;
+  createdAt?: string | null;
+}
+
+export interface ApiUserPayload {
+  user: ApiUserRecord;
+}
+
+export type UserApiResponse = ApiResponse<ApiUserPayload>;
+
+const DEFAULT_USER_LABEL = "User";
+
+function pickFirstValue(
+  ...values: Array<string | null | undefined>
+): string | undefined {
+  return values.find(
+    (value): value is string => typeof value === "string" && value.trim().length > 0,
+  );
+}
+
+export function getUserInitials(displayName: string): string {
+  const parts = displayName
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2);
+
+  if (parts.length === 0) {
+    return "??";
+  }
+
+  return parts.map((part) => part[0]?.toUpperCase() ?? "").join("");
+}
+
+export function truncateWalletAddress(walletAddress: string): string {
+  if (walletAddress.includes("...") || walletAddress.length <= 12) {
+    return walletAddress;
+  }
+
+  return `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`;
+}
+
+function resolveDisplayName(
+  fallbackValues: Array<string | null | undefined>,
+): string {
+  return pickFirstValue(...fallbackValues) ?? DEFAULT_USER_LABEL;
+}
+
+export function adaptMockAuthUser(record: MockAuthUserRecord): User {
+  const displayName = resolveDisplayName([
+    record.name,
+    record.email.split("@")[0],
+    record.walletAddress,
+    record.id,
+  ]);
+
+  return {
+    id: record.id,
+    displayName,
+    email: record.email.toLowerCase(),
+    walletAddress: record.walletAddress,
+    avatarUrl: record.avatar,
+    avatarInitials: getUserInitials(displayName),
+    createdAt: record.createdAt,
+  };
+}
+
+export function adaptApiUser(record: ApiUserRecord): User {
+  const walletAddress = pickFirstValue(record.walletAddress, record.address);
+  const displayName = resolveDisplayName([
+    record.displayName,
+    record.name,
+    record.email ? record.email.split("@")[0] : undefined,
+    walletAddress,
+    record.id,
+  ]);
+
+  return {
+    id: record.id,
+    displayName,
+    email: record.email ?? undefined,
+    walletAddress,
+    avatarUrl: pickFirstValue(record.avatarUrl, record.avatar),
+    avatarInitials: getUserInitials(displayName),
+    createdAt: record.createdAt ?? undefined,
+  };
+}
+
+export function getUserAddressLabel(
+  user: Pick<User, "walletAddress">,
+): string | undefined {
+  return user.walletAddress ? truncateWalletAddress(user.walletAddress) : undefined;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,11 +1,8 @@
-// ── Auth ──────────────────────────────────────────────────────────────────────
+import type { User } from "./user";
 
-export interface User {
-  id: string;
-  address: string; // Stellar wallet address (truncated display)
-  displayName?: string;
-  avatarInitials?: string;
-}
+export type { User } from "./user";
+
+// ── Auth ──────────────────────────────────────────────────────────────────────
 
 export interface AuthState {
   user: User | null;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,9 @@
+export interface User {
+  id: string;
+  displayName: string;
+  email?: string;
+  walletAddress?: string;
+  avatarUrl?: string;
+  avatarInitials?: string;
+  createdAt?: string;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,6 +84,136 @@
   resolved "https://registry.npmjs.org/@emurgo/cardano-serialization-lib-nodejs/-/cardano-serialization-lib-nodejs-13.2.0.tgz#7427c30c94c7e9676327c9362f4f4d2e387efd2d"
   integrity sha512-Bz1zLGEqBQ0BVkqt1OgMxdBOE3BdUWUd7Ly9Ecr/aUwkA8AV1w1XzBMe4xblmJHnB1XXNlPH4SraXCvO+q0Mig==
 
+"@esbuild/aix-ppc64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz#82b74f92aa78d720b714162939fb248c90addf53"
+  integrity sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==
+
+"@esbuild/android-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz#f78cb8a3121fc205a53285adb24972db385d185d"
+  integrity sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==
+
+"@esbuild/android-arm@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.7.tgz#593e10a1450bbfcac6cb321f61f468453bac209d"
+  integrity sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==
+
+"@esbuild/android-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.7.tgz#453143d073326033d2d22caf9e48de4bae274b07"
+  integrity sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==
+
+"@esbuild/darwin-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz#6f23000fb9b40b7e04b7d0606c0693bd0632f322"
+  integrity sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==
+
+"@esbuild/darwin-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz#27393dd18bb1263c663979c5f1576e00c2d024be"
+  integrity sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==
+
+"@esbuild/freebsd-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz#22e4638fa502d1c0027077324c97640e3adf3a62"
+  integrity sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==
+
+"@esbuild/freebsd-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz#9224b8e4fea924ce2194e3efc3e9aebf822192d6"
+  integrity sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==
+
+"@esbuild/linux-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz#4f5d1c27527d817b35684ae21419e57c2bda0966"
+  integrity sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==
+
+"@esbuild/linux-arm@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz#b9e9d070c8c1c0449cf12b20eac37d70a4595921"
+  integrity sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==
+
+"@esbuild/linux-ia32@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz#3f80fb696aa96051a94047f35c85b08b21c36f9e"
+  integrity sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==
+
+"@esbuild/linux-loong64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz#9be1f2c28210b13ebb4156221bba356fe1675205"
+  integrity sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==
+
+"@esbuild/linux-mips64el@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz#4ab5ee67a3dfcbcb5e8fd7883dae6e735b1163b8"
+  integrity sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==
+
+"@esbuild/linux-ppc64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz#dac78c689f6499459c4321e5c15032c12307e7ea"
+  integrity sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==
+
+"@esbuild/linux-riscv64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz#050f7d3b355c3a98308e935bc4d6325da91b0027"
+  integrity sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==
+
+"@esbuild/linux-s390x@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz#d61f715ce61d43fe5844ad0d8f463f88cbe4fef6"
+  integrity sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==
+
+"@esbuild/linux-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz#ca8e1aa478fc8209257bf3ac8f79c4dc2982f32a"
+  integrity sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==
+
+"@esbuild/netbsd-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz#1650f2c1b948deeb3ef948f2fc30614723c09690"
+  integrity sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==
+
+"@esbuild/netbsd-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz#65772ab342c4b3319bf0705a211050aac1b6e320"
+  integrity sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==
+
+"@esbuild/openbsd-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz#37ed7cfa66549d7955852fce37d0c3de4e715ea1"
+  integrity sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==
+
+"@esbuild/openbsd-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz#01bf3d385855ef50cb33db7c4b52f957c34cd179"
+  integrity sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==
+
+"@esbuild/openharmony-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz#6c1f94b34086599aabda4eac8f638294b9877410"
+  integrity sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==
+
+"@esbuild/sunos-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz#4b0dd17ae0a6941d2d0fd35a906392517071a90d"
+  integrity sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==
+
+"@esbuild/win32-arm64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz#34193ab5565d6ff68ca928ac04be75102ccb2e77"
+  integrity sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==
+
+"@esbuild/win32-ia32@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz#eb67f0e4482515d8c1894ede631c327a4da9fc4d"
+  integrity sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==
+
+"@esbuild/win32-x64@0.27.7":
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz#8fe30b3088b89b4873c3a6cc87597ae3920c0a8b"
+  integrity sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==
+
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.9.1"
   resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
@@ -3377,6 +3507,38 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
+esbuild@~0.27.0:
+  version "0.27.7"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.27.7.tgz#bcadce22b2f3fd76f257e3a64f83a64986fea11f"
+  integrity sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.27.7"
+    "@esbuild/android-arm" "0.27.7"
+    "@esbuild/android-arm64" "0.27.7"
+    "@esbuild/android-x64" "0.27.7"
+    "@esbuild/darwin-arm64" "0.27.7"
+    "@esbuild/darwin-x64" "0.27.7"
+    "@esbuild/freebsd-arm64" "0.27.7"
+    "@esbuild/freebsd-x64" "0.27.7"
+    "@esbuild/linux-arm" "0.27.7"
+    "@esbuild/linux-arm64" "0.27.7"
+    "@esbuild/linux-ia32" "0.27.7"
+    "@esbuild/linux-loong64" "0.27.7"
+    "@esbuild/linux-mips64el" "0.27.7"
+    "@esbuild/linux-ppc64" "0.27.7"
+    "@esbuild/linux-riscv64" "0.27.7"
+    "@esbuild/linux-s390x" "0.27.7"
+    "@esbuild/linux-x64" "0.27.7"
+    "@esbuild/netbsd-arm64" "0.27.7"
+    "@esbuild/netbsd-x64" "0.27.7"
+    "@esbuild/openbsd-arm64" "0.27.7"
+    "@esbuild/openbsd-x64" "0.27.7"
+    "@esbuild/openharmony-arm64" "0.27.7"
+    "@esbuild/sunos-x64" "0.27.7"
+    "@esbuild/win32-arm64" "0.27.7"
+    "@esbuild/win32-ia32" "0.27.7"
+    "@esbuild/win32-x64" "0.27.7"
+
 escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
@@ -3776,6 +3938,11 @@ fsevents@2.3.2:
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
@@ -3841,7 +4008,7 @@ get-symbol-description@^1.1.0:
     es-errors "^1.3.0"
     get-intrinsic "^1.2.6"
 
-get-tsconfig@^4.10.0:
+get-tsconfig@^4.10.0, get-tsconfig@^4.7.5:
   version "4.14.0"
   resolved "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz#985d85c52a9903864280ccc2448d413fbf1efed8"
   integrity sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==
@@ -6075,6 +6242,16 @@ tslib@^2.1.0, tslib@^2.3.1, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
+
+tsx@^4.20.6:
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.21.0.tgz#32aa6cf17481e336f756195e6fe04dae3e6308b1"
+  integrity sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==
+  dependencies:
+    esbuild "~0.27.0"
+    get-tsconfig "^4.7.5"
+  optionalDependencies:
+    fsevents "~2.3.3"
 
 tweetnacl-util@^0.15.1:
   version "0.15.1"


### PR DESCRIPTION
## Summary
- align `src/lib/routeMetadata.tsx` with App Router dashboard pages and reuse it for dashboard labels/navigation
- unify the exported `User` contract with thin mock/API adapters across auth code paths
- add unit coverage for formatters, date filtering, transaction list logic, and route metadata coverage using `node --test` + `tsx`
- document the current `yarn audit` triage policy for direct Next.js risk and transitive Stellar wallet risk in `docs/security/npm-audit-policy.md`

## Verification
- `yarn typecheck`
- `yarn test`
- `yarn build`
- `yarn lint` (passes with pre-existing warnings in avatar/time picker/usePortfolio files)

## Issues
- Closes #138
- Closes #139
- Closes #140
- Closes #141
