### PR TITLE
docs: add SECURITY policy and Stellar network config guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 NEXT_PUBLIC_WEBHOOK_URL=http://localhost:2000
 NEXT_PUBLIC_API_URL=http://localhost:3001
 NEXT_TELEMETRY_DISABLED=1
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
 # Server-side Backend API Configuration (optional, uses demo data if not set)
 # NEUROWEALTH_API_BASE_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -265,3 +265,8 @@ The deposit detection system monitors user Stellar wallet addresses for incoming
 - **Deposit Recorder**: Records deposits in database with idempotency
 - **Deployment Coordinator**: Emits deployment events and handles confirmations
 - **Deposit Messaging**: Sends WhatsApp notifications for deposit lifecycle events
+
+## Documentation
+
+- [Networks](docs/networks.md): frontend network switching config and current mainnet scope boundaries.
+- [Security Policy](SECURITY.md): private vulnerability reporting process and response expectations.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,37 @@
+# Security Policy
+
+## Scope and ownership
+
+This policy applies to the `Neurowealth/NeuroWealth-Frontend` repository and the code it contains.
+
+- Owner: NeuroWealth frontend maintainers
+- In scope: frontend application code, frontend build/runtime configuration, and repository workflows
+- Out of scope: backend services, smart contracts, third-party infrastructure, and organization-wide policies outside this repository
+
+## Reporting a vulnerability
+
+Please do not open public GitHub issues for security reports.
+
+Use one of these private channels:
+
+1. Preferred: GitHub private vulnerability reporting (Security tab)  
+   `https://github.com/Neurowealth/NeuroWealth-Frontend/security/advisories/new`
+2. Fallback: email `support@neurowealth.app` with subject prefix `[SECURITY]`
+
+Include as much detail as possible:
+
+- Affected route, component, or file path
+- Reproduction steps and expected vs actual behavior
+- Impact assessment (data exposure, auth bypass, privilege escalation, etc.)
+- Proof-of-concept details, logs, screenshots, or request samples
+
+## Response expectations
+
+- Initial acknowledgement: within 3 business days
+- Triage and severity classification: within 7 business days
+- Remediation plan or mitigation update: within 14 business days for high/critical findings
+- Coordinated disclosure after a fix is available and validated
+
+## Supported versions
+
+Security fixes are prioritized for the latest `main` branch state. Older snapshots or forks may not receive backports.

--- a/docs/networks.md
+++ b/docs/networks.md
@@ -1,0 +1,42 @@
+# Networks
+
+## Current default
+
+The frontend defaults to Stellar testnet. If no network variables are set, wallet connectivity and Horizon requests use:
+
+- Network: `testnet`
+- Horizon URL: `https://horizon-testnet.stellar.org`
+
+## Environment variables
+
+Set these in `.env.local` to control the active network:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `NEXT_PUBLIC_STELLAR_NETWORK` | Wallet + provider network selector. Supported values: `testnet`, `mainnet`, `public`. | `testnet` |
+| `NEXT_PUBLIC_STELLAR_HORIZON_URL` | Optional Horizon endpoint override for the selected network. | `https://horizon-testnet.stellar.org` |
+
+Mainnet example:
+
+```bash
+NEXT_PUBLIC_STELLAR_NETWORK=mainnet
+NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon.stellar.org
+```
+
+## Current phase and scope
+
+Mainnet launch is out of scope for the current frontend milestone. Switching to `mainnet` only changes wallet and Horizon network configuration in the UI layer.
+
+The following flows remain mock or simulation-first in this phase:
+
+- Transaction lifecycle previews in `src/lib/transactions.ts`
+- Demo portfolio and service data in `src/lib/mock-services.ts`
+- API fallback behavior when backend endpoints are not configured
+
+Treat mainnet usage in this repository as preparation and QA only until a separate mainnet milestone is approved.
+
+## Quick QA steps
+
+1. Set `NEXT_PUBLIC_STELLAR_NETWORK=testnet`, start the app, and confirm the navbar network badge shows `TESTNET` after wallet connection.
+2. Switch to `NEXT_PUBLIC_STELLAR_NETWORK=mainnet` with `NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon.stellar.org`, restart, and confirm the badge shows `PUBLIC`.
+3. Run deposit and withdrawal UI flows and confirm they still behave as simulated previews in this milestone.

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { ReactNode } from "react";
+import { Networks } from "@stellar/stellar-sdk";
 import { AuthProvider } from "@/contexts";
 import { WalletProvider } from "@/contexts";
 import { I18nProvider } from "@/contexts/I18nContext";
@@ -9,13 +10,32 @@ import { ToastProvider } from "@/components/notifications/ToastProvider";
 import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
 import { CookieBanner, PrivacyModal } from "@/components/cookie";
 
+function resolveStellarConfig() {
+  const rawNetwork = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet").toLowerCase();
+  const isMainnet = rawNetwork === "mainnet" || rawNetwork === "public";
+  const network = isMainnet ? Networks.PUBLIC : Networks.TESTNET;
+  const fallbackHorizonUrl = isMainnet
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+
+  return {
+    network,
+    horizonUrl: process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL || fallbackHorizonUrl,
+  };
+}
+
 export function ClientProviders({ children }: { children: ReactNode }) {
+  const walletConfig = resolveStellarConfig();
+
   return (
     <SandboxProvider>
       <ThemeProvider>
         <I18nProvider>
           <AuthProvider>
-            <WalletProvider>
+            <WalletProvider
+              network={walletConfig.network}
+              horizonUrl={walletConfig.horizonUrl}
+            >
               <ToastProvider>
                 <CookieConsentProvider>
                   {children}

--- a/src/lib/stellar-wallet-kit.ts
+++ b/src/lib/stellar-wallet-kit.ts
@@ -11,6 +11,11 @@ import {
 } from "@creit.tech/stellar-wallets-kit";
 
 const INJECTED_WALLETS = ["freighter", "albedo", "lobstr"] as unknown as string[];
+const RAW_NETWORK = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet").toLowerCase();
+const KIT_NETWORK =
+  RAW_NETWORK === "mainnet" || RAW_NETWORK === "public"
+    ? WalletNetwork.PUBLIC
+    : WalletNetwork.TESTNET;
 
 let kitInstance: StellarWalletsKit | null = null;
 
@@ -30,7 +35,7 @@ export const getKit = (): StellarWalletsKit => {
     if (walletList.includes('hana')) modules.push(new HanaModule());
 
     kitInstance = new StellarWalletsKit({
-      network:  WalletNetwork.TESTNET,
+      network: KIT_NETWORK,
       selectedWalletId: FREIGHTER_ID,
       modules: modules.length > 0 ? modules : [new FreighterModule(), new AlbedoModule(), new LobstrModule()],
     });


### PR DESCRIPTION
Closes #115
Closes #93
Closes #86
Closes #60

## Changes
- add root SECURITY.md with private reporting channel, scope, and response expectations
- add docs/networks.md documenting Stellar testnet/mainnet switching via env config
- wire NEXT_PUBLIC_STELLAR_NETWORK and NEXT_PUBLIC_STELLAR_HORIZON_URL into wallet provider and wallet kit defaults
- add docs links in README and include new env vars in .env.example

## Testing
- Verification by inspection of docs and config wiring
- Could not run local lint/typecheck in this environment because dependency lockfiles are currently out of sync (both yarn and npm ci fail before checks run)