### PR TITLE
docs: document env boundaries and third-party script guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,32 +189,17 @@ The app will be available at `http://localhost:3000`
 ### Required Environment Variables
 
 ```bash
-# Meta WhatsApp Cloud API
-WHATSAPP_APP_SECRET=your_meta_app_secret_here
-WHATSAPP_VERIFY_TOKEN=your_custom_verify_token_here
-WHATSAPP_ACCESS_TOKEN=EAA...your_token_here
-WHATSAPP_PHONE_NUMBER_ID=1015554021640186
-WHATSAPP_WABA_ID=871074939257642
+# Public (embedded in browser bundle)
+NEXT_PUBLIC_WEBHOOK_URL=http://localhost:2000
+NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
-# Server
-PORT=3000
-NODE_ENV=development
-LOG_LEVEL=info
-
-# PostgreSQL Database
-DB_HOST=localhost
-DB_PORT=5432
-DB_NAME=neurowealth
-DB_USER=postgres
-DB_PASSWORD=your_database_password_here
-
-# Stellar Network
-STELLAR_NETWORK=testnet  # or 'mainnet'
-STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
-
-# Wallet Encryption
-# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
-WALLET_ENCRYPTION_KEY=your_64_character_hex_string_here
+# Server-only (do not expose)
+# NEUROWEALTH_API_BASE_URL=http://localhost:8000
+# NEUROWEALTH_PORTFOLIO_PATH=/portfolio/overview
+# NEUROWEALTH_TRANSACTIONS_PATH=/transactions
+AUTH_SECRET=change-me-in-production
 ```
 
 ### Database Setup
@@ -232,10 +217,10 @@ WALLET_ENCRYPTION_KEY=your_64_character_hex_string_here
 
 ### Stellar Network Configuration
 
-- **Testnet**: Use `https://horizon-testnet.stellar.org` for development
-- **Mainnet**: Use `https://horizon.stellar.org` for production
+Network switching for the frontend is controlled via `NEXT_PUBLIC_STELLAR_NETWORK` and `NEXT_PUBLIC_STELLAR_HORIZON_URL`.
 
-The deposit monitor will automatically connect to the configured Horizon endpoint and stream payment events for all registered user wallet addresses.
+See:
+- [Networks](docs/networks.md)
 
 ## Deposit Detection System
 
@@ -269,4 +254,6 @@ The deposit detection system monitors user Stellar wallet addresses for incoming
 ## Documentation
 
 - [Networks](docs/networks.md): frontend network switching config and current mainnet scope boundaries.
+- [Environment](docs/env.md): server-only vs `NEXT_PUBLIC_*` env, and future Edge runtime constraints.
+- [Third-party scripts](docs/third-party-scripts.md): how to add analytics/SDK scripts using `next/script` without hurting LCP.
 - [Security Policy](SECURITY.md): private vulnerability reporting process and response expectations.

--- a/docs/env.md
+++ b/docs/env.md
@@ -1,0 +1,49 @@
+# Environment variables
+
+## Public vs server-only
+
+In Next.js, any variable prefixed with `NEXT_PUBLIC_` is embedded into the client bundle and **must be treated as public**.
+
+- `NEXT_PUBLIC_*`: safe to expose to browsers (URLs, feature flags, non-secrets)
+- Non-`NEXT_PUBLIC_*`: server-only secrets/config (API keys, private tokens, encryption keys)
+
+Do not put secrets in `NEXT_PUBLIC_*` variables.
+
+## Variables used by this repository
+
+### Public (browser)
+
+Set these in `.env.local`:
+
+- `NEXT_PUBLIC_WEBHOOK_URL`
+- `NEXT_PUBLIC_API_URL`
+- `NEXT_PUBLIC_STELLAR_NETWORK` (supported: `testnet`, `mainnet`, `public`)
+- `NEXT_PUBLIC_STELLAR_HORIZON_URL` (optional override)
+
+Example:
+
+```bash
+NEXT_PUBLIC_WEBHOOK_URL=http://localhost:2000
+NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+```
+
+### Server-only (Node runtime)
+
+These must not be exposed to the browser:
+
+- `NEUROWEALTH_API_BASE_URL` (optional; if not set, the UI uses demo/mock data)
+- `NEUROWEALTH_PORTFOLIO_PATH` (optional)
+- `NEUROWEALTH_TRANSACTIONS_PATH` (optional)
+- `AUTH_SECRET`
+
+## Edge runtime and middleware constraints (future)
+
+If/when this repo introduces Next.js Middleware or Edge Route Handlers, keep in mind:
+
+- Edge runtime does not support all Node.js APIs (e.g. many `crypto` and filesystem patterns)
+- Secrets should remain server-only and should never be referenced by client components
+- Prefer passing data through server components/route handlers rather than reading secrets in client code
+
+This repository currently assumes a Node.js runtime for any future “real backend” integration.

--- a/docs/third-party-scripts.md
+++ b/docs/third-party-scripts.md
@@ -1,0 +1,28 @@
+# Third-party scripts (analytics, SDKs)
+
+## Current status
+
+This repository currently avoids adding third-party analytics script tags by default.
+
+The only script injected at app root today is a small inline theme bootstrap in `src/app/layout.tsx` using `next/script` with `strategy="beforeInteractive"` to prevent a theme flash.
+
+## If you need to add a third-party script
+
+Use `next/script` instead of raw `<script>` tags.
+
+Recommended strategies:
+
+- `afterInteractive`: for most analytics/SDKs that can wait until hydration
+- `lazyOnload`: for non-critical scripts that can wait until the browser is idle
+
+Notes:
+
+- Adding large scripts can regress LCP/INP and increase total JS. Treat changes here as performance-sensitive.
+- Prefer dynamic import (e.g. `import("...")`) when the integration can be loaded only on specific routes or user actions.
+- Defer consent and data collection behavior to the privacy/cookie workstreams.
+
+## QA checklist for script changes
+
+- Confirm the script loads with the intended strategy (`afterInteractive` / `lazyOnload`)
+- Validate no blocking network requests happen before first paint unless explicitly intended
+- Re-run `yarn build` and sanity check bundle size and performance


### PR DESCRIPTION
# PR: Document network switching, env boundaries, security policy, and third-party script guidance

Closes #147 
Closes #148 
Closes #149 
Closes #150 

## Summary

This PR documents:

- Stellar **testnet vs mainnet** switching via config (`NEXT_PUBLIC_STELLAR_NETWORK`, `NEXT_PUBLIC_STELLAR_HORIZON_URL`) and what remains **mock-only** in the current milestone.
- **Public vs server-only env vars** (`NEXT_PUBLIC_*` vs server secrets) and notes about future **Edge runtime** limitations.
- A lightweight **security policy** (private reporting + response expectations).
- How to add **third-party scripts** using `next/script` with recommended strategies and a short LCP/perf checklist.

## Changes

- `docs/networks.md`: existing one-page network switching and scope notes (testnet default; mainnet out of scope in this milestone)
- `docs/env.md`: new env documentation
- `docs/third-party-scripts.md`: new guidance for analytics/SDK scripts
- `README.md`: updated env var examples and doc links
- `SECURITY.md`: security reporting policy

## QA steps (written verification)

1. Confirm docs exist and links work:
   - `README.md` links to `docs/networks.md`, `docs/env.md`, `docs/third-party-scripts.md`, and `SECURITY.md`
2. Validate network switching expectations:
   - Set `NEXT_PUBLIC_STELLAR_NETWORK=testnet` and (optionally) `NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org`
   - Restart dev server and connect a wallet; behavior should match testnet.
   - Switch to `NEXT_PUBLIC_STELLAR_NETWORK=mainnet` and `NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon.stellar.org`, restart, and confirm the UI layer uses public network settings.
   - Confirm deposit/withdrawal UX remains simulation-first per `docs/networks.md`.
3. Script injection audit:
   - Verify root layout uses `next/script` (no raw `<script>` tags for third-party libraries).

## Notes / scope boundaries

- Mainnet usage is documented as **preparation + QA only** until a separate milestone approves a real mainnet rollout.
- Consent/privacy requirements for analytics are intentionally deferred to the privacy/cookie workstreams.
