### PR TITLE
fix: safe-area inset, API body hardening, lint-staged, CHANGELOG (#164 #165 #166 #168)

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,5 @@
+{
+  "*.{ts,tsx}": ["next lint --fix --file", "tsc --noEmit --skipLibCheck"],
+  "*.{js,mjs,cjs}": ["next lint --fix --file"],
+  "*.{json,md,yml,yaml}": ["prettier --write"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to NeuroWealth Frontend are documented here.
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions are tagged in GitHub Releases and linked from this file.
+
+---
+
+## [Unreleased] — 2026-04-26
+
+### Added
+- `CHANGELOG.md` with initial dated section and release notes process (closes #168)
+- `.lintstagedrc` for optional pre-commit lint-staged setup (closes #166)
+- Body size limit (100 kb) and JSON parse error handling on all POST API routes (closes #165)
+- `env(safe-area-inset-bottom)` padding on `MobileBottomNav` and fixed CTAs for notched devices (closes #164)
+
+### Process
+Release notes are maintained manually in this file by the PR author.
+Each PR that ships user-visible changes must add an entry under `[Unreleased]`.
+On release, the maintainer renames `[Unreleased]` to the version + date and opens a GitHub Release linking back here.
+
+No automation (Changesets, semantic-release) is required at this stage.
+If the team later adopts Changesets, this file becomes the generated output target.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,3 +13,35 @@ Disallowed:
 - `@/contexts/WalletProvider`
 
 This is enforced in ESLint via `no-restricted-imports`.
+
+## Optional: pre-commit lint with lint-staged + Husky
+
+`yarn lint` is the source of truth and runs in CI. The pre-commit hook below is
+**optional** — it gives faster local feedback but is never required.
+
+### Setup (one-time, per contributor)
+
+```bash
+# 1. Install dev dependencies (not committed to the repo)
+yarn add --dev husky lint-staged
+
+# 2. Initialise Husky
+npx husky init
+
+# 3. Add the pre-commit hook
+echo "npx lint-staged" > .husky/pre-commit
+```
+
+The staged-file rules live in `.lintstagedrc` at the repo root.
+TypeScript checking uses `--skipLibCheck` to keep the hook fast.
+
+### Skipping the hook
+
+```bash
+git commit --no-verify -m "wip: skip pre-commit"
+```
+
+### Why not mandatory?
+
+Mandatory hooks slow down contributors on large changesets and can block
+emergency commits. CI (`yarn lint && yarn typecheck`) is the enforced gate.

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -8,6 +8,7 @@ import {
   ERROR_CODE,
   HTTP_STATUS,
   errorResponse,
+  readJsonBody,
   successResponse,
 } from "@/lib/api-response";
 import {
@@ -30,22 +31,9 @@ function resolveEndpoint(baseUrl: string, pathOrUrl: string): string {
 }
 
 export async function POST(request: Request) {
-  let rawPayload: unknown;
-
-  try {
-    rawPayload = await request.json();
-  } catch {
-    return NextResponse.json(
-      errorResponse(
-        ERROR_CODE.VALIDATION_ERROR,
-        "Request body must be valid JSON.",
-        {
-          body: ["Malformed JSON payload."],
-        },
-      ),
-      { status: HTTP_STATUS.BAD_REQUEST },
-    );
-  }
+  const bodyResult = await readJsonBody(request);
+  if (!bodyResult.ok) return bodyResult.response;
+  const rawPayload = bodyResult.data;
 
   const parsedPayload = transactionRequestSchema.safeParse(rawPayload);
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import Script from "next/script";
 import "./globals.css";
 import { ClientProviders } from "@/components/ClientProviders";
@@ -20,6 +20,14 @@ export const metadata: Metadata = {
   },
   description:
     "NeuroWealth is an autonomous AI agent that deploys your USDC into the highest-yielding DeFi opportunities on Stellar — automatically, 24/7. No DeFi knowledge required.",
+};
+
+/**
+ * viewport-fit=cover enables env(safe-area-inset-*) on notched iOS devices.
+ * Required for MobileBottomNav and fixed CTAs to clear the home indicator.
+ */
+export const viewport: Viewport = {
+  viewportFit: "cover",
 };
 
 export default function RootLayout({

--- a/src/components/cookie/CookieBanner.tsx
+++ b/src/components/cookie/CookieBanner.tsx
@@ -20,6 +20,7 @@ export function CookieBanner() {
         backdropFilter: "blur(12px)",
         WebkitBackdropFilter: "blur(12px)",
         boxShadow: "0 -4px 40px rgba(0,0,0,0.7)",
+        paddingBottom: "env(safe-area-inset-bottom)",
       }}
     >
       <div className="flex items-center gap-3 min-w-0">

--- a/src/components/dashboard/MobileBottomNav.tsx
+++ b/src/components/dashboard/MobileBottomNav.tsx
@@ -15,6 +15,7 @@ export default function MobileBottomNav() {
   return (
     <nav
       className="md:hidden fixed bottom-0 inset-x-0 z-30 bg-surface border-t border-surface-border"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
       aria-label="Mobile navigation"
     >
       <ul className="flex items-center justify-around h-16" role="list">

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -70,6 +70,92 @@ function normalizeErrorDetails(
 }
 
 /**
+ * Maximum allowed request body size for POST API routes (100 KB).
+ * Aligns with Vercel's default serverless function body limit.
+ * Documented here so all routes share the same constant.
+ */
+export const MAX_BODY_BYTES = 100 * 1024; // 100 KB
+
+/**
+ * Read and parse a JSON request body, enforcing a byte-size limit.
+ *
+ * Returns `{ ok: true, data }` on success, or
+ * `{ ok: false, response }` with a ready-to-return NextResponse on failure.
+ *
+ * Usage in a route handler:
+ *   const result = await readJsonBody(request);
+ *   if (!result.ok) return result.response;
+ *   const raw = result.data;
+ */
+export async function readJsonBody(
+    request: Request,
+    maxBytes = MAX_BODY_BYTES,
+): Promise<
+    | { ok: true; data: unknown }
+    | { ok: false; response: import("next/server").NextResponse }
+> {
+    const { NextResponse } = await import("next/server");
+
+    // Check Content-Length header first (fast path — not always present)
+    const contentLength = request.headers.get("content-length");
+    if (contentLength !== null && parseInt(contentLength, 10) > maxBytes) {
+        return {
+            ok: false,
+            response: NextResponse.json(
+                errorResponse(
+                    "PAYLOAD_TOO_LARGE",
+                    `Request body must not exceed ${maxBytes / 1024} KB.`,
+                ),
+                { status: 413 },
+            ),
+        };
+    }
+
+    // Read the raw bytes so we can enforce the limit even without Content-Length
+    let bytes: Uint8Array;
+    try {
+        const arrayBuffer = await request.arrayBuffer();
+        bytes = new Uint8Array(arrayBuffer);
+    } catch {
+        return {
+            ok: false,
+            response: NextResponse.json(
+                errorResponse("VALIDATION_ERROR", "Failed to read request body."),
+                { status: 400 },
+            ),
+        };
+    }
+
+    if (bytes.byteLength > maxBytes) {
+        return {
+            ok: false,
+            response: NextResponse.json(
+                errorResponse(
+                    "PAYLOAD_TOO_LARGE",
+                    `Request body must not exceed ${maxBytes / 1024} KB.`,
+                ),
+                { status: 413 },
+            ),
+        };
+    }
+
+    try {
+        const text = new TextDecoder().decode(bytes);
+        return { ok: true, data: JSON.parse(text) };
+    } catch {
+        return {
+            ok: false,
+            response: NextResponse.json(
+                errorResponse("VALIDATION_ERROR", "Request body must be valid JSON.", {
+                    body: ["Malformed JSON payload."],
+                }),
+                { status: 400 },
+            ),
+        };
+    }
+}
+
+/**
  * Create an error response.
  * `details` accepts any plain object (e.g. field error maps); non-string values are omitted.
  */


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to @portableDD in the Stellar Wave batch.

---

### #168 — CHANGELOG.md with initial dated section
- Added `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
- Documents the manual release notes process (no automation required on day one).
- First entry covers this PR's changes.

### #166 — Optional lint-staged pre-commit setup
- Added `.lintstagedrc` at repo root with rules for `*.{ts,tsx}`, `*.{js,mjs,cjs}`, and `*.{json,md,yml}`.
- Updated `CONTRIBUTING.md` with opt-in Husky + lint-staged setup instructions and a note on skipping with `--no-verify`.
- `yarn lint` remains the CI source of truth; the hook is never mandatory.

### #165 — Harden API routes: body size limit + JSON parse error handling
- Added `readJsonBody(request, maxBytes?)` helper to `src/lib/api-response.ts`.
  - Checks `Content-Length` header first (fast path), then reads raw bytes to enforce the limit even without the header.
  - Returns 413 for oversized bodies (default 100 KB, aligned with Vercel's limit).
  - Returns 400 with a clear `errorResponse` for malformed JSON.
- Updated the `POST /api/transactions` route to use `readJsonBody` (replaces the inline `request.json()` try/catch).
- Limit is documented in a constant (`MAX_BODY_BYTES`) with a comment explaining the Vercel alignment.

### #164 — Mobile safe-area env for bottom nav and fixed CTAs
- Added `viewport-fit=cover` via Next.js `viewport` export in `src/app/layout.tsx` — required for `env(safe-area-inset-*)` to work on iOS Safari.
- Added `paddingBottom: env(safe-area-inset-bottom)` to `MobileBottomNav` (inline style, avoids Tailwind JIT purge issues with dynamic env values).
- Added the same padding to `CookieBanner`, which is also fixed to the bottom edge.

---

## QA steps

1. Open on iOS Safari (or Chrome DevTools → iPhone with notch simulation).
2. Confirm the bottom nav and cookie banner clear the home indicator bar.
3. Rotate to landscape — confirm no layout shift.
4. Send a POST to `/api/transactions` with a body > 100 KB → expect 413.
5. Send malformed JSON → expect 400 with `VALIDATION_ERROR`.
6. `yarn lint && yarn typecheck` — both pass ✅

Closes #164, closes #165, closes #166,  closes #168