### PR TITLE
Fix all issues

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState, type FormEvent } from "react";
 import Link from "next/link";
 import { Check, CheckCircle2, X } from "lucide-react";
 import { useAuth } from "@/contexts";
-import { mockAudit } from "@/lib/mock-audit";
+import { mockAuditService } from "@/lib/mock-audit";
 import { Button, Card, FieldError, FormErrorSummary, SectionError } from "@/components/ui";
 import {
   emailFormat,
@@ -91,12 +91,12 @@ export default function SignUpPage() {
     try {
       await signUp(email, name, password);
       setState("success");
-      mockAudit.logEvent("signup", { email, name, timestamp: new Date().toISOString() });
+      mockAuditService.logEvent("signup", { email, name, timestamp: new Date().toISOString() });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to create account";
       setErrors({ email: message });
       setState("idle");
-      mockAudit.logEvent("signup", { email, status: "failed", reason: message });
+      mockAuditService.logEvent("signup", { email, status: "failed", reason: message });
     }
   };
 

--- a/src/app/dashboard/settings/notifications/page.tsx
+++ b/src/app/dashboard/settings/notifications/page.tsx
@@ -7,7 +7,7 @@ import { useToast } from "@/components/notifications/ToastProvider";
 export const dynamic = "force-dynamic";
 import { Button, Card, InlineBanner } from "@/components/ui";
 import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
-import { mockAudit } from "@/lib/mock-audit";
+import { mockAuditService } from "@/lib/mock-audit";
 
 interface NotificationPreferences {
   emailNotifications: boolean;
@@ -124,7 +124,7 @@ export default function NotificationsSettingsPage() {
       setSaved(draft);
       setEditing(false);
       setStatus("success");
-      mockAudit.logEvent("settings_change", { section: "notifications", changes: draft });
+      mockAuditService.logEvent("settings_change", { section: "notifications", changes: draft });
       pushToast({
         variant: "success",
         title: "Preferences saved",

--- a/src/app/dashboard/settings/preferences/page.tsx
+++ b/src/app/dashboard/settings/preferences/page.tsx
@@ -5,7 +5,7 @@ import { Globe, Clock, DollarSign, Save, X, AlertCircle, CheckCircle2, Sun, Moon
 import { Button } from "@/components/ui/Button";
 
 export const dynamic = "force-dynamic";
-import { mockAudit } from "@/lib/mock-audit";
+import { mockAuditService } from "@/lib/mock-audit";
 import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
 import { useTheme, ThemeMode } from "@/contexts/ThemeProvider";
 
@@ -91,7 +91,7 @@ export default function PreferencesPage() {
       setSaved(draft);
       setStatus("success");
       setEditing(false);
-      mockAudit.logEvent("settings_change", { section: "preferences", changes: draft });
+      mockAuditService.logEvent("settings_change", { section: "preferences", changes: draft });
       setTimeout(() => setStatus("idle"), 3000);
     } catch {
       setStatus("error");

--- a/src/app/dashboard/settings/security/page.tsx
+++ b/src/app/dashboard/settings/security/page.tsx
@@ -5,7 +5,7 @@ import { Lock, Shield, AlertCircle, CheckCircle2, Save, X } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 
 export const dynamic = "force-dynamic";
-import { mockAudit } from "@/lib/mock-audit";
+import { mockAuditService } from "@/lib/mock-audit";
 import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
 
 interface SecurityData {
@@ -61,7 +61,7 @@ export default function SecurityPage() {
       setSaved(draft);
       setStatus("success");
       setEditing(false);
-      mockAudit.logEvent("settings_change", { section: "security", changes: draft });
+      mockAuditService.logEvent("settings_change", { section: "security", changes: draft });
       setTimeout(() => setStatus("idle"), 3000);
     } catch {
       setStatus("error");
@@ -91,7 +91,7 @@ export default function SecurityPage() {
       setStatus("success");
       setShowPasswordModal(false);
       setNewPassword("");
-      mockAudit.logEvent("password_change", { timestamp: new Date().toISOString() });
+      mockAuditService.logEvent("password_change", { timestamp: new Date().toISOString() });
       setTimeout(() => setStatus("idle"), 3000);
     } catch {
       setStatus("error");

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -18,14 +18,7 @@ import {
 } from "lucide-react";
 import { ProfileFormSkeleton } from "@/components/ui/Skeleton";
 
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-interface ProfileData {
-  displayName: string;
-  locale: string;
-  timezone: string;
-  currencyFormat: string;
-}
+import { ProfileData, DEFAULT_PROFILE, mockProfileService } from "@/lib/mock-services";
 
 interface ValidationErrors {
   displayName?: string;
@@ -79,39 +72,6 @@ const CURRENCY_FORMATS = [
   { value: "BRL", label: "BRL — Brazilian Real (R$)" },
   { value: "CAD", label: "CAD — Canadian Dollar (CA$)" },
 ];
-
-const STORAGE_KEY = "neurowealth_profile";
-
-const DEFAULT_PROFILE: ProfileData = {
-  displayName: "",
-  locale: "en-US",
-  timezone: "UTC",
-  currencyFormat: "USD",
-};
-
-// ─── Mock API ─────────────────────────────────────────────────────────────────
-
-function mockSaveProfile(data: ProfileData): Promise<void> {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      // Simulate occasional network errors (10% chance)
-      if (Math.random() < 0.1) {
-        reject(new Error("Network error — please try again."));
-      } else {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-        resolve();
-      }
-    }, 800);
-  });
-}
-
-function mockLoadProfile(): ProfileData {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) return { ...DEFAULT_PROFILE, ...JSON.parse(raw) };
-  } catch {}
-  return DEFAULT_PROFILE;
-}
 
 // ─── Validation ───────────────────────────────────────────────────────────────
 
@@ -199,7 +159,7 @@ export default function ProfilePage() {
   useEffect(() => {
     // Simulate async profile load
     const timer = setTimeout(() => {
-      const loaded = mockLoadProfile();
+      const loaded = mockProfileService.loadProfile();
       setSaved(loaded);
       setDraft(loaded);
       setProfileLoading(false);
@@ -247,7 +207,7 @@ export default function ProfilePage() {
     setSaveError("");
 
     try {
-      await mockSaveProfile(draft);
+      await mockProfileService.saveProfile(draft);
       setSaved(draft);
       setSaveStatus("success");
       setEditing(false);

--- a/src/components/audit/AuditTrail.tsx
+++ b/src/components/audit/AuditTrail.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { AuditEvent, mockAudit } from "@/lib/mock-audit";
+import { AuditEvent, mockAuditService } from "@/lib/mock-audit";
 import { Download, Filter, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { AuditTableSkeleton } from "@/components/ui/Skeleton";
@@ -18,8 +18,9 @@ export function AuditTrail() {
   useEffect(() => {
     setLoading(true);
     // Simulate async fetch of audit events
-    const timer = setTimeout(() => {
-      setEvents(mockAudit.getEvents());
+    const timer = setTimeout(async () => {
+      const data = await mockAuditService.getEvents();
+      setEvents(data);
       setLoading(false);
     }, 800);
     return () => clearTimeout(timer);
@@ -36,8 +37,8 @@ export function AuditTrail() {
       return sortOrder === "desc" ? diff : -diff;
     });
 
-  const handleExport = () => {
-    const csv = mockAudit.exportAsCSV();
+  const handleExport = async () => {
+    const csv = await mockAuditService.exportAsCSV();
     const blob = new Blob([csv], { type: "text/csv" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");

--- a/src/lib/mock-audit.ts
+++ b/src/lib/mock-audit.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { random } from "./seeded-rng";
+
 export interface AuditEvent {
     id: string;
     eventType: "login" | "logout" | "signup" | "profile_update" | "password_change" | "settings_change" | "transaction" | "export";
@@ -13,11 +15,18 @@ export interface AuditEvent {
 const STORAGE_KEY = "nw_audit_trail";
 
 function generateId(): string {
-    return "evt_" + Math.random().toString(36).substring(2, 11);
+    return "evt_" + random().toString(36).substring(2, 11);
 }
 
-export const mockAudit = {
-    logEvent: (eventType: AuditEvent["eventType"], metadata: Record<string, unknown> = {}): AuditEvent => {
+export interface AuditService {
+    logEvent(eventType: AuditEvent["eventType"], metadata?: Record<string, unknown>): Promise<AuditEvent>;
+    getEvents(): Promise<AuditEvent[]>;
+    clearEvents(): Promise<void>;
+    exportAsCSV(): Promise<string>;
+}
+
+export const mockAuditService: AuditService = {
+    logEvent: async (eventType: AuditEvent["eventType"], metadata: Record<string, unknown> = {}): Promise<AuditEvent> => {
         const event: AuditEvent = {
             id: generateId(),
             eventType,
@@ -28,14 +37,14 @@ export const mockAudit = {
             userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "Unknown",
         };
 
-        const events = mockAudit.getEvents();
+        const events = await mockAuditService.getEvents();
         events.unshift(event);
         localStorage.setItem(STORAGE_KEY, JSON.stringify(events.slice(0, 100)));
 
         return event;
     },
 
-    getEvents: (): AuditEvent[] => {
+    getEvents: async (): Promise<AuditEvent[]> => {
         try {
             const stored = localStorage.getItem(STORAGE_KEY);
             if (stored) {
@@ -48,12 +57,12 @@ export const mockAudit = {
         return [];
     },
 
-    clearEvents: () => {
+    clearEvents: async (): Promise<void> => {
         localStorage.removeItem(STORAGE_KEY);
     },
 
-    exportAsCSV: (): string => {
-        const events = mockAudit.getEvents();
+    exportAsCSV: async (): Promise<string> => {
+        const events = await mockAuditService.getEvents();
         const headers = ["Event ID", "Event Type", "Actor", "Timestamp", "IP Address", "Metadata"];
         const rows = events.map((e) => [
             e.id,

--- a/src/lib/mock-auth.ts
+++ b/src/lib/mock-auth.ts
@@ -15,6 +15,7 @@ import {
 } from "./user";
 import type { User } from "@/types";
 import type { AuthAdapter, AuthSession } from "./auth-adapter";
+import { random } from "./seeded-rng";
 
 export type { AuthSession } from "./auth-adapter";
 
@@ -33,7 +34,7 @@ const MOCK_USERS: Record<string, { password: string; user: MockAuthUserRecord }>
 };
 
 function generateToken(): string {
-  return `mock_token_${Math.random().toString(36).slice(2)}`;
+  return `mock_token_${random().toString(36).slice(2)}`;
 }
 
 function isLegacyMockAuthUserRecord(value: unknown): value is MockAuthUserRecord {
@@ -135,7 +136,7 @@ export const mockAuth: AuthAdapter = {
       throw new Error("An account with this email already exists");
     }
     const user: MockAuthUserRecord = {
-      id: `usr_${Math.random().toString(36).slice(2)}`,
+      id: `usr_${random().toString(36).slice(2)}`,
       email: email.toLowerCase(),
       name,
       createdAt: new Date().toISOString(),

--- a/src/lib/mock-chart-data.ts
+++ b/src/lib/mock-chart-data.ts
@@ -1,3 +1,5 @@
+import { randomInt } from "./seeded-rng";
+
 // Mock data for chart examples
 export interface ChartDataPoint {
   name: string;
@@ -5,66 +7,48 @@ export interface ChartDataPoint {
   [key: string]: any;
 }
 
+const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
 // Line/Area chart data: Portfolio value over time
-export const portfolioValueData: ChartDataPoint[] = [
-  { name: "Jan", value: 10000, yield: 120 },
-  { name: "Feb", value: 10500, yield: 150 },
-  { name: "Mar", value: 10200, yield: 80 },
-  { name: "Apr", value: 10800, yield: 200 },
-  { name: "May", value: 11500, yield: 300 },
-  { name: "Jun", value: 12000, yield: 250 },
-  { name: "Jul", value: 12500, yield: 400 },
-  { name: "Aug", value: 13000, yield: 350 },
-  { name: "Sep", value: 13500, yield: 300 },
-  { name: "Oct", value: 14200, yield: 450 },
-  { name: "Nov", value: 14800, yield: 380 },
-  { name: "Dec", value: 15200, yield: 320 },
-];
+export const portfolioValueData: ChartDataPoint[] = months.map((month, i) => {
+  const baseValue = 10000 + (i * 450);
+  const noise = randomInt(-300, 300);
+  return {
+    name: month,
+    value: baseValue + noise,
+    yield: randomInt(80, 450)
+  };
+});
 
 // Bar chart data: Monthly yield
-export const monthlyYieldData: ChartDataPoint[] = [
-  { name: "Jan", value: 120 },
-  { name: "Feb", value: 150 },
-  { name: "Mar", value: 80 },
-  { name: "Apr", value: 200 },
-  { name: "May", value: 300 },
-  { name: "Jun", value: 250 },
-  { name: "Jul", value: 400 },
-  { name: "Aug", value: 350 },
-  { name: "Sep", value: 300 },
-  { name: "Oct", value: 450 },
-  { name: "Nov", value: 380 },
-  { name: "Dec", value: 320 },
-];
+export const monthlyYieldData: ChartDataPoint[] = portfolioValueData.map(p => ({
+  name: p.name,
+  value: p.yield
+}));
 
 // Donut chart data: Asset allocation
 export const assetAllocationData: ChartDataPoint[] = [
-  { name: "USDC", value: 40, tone: "primary" },
-  { name: "USDT", value: 25, tone: "accent" },
-  { name: "XLM", value: 20, tone: "warning" },
-  { name: "Other", value: 15, tone: "neutral-strong" },
+  { name: "USDC", value: randomInt(35, 50), tone: "primary" },
+  { name: "USDT", value: randomInt(20, 30), tone: "accent" },
+  { name: "XLM", value: randomInt(15, 25), tone: "warning" },
+  { name: "Other", value: randomInt(5, 15), tone: "neutral-strong" },
 ];
 
 // Time series data for multiple lines
-export const multiLineData = [
-  { name: "Jan", portfolio: 10000, benchmark: 9800 },
-  { name: "Feb", portfolio: 10500, benchmark: 10100 },
-  { name: "Mar", portfolio: 10200, benchmark: 9900 },
-  { name: "Apr", portfolio: 10800, benchmark: 10300 },
-  { name: "May", portfolio: 11500, benchmark: 10800 },
-  { name: "Jun", portfolio: 12000, benchmark: 11200 },
-  { name: "Jul", portfolio: 12500, benchmark: 11800 },
-  { name: "Aug", portfolio: 13000, benchmark: 12300 },
-  { name: "Sep", portfolio: 13500, benchmark: 12800 },
-  { name: "Oct", portfolio: 14200, benchmark: 13500 },
-  { name: "Nov", portfolio: 14800, benchmark: 14100 },
-  { name: "Dec", portfolio: 15200, benchmark: 14600 },
-];
+export const multiLineData = months.map((month, i) => {
+  const portfolio = portfolioValueData[i].value;
+  const benchmarkBase = 9800 + (i * 400);
+  return {
+    name: month,
+    portfolio,
+    benchmark: benchmarkBase + randomInt(-200, 200)
+  };
+});
 
 // Categorical bar data
 export const categoricalBarData: ChartDataPoint[] = [
-  { name: "Deposits", value: 15000 },
-  { name: "Withdrawals", value: 3000 },
-  { name: "Yield", value: 2800 },
-  { name: "Fees", value: 200 },
+  { name: "Deposits", value: randomInt(12000, 18000) },
+  { name: "Withdrawals", value: randomInt(2000, 5000) },
+  { name: "Yield", value: randomInt(2000, 3500) },
+  { name: "Fees", value: randomInt(100, 300) },
 ];

--- a/src/lib/mock-services.ts
+++ b/src/lib/mock-services.ts
@@ -36,6 +36,7 @@ import {
 } from "./transactions";
 import type { AuthSession } from "./mock-auth";
 import { adaptMockAuthUser } from "./user";
+import { STORAGE_KEYS } from "./storage-keys";
 
 // ─── Shared error model ───────────────────────────────────────────────────────
 
@@ -200,6 +201,55 @@ export const mockPortfolioService: PortfolioService = {
 
     const raw = buildScenarioPayload("live");
     return normalizePortfolioPayload(raw, "demo");
+  },
+};
+
+// ─── Profile service ─────────────────────────────────────────────────────────
+
+export interface ProfileData {
+  displayName: string;
+  locale: string;
+  timezone: string;
+  currencyFormat: string;
+}
+
+export const DEFAULT_PROFILE: ProfileData = {
+  displayName: "",
+  locale: "en-US",
+  timezone: "UTC",
+  currencyFormat: "USD",
+};
+
+export interface ProfileService {
+  saveProfile(data: ProfileData, opts?: SimulationOptions): Promise<void>;
+  loadProfile(): ProfileData;
+}
+
+const PROFILE_STORAGE_KEY = STORAGE_KEYS.PROFILE;
+
+export const mockProfileService: ProfileService = {
+  async saveProfile(data, opts = {}) {
+    logger.info("mockProfileService.saveProfile");
+    await delay(opts.latencyMs ?? 800);
+
+    if (shouldFail(opts.outcome)) {
+      throw new ServiceError(
+        "NETWORK_ERROR",
+        "Network error — please try again.",
+        true,
+      );
+    }
+
+    localStorage.setItem(PROFILE_STORAGE_KEY, JSON.stringify(data));
+  },
+
+  loadProfile(): ProfileData {
+    if (typeof window === "undefined") return DEFAULT_PROFILE;
+    try {
+      const raw = localStorage.getItem(PROFILE_STORAGE_KEY);
+      if (raw) return { ...DEFAULT_PROFILE, ...JSON.parse(raw) };
+    } catch {}
+    return DEFAULT_PROFILE;
   },
 };
 

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -9,6 +9,8 @@ export type TransactionPreviewState =
   | "failure";
 export type ValidationTone = "error" | "success" | "warning";
 
+import { random } from "./seeded-rng";
+
 // Error recovery types
 export type RecoveryAction = "retry" | "edit" | "support";
 export type ErrorMode =
@@ -279,7 +281,7 @@ function generateReference(kind: TransactionKind): string {
     .toISOString()
     .replace(/[-:TZ.]/g, "")
     .slice(0, 14);
-  const suffix = Math.random().toString(36).slice(2, 8).toUpperCase();
+  const suffix = random().toString(36).slice(2, 8).toUpperCase();
 
   return `NW-${prefix}-${stamp}-${suffix}`;
 }


### PR DESCRIPTION
# Refactor Mock Architecture and Storage Registries

This PR addresses several open issues to centralize our mock infrastructure and streamline storage keys.

## What's Included
- **Profile Persistence (Closes: #188)**: Moved profile data persistence out of the page component and into a reusable, typed `mockProfileService`.
- **Domain Event Audit Service (Closes: #189)**: Refactored `mockAudit` into `mockAuditService` implementing a domain-driven `AuditService` interface. Updated all call sites and made the API asynchronous to decouple the UI from storage-backed singletons.
- **Deterministic Mock Data Seeding (Closes: #191)**: Replaced instances of `Math.random()` with deterministic `seededRandom()` in `transactions.ts`, `mock-auth.ts`, and `mock-audit.ts`. Refactored `mock-chart-data.ts` to dynamically generate deterministic chart values using the initialized seed, ensuring demos and screenshots stay consistent.
- **Sandbox Shared Registry (Closes: #192)**: Verified that raw strings for sandbox scenarios were replaced with `STORAGE_KEYS.SANDBOX_SCENARIOS` across the context and client components (partially resolved in a previous PR, validated here).

## How to Test
- Navigate to the dashboard sandbox and ensure scenarios persist correctly.
- Go to the Profile page and verify that updating settings works as expected without errors.
- Test the audit trails by triggering changes in settings and viewing the Audit logs.
- Provide a `NEXT_PUBLIC_DEMO_SEED` and verify that the chart data in the dashboard is consistent across reloads.
