### PR TITLE
refactor: compose provider tree with composeProviders helper (#182)

### DIFF
--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -1,14 +1,14 @@
 "use client";
 import { ReactNode } from "react";
 import { Networks } from "@stellar/stellar-sdk";
-import { AuthProvider } from "@/contexts";
-import { WalletProvider } from "@/contexts";
+import { AuthProvider, WalletProvider } from "@/contexts";
 import { I18nProvider } from "@/contexts/I18nContext";
 import { SandboxProvider } from "@/contexts/SandboxContext";
 import { ThemeProvider } from "@/contexts/ThemeProvider";
 import { ToastProvider } from "@/components/notifications/ToastProvider";
 import { CookieConsentProvider } from "@/contexts/CookieConsentContext";
 import { CookieBanner, PrivacyModal } from "@/components/cookie";
+import { composeProviders } from "@/lib/composeProviders";
 
 function resolveStellarConfig() {
   const rawNetwork = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet").toLowerCase();
@@ -25,28 +25,23 @@ function resolveStellarConfig() {
 }
 
 export function ClientProviders({ children }: { children: ReactNode }) {
-  const walletConfig = resolveStellarConfig();
+  const { network, horizonUrl } = resolveStellarConfig();
+
+  const Providers = composeProviders([
+    SandboxProvider,
+    ThemeProvider,
+    I18nProvider,
+    AuthProvider,
+    [WalletProvider, { network, horizonUrl }],
+    ToastProvider,
+    CookieConsentProvider,
+  ]);
 
   return (
-    <SandboxProvider>
-      <ThemeProvider>
-        <I18nProvider>
-          <AuthProvider>
-            <WalletProvider
-              network={walletConfig.network}
-              horizonUrl={walletConfig.horizonUrl}
-            >
-              <ToastProvider>
-                <CookieConsentProvider>
-                  {children}
-                  <CookieBanner />
-                  <PrivacyModal />
-                </CookieConsentProvider>
-              </ToastProvider>
-            </WalletProvider>
-          </AuthProvider>
-        </I18nProvider>
-      </ThemeProvider>
-    </SandboxProvider>
+    <Providers>
+      {children}
+      <CookieBanner />
+      <PrivacyModal />
+    </Providers>
   );
 }

--- a/src/lib/composeProviders.tsx
+++ b/src/lib/composeProviders.tsx
@@ -1,0 +1,32 @@
+import { type ComponentType, type ReactNode } from "react";
+
+type ProviderComponent =
+  | ComponentType<{ children: ReactNode }>
+  | [ComponentType<{ children: ReactNode } & Record<string, unknown>>, Record<string, unknown>];
+
+/**
+ * Composes an array of providers into a single wrapper, eliminating deep nesting.
+ *
+ * Usage:
+ * ```tsx
+ * const AllProviders = composeProviders([
+ *   ThemeProvider,
+ *   [WalletProvider, { network, horizonUrl }],
+ *   ToastProvider,
+ * ]);
+ *
+ * return <AllProviders>{children}</AllProviders>;
+ * ```
+ */
+export function composeProviders(providers: ProviderComponent[]) {
+  return function ComposedProviders({ children }: { children: ReactNode }) {
+    return providers.reduceRight<ReactNode>((acc, entry) => {
+      if (Array.isArray(entry)) {
+        const [Provider, props] = entry;
+        return <Provider {...props}>{acc}</Provider>;
+      }
+      const Provider = entry;
+      return <Provider>{acc}</Provider>;
+    }, children);
+  };
+}


### PR DESCRIPTION
Closes #182

## Changes
- Added `src/lib/composeProviders.tsx` — a generic helper that takes an array of providers and composes them via `reduceRight`, eliminating 7-level JSX nesting
- Refactored `ClientProviders.tsx` to use it: providers are now a flat, readable array with props passed as tuples

## Testing
- Provider order is preserved (same as before)
- `CookieBanner` / `PrivacyModal` still render as siblings inside `CookieConsentProvider`