### PR TITLE
fix: enforce lint in builds, typed fetch client, unified API envelopes, and route validation

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  eslint: {
-    ignoreDuringBuilds: true,
-  },
   reactStrictMode: true,
   staticPageGenerationTimeout: 0,
   // Compress responses with gzip for smaller transfer sizes

--- a/src/app/api/strategy/route.ts
+++ b/src/app/api/strategy/route.ts
@@ -2,9 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   parseStrategyKind,
   StrategyPreference,
-  StrategyUpdatePayload,
 } from "@/lib/strategies";
 import { STORAGE_KEYS } from "@/lib/storage-keys";
+import {
+  ERROR_CODE,
+  HTTP_STATUS,
+  errorResponse,
+  readJsonBody,
+  successResponse,
+} from "@/lib/api-response";
+import { strategyUpdateSchema, zodErrorToDetails } from "@/lib/validation/api";
 
 const STRATEGY_COOKIE_KEY = STORAGE_KEYS.STRATEGY_PREFERENCE;
 
@@ -28,38 +35,45 @@ export async function GET(request: NextRequest) {
 
       if (res.ok) {
         const data = (await res.json()) as StrategyPreference;
-        return NextResponse.json(data, {
+        return NextResponse.json(successResponse(data), {
           headers: { "Cache-Control": "no-store" },
         });
       }
     } catch {
-      // fall through to mock
+      // fall through to local fallback
     }
   }
 
   const strategy = parseStrategyKind(
     request.cookies.get(STRATEGY_COOKIE_KEY)?.value ?? null,
   );
-  const body: StrategyPreference = { strategy };
-  return NextResponse.json(body, {
+  return NextResponse.json(successResponse<StrategyPreference>({ strategy }), {
     headers: { "Cache-Control": "no-store" },
   });
 }
 
 export async function PUT(request: NextRequest) {
+  const bodyResult = await readJsonBody(request);
+  if (!bodyResult.ok) return bodyResult.response;
+
+  const parsed = strategyUpdateSchema.safeParse(bodyResult.data);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      errorResponse(
+        ERROR_CODE.VALIDATION_ERROR,
+        "Invalid strategy value. Must be conservative, balanced, or growth.",
+        zodErrorToDetails(parsed.error),
+      ),
+      { status: HTTP_STATUS.UNPROCESSABLE_ENTITY },
+    );
+  }
+
+  const { strategy } = parsed.data;
+
   const apiBaseUrl = process.env.NEUROWEALTH_API_BASE_URL;
   const strategyPath =
     process.env.NEUROWEALTH_STRATEGY_PATH ?? "/strategy/preference";
-
-  const payload = (await request.json()) as Partial<StrategyUpdatePayload>;
-  const strategy = parseStrategyKind(payload.strategy ?? null);
-
-  if (!strategy) {
-    return NextResponse.json(
-      { message: "Invalid strategy value. Must be conservative, balanced, or growth." },
-      { status: 422 },
-    );
-  }
 
   if (apiBaseUrl) {
     try {
@@ -82,12 +96,12 @@ export async function PUT(request: NextRequest) {
         },
       });
     } catch {
-      // fall through to mock
+      // fall through to local fallback
     }
   }
 
-  const body: StrategyPreference = { strategy };
-  const response = NextResponse.json(body, {
+  const responseBody = successResponse<StrategyPreference>({ strategy });
+  const response = NextResponse.json(responseBody, {
     headers: { "Cache-Control": "no-store" },
   });
   response.cookies.set(STRATEGY_COOKIE_KEY, strategy, {

--- a/src/app/api/transaction-history/route.ts
+++ b/src/app/api/transaction-history/route.ts
@@ -5,30 +5,51 @@ import {
   parseHistoryStatus,
   TransactionHistoryFilter,
 } from "@/lib/transaction-history";
+import {
+  ERROR_CODE,
+  HTTP_STATUS,
+  errorResponse,
+  successResponse,
+} from "@/lib/api-response";
+import { transactionHistoryQuerySchema, zodErrorToDetails } from "@/lib/validation/api";
 
 export function GET(req: NextRequest) {
   const params = req.nextUrl.searchParams;
 
-  const kind = parseHistoryKind(params.get("kind"));
-  const status = parseHistoryStatus(params.get("status"));
-  const dateFrom = params.get("dateFrom") ?? "";
-  const dateTo = params.get("dateTo") ?? "";
-  const page = Math.max(1, parseInt(params.get("page") ?? "1", 10) || 1);
-  const pageSize = Math.min(
-    50,
-    Math.max(1, parseInt(params.get("pageSize") ?? "10", 10) || 10),
-  );
+  const rawQuery = {
+    kind: params.get("kind") ?? undefined,
+    status: params.get("status") ?? undefined,
+    dateFrom: params.get("dateFrom") ?? undefined,
+    dateTo: params.get("dateTo") ?? undefined,
+    page: params.get("page") ?? undefined,
+    pageSize: params.get("pageSize") ?? undefined,
+  };
+
+  const parsedQuery = transactionHistoryQuerySchema.safeParse(rawQuery);
+
+  if (!parsedQuery.success) {
+    return NextResponse.json(
+      errorResponse(
+        ERROR_CODE.VALIDATION_ERROR,
+        "Query parameter validation failed.",
+        zodErrorToDetails(parsedQuery.error),
+      ),
+      { status: HTTP_STATUS.BAD_REQUEST },
+    );
+  }
+
+  const { kind, status, dateFrom, dateTo, page, pageSize } = parsedQuery.data;
 
   const filter: TransactionHistoryFilter = {
-    kind,
-    status,
-    dateFrom,
-    dateTo,
-    page,
-    pageSize,
+    kind: parseHistoryKind(kind ?? null),
+    status: parseHistoryStatus(status ?? null),
+    dateFrom: dateFrom ?? "",
+    dateTo: dateTo ?? "",
+    page: page ?? 1,
+    pageSize: Math.min(50, Math.max(1, pageSize ?? 10)),
   };
 
   const result = filterAndPaginateHistory(filter);
 
-  return NextResponse.json(result);
+  return NextResponse.json(successResponse(result));
 }

--- a/src/components/strategies/StrategySelector.tsx
+++ b/src/components/strategies/StrategySelector.tsx
@@ -21,6 +21,7 @@ import {
   loadStoredPreference,
   saveStoredPreference,
 } from "@/lib/strategies";
+import { apiRequest, ApiRequestError } from "@/lib/api-client";
 import { Button } from "@/components/ui/Button";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -466,16 +467,11 @@ export function StrategySelector() {
       return;
     }
 
-    fetch("/api/strategy", { cache: "no-store" })
-      .then((res) => {
-        if (!res.ok) throw new Error("Failed to load");
-        return res.json() as Promise<StrategyPreference>;
-      })
+    apiRequest<StrategyPreference>("/api/strategy", { timeoutMs: 8000 })
       .then((data) => {
         dispatch({ type: "LOAD_SUCCESS", strategy: data.strategy });
       })
       .catch(() => {
-        // Default to no preference selected
         dispatch({ type: "LOAD_SUCCESS", strategy: null });
       });
   }, []);
@@ -496,23 +492,19 @@ export function StrategySelector() {
     dispatch({ type: "SAVE_START" });
 
     try {
-      const res = await fetch("/api/strategy", {
+      await apiRequest<StrategyPreference>("/api/strategy", {
         method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ strategy }),
-        cache: "no-store",
+        body: { strategy },
+        timeoutMs: 8000,
       });
-
-      if (!res.ok) {
-        const err = (await res.json()) as { message?: string };
-        throw new Error(err.message ?? `Request failed (${res.status})`);
-      }
 
       saveStoredPreference(strategy);
       dispatch({ type: "SAVE_SUCCESS", strategy });
     } catch (err: unknown) {
       const message =
-        err instanceof Error ? err.message : "Failed to save strategy. Please try again.";
+        err instanceof ApiRequestError
+          ? err.message
+          : "Failed to save strategy. Please try again.";
       dispatch({ type: "SAVE_ERROR", message });
     }
   }

--- a/src/components/transactions/TransactionHistory.tsx
+++ b/src/components/transactions/TransactionHistory.tsx
@@ -17,6 +17,7 @@ import {
   HistoryStatus,
   TransactionHistoryPage,
 } from "@/lib/transaction-history";
+import { apiRequest } from "@/lib/api-client";
 import { formatTimestamp } from "@/lib/formatters";
 import { Button } from "@/components/ui/Button";
 
@@ -657,14 +658,10 @@ export function TransactionHistory() {
       pageSize: String(PAGE_SIZE),
     });
 
-    fetch(`/api/transaction-history?${params.toString()}`, {
-      cache: "no-store",
-      signal: controller.signal,
-    })
-      .then((res) => {
-        if (!res.ok) throw new Error(`Request failed (${res.status})`);
-        return res.json() as Promise<TransactionHistoryPage>;
-      })
+    apiRequest<TransactionHistoryPage>(
+      `/api/transaction-history?${params.toString()}`,
+      { signal: controller.signal, timeoutMs: 10000 },
+    )
       .then((payload) => {
         if (!controller.signal.aborted) {
           dispatchData({ type: "FETCH_SUCCESS", payload });

--- a/src/lib/validation/api.ts
+++ b/src/lib/validation/api.ts
@@ -12,6 +12,21 @@ export const portfolioQuerySchema = z.object({
   scenario: portfolioScenarioSchema.optional(),
 });
 
+export const strategyKindSchema = z.enum(["conservative", "balanced", "growth"]);
+
+export const strategyUpdateSchema = z.object({
+  strategy: strategyKindSchema,
+});
+
+export const transactionHistoryQuerySchema = z.object({
+  kind: z.enum(["all", "deposit", "withdrawal", "rebalance"]).optional(),
+  status: z.enum(["all", "pending", "confirmed", "failed"]).optional(),
+  dateFrom: z.string().optional(),
+  dateTo: z.string().optional(),
+  page: z.coerce.number().int().min(1).optional(),
+  pageSize: z.coerce.number().int().min(1).max(50).optional(),
+});
+
 export const transactionKindSchema = z.enum(["deposit", "withdrawal"]);
 
 export const transactionFormValuesSchema = z.object({


### PR DESCRIPTION
## Summary

This PR resolves four related API-hardening issues by tightening build-time safety, consolidating fetch logic, standardising response shapes, and adding runtime input validation across all remaining route handlers.

### #218 — Stop ignoring lint failures during production builds

Removed the `eslint.ignoreDuringBuilds: true` block from `next.config.mjs`. Lint failures now cause `next build` to abort, matching the gate already enforced in CI by `yarn lint`. There is no separate justification for bypassing it in production builds when CI already requires a clean lint pass.

### #217 — Introduce a small typed fetch client

The typed client (`src/lib/api-client.ts`) was already in place but not wired up to the two remaining callers:

- `src/components/strategies/StrategySelector.tsx` — replaced both the initial-load `fetch` and the save `fetch` with `apiRequest`, gaining automatic JSON envelope unwrapping, `ApiRequestError` normalisation, and timeout support.
- `src/components/transactions/TransactionHistory.tsx` — replaced the history-fetch `fetch` chain with `apiRequest`, which also handles the existing `AbortController` signal correctly.

### #216 — Unify API error envelopes across handlers

`src/app/api/strategy/route.ts` and `src/app/api/transaction-history/route.ts` were the two remaining routes that did not use `successResponse` / `errorResponse` from `src/lib/api-response.ts`. Both are now fully aligned with the envelope shape used by `portfolio/route.ts` and `transactions/route.ts`.

### #215 — Add runtime validation to all route handlers

Added Zod schemas for the two previously-unvalidated routes:

- **`strategyUpdateSchema`** — validates that the `strategy` field in a `PUT /api/strategy` body is one of `conservative | balanced | growth`. Invalid payloads now return a structured `422` with field-level details instead of silently falling through to `parseStrategyKind`.
- **`transactionHistoryQuerySchema`** — validates the six query parameters (`kind`, `status`, `dateFrom`, `dateTo`, `page`, `pageSize`) on `GET /api/transaction-history`. Unknown or out-of-range values return a structured `400` rather than being silently coerced.

Both schemas live in `src/lib/validation/api.ts` alongside the existing `portfolioQuerySchema` and `transactionRequestSchema`.

## Files changed

| File | Change |
|---|---|
| `next.config.mjs` | Remove `eslint.ignoreDuringBuilds` |
| `src/lib/validation/api.ts` | Add `strategyKindSchema`, `strategyUpdateSchema`, `transactionHistoryQuerySchema` |
| `src/app/api/strategy/route.ts` | Zod validation on PUT body; `successResponse`/`errorResponse` envelope on both GET and PUT |
| `src/app/api/transaction-history/route.ts` | Zod validation on query params; `successResponse` envelope on GET |
| `src/components/strategies/StrategySelector.tsx` | Replace raw `fetch` with `apiRequest` |
| `src/components/transactions/TransactionHistory.tsx` | Replace raw `fetch` with `apiRequest` |

## Test plan

- [ ] `yarn lint` passes with no warnings or errors
- [ ] `yarn build` aborts when a lint error is introduced (verify `ignoreDuringBuilds` is gone)
- [ ] `PUT /api/strategy` with `{ "strategy": "invalid" }` returns `422` with `VALIDATION_ERROR` code and field details
- [ ] `GET /api/transaction-history?page=-1` returns `400` with `VALIDATION_ERROR` code
- [ ] Strategy selector loads and saves preference correctly in the browser
- [ ] Transaction history page loads, filters, and paginates correctly

Closes #215
Closes #216
Closes #217
Closes #218