### PR TITLE
Respect reduced motion in overlay components

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -120,7 +120,7 @@ export function CommandPalette() {
         role="dialog"
         aria-modal="true"
         aria-label="Command Palette"
-        className="relative w-full max-w-full overflow-hidden border border-slate-800 bg-slate-900 shadow-2xl animate-in fade-in zoom-in-95 duration-200 sm:max-w-[640px] sm:rounded-xl"
+        className="relative w-full max-w-full overflow-hidden border border-slate-800 bg-slate-900 shadow-2xl animate-in fade-in zoom-in-95 duration-200 motion-reduce:animate-none motion-reduce:duration-0 motion-reduce:transform-none sm:max-w-[640px] sm:rounded-xl"
       >
         <div className="flex min-h-[56px] items-center border-b border-slate-800 px-4">
           <Search className="mr-3 h-5 w-5 shrink-0 text-slate-400" />
@@ -160,7 +160,7 @@ export function CommandPalette() {
                 role="option"
                 aria-selected={isSelected}
                 className={cn(
-                  "flex min-h-[44px] cursor-pointer items-center rounded-md px-4 py-2 text-sm transition-colors",
+                  "flex min-h-[44px] cursor-pointer items-center rounded-md px-4 py-2 text-sm transition-colors motion-reduce:transition-none",
                   isSelected
                     ? "bg-slate-800 text-sky-400"
                     : "text-slate-400 hover:bg-slate-800/50 hover:text-slate-200",

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -63,7 +63,7 @@ export function Drawer({
       {/* Panel — 360px desktop, full mobile */}
       <div
         ref={containerRef}
-        className={`absolute top-0 bottom-0 ${positionClass} z-10 w-full sm:w-[360px] bg-white dark:bg-zinc-900 shadow-2xl flex flex-col transform transition-transform duration-300 ease-in-out ${slideClass}`}
+        className={`absolute top-0 bottom-0 ${positionClass} z-10 w-full sm:w-[360px] bg-white dark:bg-zinc-900 shadow-2xl flex flex-col transform transition-transform duration-300 ease-in-out motion-reduce:transform-none motion-reduce:transition-none motion-reduce:duration-0 ${slideClass}`}
       >
         {/* Header — 16px padding */}
         <div className="flex items-center justify-between px-4 py-4 border-b border-zinc-2ark:border-zinc-700">
@@ -74,7 +74,7 @@ export function Drawer({
             <button
               onClick={onClose}
               aria-label="Close drawer"
-              className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+              className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors motion-reduce:transition-none"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -58,7 +58,7 @@ export function Modal({
     >
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity motion-reduce:transition-none"
         onClick={() => !preventClose && onClose()}
       />
 
@@ -76,7 +76,7 @@ export function Modal({
             <button
               onClick={onClose}
               aria-label="Close modal"
-              className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors"
+              className="p-1.5 rounded-lg text-zinc-400 hover:text-zinc-600 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition-colors motion-reduce:transition-none"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />


### PR DESCRIPTION
Summary
- Updated overlay components to suppress animations and transitions for users who prefer reduced motion.

Issue
- Closes #214

Changes
- Added motion-reduce variants to CommandPalette entrance animation and option color transitions.
- Added motion-reduce transition suppression to Modal backdrop and close button.
- Added motion-reduce transform/transition suppression to Drawer panel and close button.

Validation
- Ran git diff --check.
- npm ci failed because package.json and npm-shrinkwrap.json are out of sync: missing bufferutil@4.1.0 from the lock file.
- corepack yarn install --frozen-lockfile timed out before dependencies were installed.
- npm run typecheck could not run because tsc is unavailable without installed dependencies.

Notes
- Validation is blocked by dependency installation/lockfile environment issues, not by a known code failure.