### PR TITLE
Test overlay focus restoration

### DIFF
--- a/src/components/ui/Drawer.test.ts
+++ b/src/components/ui/Drawer.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+test("Drawer delegates open-state focus management to useFocusTrap", () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src/components/ui/Drawer.tsx"),
+    "utf8",
+  );
+
+  assert.match(source, /const containerRef = useRef<HTMLDivElement>\(null\);/);
+  assert.match(source, /useFocusTrap\(containerRef, isOpen\);/);
+});

--- a/src/components/ui/Modal.test.ts
+++ b/src/components/ui/Modal.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+test("Modal delegates open-state focus management to useFocusTrap", () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src/components/ui/Modal.tsx"),
+    "utf8",
+  );
+
+  assert.match(source, /const containerRef = useRef<HTMLDivElement>\(null\);/);
+  assert.match(source, /useFocusTrap\(containerRef, isOpen\);/);
+});

--- a/src/hooks/focusTrap.ts
+++ b/src/hooks/focusTrap.ts
@@ -1,0 +1,48 @@
+const FOCUSABLE_SELECTORS = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+export function createFocusTrap(container: HTMLElement, ownerDocument: Document = document) {
+  const previouslyFocusedElement = ownerDocument.activeElement;
+  const focusableEls = Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+  );
+
+  if (focusableEls.length) focusableEls[0].focus();
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key !== "Tab") return;
+    const first = focusableEls[0];
+    const last = focusableEls[focusableEls.length - 1];
+
+    if (e.shiftKey) {
+      if (ownerDocument.activeElement === first) {
+        e.preventDefault();
+        last?.focus();
+      }
+    } else {
+      if (ownerDocument.activeElement === last) {
+        e.preventDefault();
+        first?.focus();
+      }
+    }
+  };
+
+  container.addEventListener("keydown", handleKeyDown);
+
+  return () => {
+    container.removeEventListener("keydown", handleKeyDown);
+
+    if (
+      previouslyFocusedElement instanceof HTMLElement &&
+      ownerDocument.contains(previouslyFocusedElement)
+    ) {
+      previouslyFocusedElement.focus();
+    }
+  };
+}

--- a/src/hooks/useFocusTrap.test.ts
+++ b/src/hooks/useFocusTrap.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { createFocusTrap } from "@/hooks/focusTrap";
+
+class FakeElement {
+  children: FakeElement[] = [];
+  focusCalls = 0;
+  private keydownListener: ((event: KeyboardEvent) => void) | null = null;
+
+  constructor(private readonly setActiveElement: (element: FakeElement) => void) {}
+
+  focus() {
+    this.focusCalls += 1;
+    this.setActiveElement(this);
+  }
+
+  querySelectorAll() {
+    return this.children;
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    if (type === "keydown") {
+      this.keydownListener = listener as (event: KeyboardEvent) => void;
+    }
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    if (type === "keydown" && this.keydownListener === listener) {
+      this.keydownListener = null;
+    }
+  }
+
+  dispatchTab(shiftKey = false) {
+    let defaultPrevented = false;
+    this.keydownListener?.({
+      key: "Tab",
+      shiftKey,
+      preventDefault: () => {
+        defaultPrevented = true;
+      },
+    } as KeyboardEvent);
+    return defaultPrevented;
+  }
+}
+
+const nativeHTMLElement = globalThis.HTMLElement;
+
+test.after(() => {
+  globalThis.HTMLElement = nativeHTMLElement;
+});
+
+function setupFocusTrapElements() {
+  let activeElement: FakeElement | null = null;
+  const connectedElements = new Set<FakeElement>();
+  const setActiveElement = (element: FakeElement) => {
+    activeElement = element;
+  };
+
+  const trigger = new FakeElement(setActiveElement);
+  const container = new FakeElement(setActiveElement);
+  const first = new FakeElement(setActiveElement);
+  const last = new FakeElement(setActiveElement);
+  container.children = [first, last];
+
+  [trigger, container, first, last].forEach((element) => connectedElements.add(element));
+  activeElement = trigger;
+  globalThis.HTMLElement = FakeElement as typeof HTMLElement;
+
+  const ownerDocument = {
+    get activeElement() {
+      return activeElement;
+    },
+    contains(element: FakeElement) {
+      return connectedElements.has(element);
+    },
+  } as unknown as Document;
+
+  return {
+    connectedElements,
+    container: container as unknown as HTMLElement,
+    first,
+    last,
+    ownerDocument,
+    trigger,
+    get activeElement() {
+      return activeElement;
+    },
+  };
+}
+
+test("createFocusTrap restores focus to the triggering control on cleanup", () => {
+  const setup = setupFocusTrapElements();
+
+  const cleanup = createFocusTrap(setup.container, setup.ownerDocument);
+  assert.equal(setup.activeElement, setup.first);
+
+  cleanup();
+
+  assert.equal(setup.activeElement, setup.trigger);
+  assert.equal(setup.trigger.focusCalls, 1);
+});
+
+test("createFocusTrap does not restore focus when the trigger is no longer connected", () => {
+  const setup = setupFocusTrapElements();
+
+  const cleanup = createFocusTrap(setup.container, setup.ownerDocument);
+  setup.connectedElements.delete(setup.trigger);
+
+  cleanup();
+
+  assert.equal(setup.activeElement, setup.first);
+  assert.equal(setup.trigger.focusCalls, 0);
+});
+
+test("createFocusTrap keeps Tab focus inside the container", () => {
+  const setup = setupFocusTrapElements();
+
+  const cleanup = createFocusTrap(setup.container, setup.ownerDocument);
+
+  setup.last.focus();
+  assert.equal(setup.container.dispatchTab(), true);
+  assert.equal(setup.activeElement, setup.first);
+
+  setup.first.focus();
+  assert.equal(setup.container.dispatchTab(true), true);
+  assert.equal(setup.activeElement, setup.last);
+
+  cleanup();
+});
+
+test("useFocusTrap delegates active cleanup to the shared focus trap controller", () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src/hooks/useFocusTrap.ts"),
+    "utf8",
+  );
+
+  assert.match(source, /import \{ createFocusTrap \} from "@\/hooks\/focusTrap";/);
+  assert.match(source, /return createFocusTrap\(ref\.current\);/);
+});

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,44 +1,11 @@
 import { useEffect, RefObject } from "react";
 
-const FOCUSABLE_SELECTORS = [
-  "a[href]",
-  "button:not([disabled])",
-  "textarea:not([disabled])",
-  "input:not([disabled])",
-  "select:not([disabled])",
-  '[tabindex]:not([tabindex="-1"])',
-].join(", ");
+import { createFocusTrap } from "@/hooks/focusTrap";
 
 export function useFocusTrap(ref: RefObject<HTMLElement>, active: boolean) {
   useEffect(() => {
     if (!active || !ref.current) return;
 
-    const container = ref.current;
-    const focusableEls = Array.from(
-      container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
-    );
-
-    if (focusableEls.length) focusableEls[0].focus();
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== "Tab") return;
-      const first = focusableEls[0];
-      const last = focusableEls[focusableEls.length - 1];
-
-      if (e.shiftKey) {
-        if (document.activeElement === first) {
-          e.preventDefault();
-          last?.focus();
-        }
-      } else {
-        if (document.activeElement === last) {
-          e.preventDefault();
-          first?.focus();
-        }
-      }
-    };
-
-    container.addEventListener("keydown", handleKeyDown);
-    return () => container.removeEventListener("keydown", handleKeyDown);
+    return createFocusTrap(ref.current);
   }, [active, ref]);
 }


### PR DESCRIPTION
Summary
- Added coverage for overlay focus restoration and shared the focus-trap cleanup logic behind Modal and Drawer.

Issue
- Closes #208

Changes
- Extracted the focus-trap controller into a testable helper.
- Updated useFocusTrap to restore focus to the previously focused trigger when the trap cleans up.
- Added tests for focus restoration, removed-trigger safety, and Tab wrapping behavior.
- Added Modal and Drawer tests to verify both components delegate open-state focus management to useFocusTrap.

Validation
- Ran git diff --check.
- Ran npx --yes tsx --test src/hooks/useFocusTrap.test.ts src/components/ui/Modal.test.ts src/components/ui/Drawer.test.ts: 6 tests passed.
- npm run test is blocked on Windows because the script starts with TZ=UTC.
- npm ci failed because package.json and npm-shrinkwrap.json are out of sync: missing bufferutil@4.1.0 from the lock file.
- npm run typecheck could not run because dependencies are not installed and tsc is unavailable.

Notes
- The direct targeted test command passes using npx tsx. Full repo validation is blocked by existing dependency/script environment issues.