### PR TITLE
fix: prevent PII leakage in logger, analytics, and audit trail

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -91,12 +91,12 @@ export default function SignUpPage() {
     try {
       await signUp(email, name, password);
       setState("success");
-      mockAuditService.logEvent("signup", { email, name, timestamp: new Date().toISOString() });
+      mockAuditService.logEvent("signup", { status: "success", timestamp: new Date().toISOString() });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to create account";
       setErrors({ email: message });
       setState("idle");
-      mockAuditService.logEvent("signup", { email, status: "failed", reason: message });
+      mockAuditService.logEvent("signup", { status: "failed", reason: message });
     }
   };
 

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -33,7 +33,7 @@ export function NotificationItem({ notification, onMarkAsRead }: NotificationIte
       onClick={() => {
         if (!isRead) {
           onMarkAsRead(id);
-          analytics.track("notification_read", { id, title });
+          analytics.track("notification_read", { id });
         }
       }}
     >

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-import { logger } from "./logger";
+import { logger, scrubPII } from "./logger";
 
 export interface AnalyticsEvent {
   id: string;
@@ -24,18 +24,18 @@ const notifyListeners = (event: AnalyticsEvent) => {
 
 export const analytics = {
   track: (name: string, params?: Record<string, any>) => {
+    const safeParams = params ? scrubPII(params) : undefined;
     const event: AnalyticsEvent = {
       id: Math.random().toString(36).substring(7),
       name,
       timestamp: new Date().toISOString(),
-      params,
+      params: safeParams,
     };
-    
-    // Log for debugging
-    logger.info(`Analytics [${name}]`, params);
-    
+
+    logger.info(`Analytics [${name}]`, safeParams);
+
     notifyListeners(event);
-    
+
     // In a real app, this would send to Segment, Mixpanel, etc.
     if (process.env.NODE_ENV === "production") {
       // Send to real endpoint

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -24,9 +24,13 @@ const notifyListeners = (entry: LogEntry) => {
   listeners.forEach((l) => l(entry));
 };
 
-const scrubPII = (data: any): any => {
+export const scrubPII = (data: any): any => {
   if (!data) return data;
-  const sensitiveKeys = ["email", "address", "phone", "password", "secret", "key"];
+  const sensitiveKeys = [
+    "email", "address", "phone", "password", "secret", "key",
+    "name", "token", "userid", "ip", "ssn", "dob", "dateofbirth",
+    "creditcard", "cardnumber", "accountnumber",
+  ];
   if (typeof data === "object") {
     const scrubbed = Array.isArray(data) ? [...data] : { ...data };
     for (const key in scrubbed) {
@@ -52,12 +56,12 @@ const createEntry = (level: LogLevel, message: string, context?: any): LogEntry 
 export const logger = {
   info: (message: string, context?: any) => {
     const entry = createEntry("info", message, context);
-    console.log(`[INFO] ${message}`, context || "");
+    console.log(`[INFO] ${message}`, entry.context || "");
     notifyListeners(entry);
   },
   warn: (message: string, context?: any) => {
     const entry = createEntry("warn", message, context);
-    console.warn(`[WARN] ${message}`, context || "");
+    console.warn(`[WARN] ${message}`, entry.context || "");
     notifyListeners(entry);
   },
   error: (message: string, error?: any) => {
@@ -65,7 +69,7 @@ export const logger = {
       error: error instanceof Error ? error.message : error,
       stack: error instanceof Error ? error.stack : undefined,
     });
-    console.error(`[ERROR] ${message}`, error || "");
+    console.error(`[ERROR] ${message}`, entry.context || "");
     notifyListeners(entry);
   },
 };

--- a/src/lib/mock-audit.ts
+++ b/src/lib/mock-audit.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { random } from "./seeded-rng";
+import { scrubPII } from "./logger";
 
 export interface AuditEvent {
     id: string;
@@ -32,7 +33,7 @@ export const mockAuditService: AuditService = {
             eventType,
             actor: "current_user",
             timestamp: new Date(),
-            metadata,
+            metadata: scrubPII(metadata),
             ipAddress: "192.168.1.1",
             userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "Unknown",
         };


### PR DESCRIPTION
## Summary

- **Logger** — `scrubPII` now applies to `console.log/warn/error` output (previously raw PII bypassed scrubbing to the console); sensitive key list expanded to cover `name`, `token`, `ip`, `ssn`, `dob`, `creditcard`, `cardnumber`, `accountnumber`; `scrubPII` exported for reuse
- **Analytics** — `analytics.track` scrubs `params` via `scrubPII` before storing in `AnalyticsEvent` and before passing to any downstream listener or third-party integration
- **Audit trail** — `mockAuditService.logEvent` scrubs `metadata` before writing to `localStorage` (and therefore before `exportAsCSV`); `email` and `name` removed from signup audit log call sites
- **Notifications** — notification `title` dropped from `analytics.track("notification_read")` payload as titles may contain user-facing PII strings

## Test plan

- [ ] Trigger sign-up flow — confirm browser console shows `***REDACTED***` for email/name fields
- [ ] Open audit trail — confirm no raw email or name in stored events
- [ ] Export audit CSV — confirm metadata column contains redacted values
- [ ] Mark a notification as read — confirm analytics event only carries `id`, not `title`
- [ ] Trigger an analytics event with a PII-bearing key (e.g. `{ email: "x" }`) — confirm it is redacted in the event bus and console

Closes #222