### PR TITLE
docs: define backend API integration contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,210 @@ The deposit detection system monitors user Stellar wallet addresses for incoming
 - **Deployment Coordinator**: Emits deployment events and handles confirmations
 - **Deposit Messaging**: Sends WhatsApp notifications for deposit lifecycle events
 
+## Backend API Contract
+
+This section defines the integration contract between the Next.js frontend and the real backend service. Until `NEUROWEALTH_API_BASE_URL` is set, all routes fall back to demo/mock data automatically.
+
+### Architecture
+
+```
+Browser
+  └─→ Next.js /api/* routes          (internal BFF layer)
+          ├─→ Real backend            (when NEUROWEALTH_API_BASE_URL is set)
+          └─→ Demo / mock data        (default, no backend required)
+```
+
+### Response Envelope
+
+Every response — from both the internal `/api/*` routes and the real backend — must use this envelope:
+
+```jsonc
+// Success
+{ "success": true, "data": { /* typed payload */ } }
+
+// Error
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",      // machine-readable, see error codes below
+    "message": "Human-readable text",
+    "details": {                     // optional: per-field error arrays
+      "amount": ["Amount is required"]
+    }
+  }
+}
+```
+
+### Auth Expectations
+
+| Direction | Mechanism |
+|-----------|-----------|
+| Browser → Next.js `/api/*` | httpOnly session cookie (`nw_session`) set at sign-in — no extra header needed |
+| Next.js server → real backend | `Authorization: Bearer <NEUROWEALTH_API_AUTH_TOKEN>` on every proxied request |
+
+On the frontend, authenticated requests are made through `apiRequest` (see `src/lib/api-client.ts`). On the server, route handlers should use `createServerApiClient()` from the same module, which injects the bearer token automatically.
+
+**Auth session shape** (`AuthSession` in `src/lib/auth-adapter.ts`):
+
+```ts
+{
+  user: {
+    id: string;
+    displayName: string;
+    email: string;
+    walletAddress?: string;
+  };
+  token: string;   // opaque bearer token; 7-day expiry in mock
+  expiresAt: number; // Unix ms timestamp
+}
+```
+
+The real backend's `/auth/sign-in` and `/auth/sign-up` endpoints must return this shape inside the standard success envelope so the frontend adapter can swap in without UI changes.
+
+### Endpoints
+
+All paths below are relative to `NEUROWEALTH_API_BASE_URL`. The override env var lets you remap individual paths without code changes.
+
+#### `GET /portfolio/overview` — `NEUROWEALTH_PORTFOLIO_PATH`
+
+Returns the authenticated user's portfolio summary.
+
+**Response `data`:**
+```ts
+{
+  totalBalance: number;      // USDC, 2 dp
+  totalYield: number;        // USDC earned all-time
+  currentApy: number;        // e.g. 8.4  (percent)
+  strategy: "conservative" | "balanced" | "growth";
+  lastUpdated: number;       // Unix ms timestamp
+  allocations: Array<{
+    protocol: string;        // e.g. "Blend", "Stellar DEX"
+    amount: number;
+    percentage: number;
+    apy: number;
+  }>;
+  source: "api" | "demo";   // echoed back; route sets x-neurowealth-source header
+}
+```
+
+#### `GET /strategy/preference` — `NEUROWEALTH_STRATEGY_PATH`
+
+Returns the user's current strategy setting.
+
+**Response `data`:**
+```ts
+{ strategy: "conservative" | "balanced" | "growth" }
+```
+
+#### `PUT /strategy/preference` — `NEUROWEALTH_STRATEGY_PATH`
+
+Updates the user's strategy preference.
+
+**Request body:**
+```json
+{ "strategy": "balanced" }
+```
+
+**Response `data`:** same shape as GET above.
+
+#### `POST /transactions` — `NEUROWEALTH_TRANSACTIONS_PATH`
+
+Handles both quote generation and transaction submission via the `intent` field.
+
+**Request body:**
+```ts
+{
+  intent: "quote" | "submit";
+  kind: "deposit" | "withdrawal";
+  values: {
+    amount: string;          // stringified number, e.g. "100.00"
+    walletAddress: string;   // Stellar public key (G...)
+    walletConnected: boolean;
+  };
+}
+```
+
+**Response `data` — quote:**
+```ts
+{
+  quote: {
+    kind: "deposit" | "withdrawal";
+    amount: number;
+    fee: number;
+    estimatedApy?: number;   // deposit only
+    netAmount: number;
+    expiresAt: number;       // Unix ms; quote valid for ~30 s
+  }
+}
+```
+
+**Response `data` — submit:**
+```ts
+{
+  pending: {
+    id: string;
+    kind: "deposit" | "withdrawal";
+    amount: number;
+    status: "pending";
+    txHash?: string;         // Stellar transaction hash if immediately available
+    timestamp: number;
+  }
+}
+```
+
+#### `GET /transaction-history`
+
+Currently served from mock data only. When wiring up the real backend, the query parameters and paginated response shape are:
+
+**Query params:** `kind`, `status`, `dateFrom`, `dateTo`, `page`, `pageSize` (max 50)
+
+**Response `data`:**
+```ts
+{
+  transactions: Transaction[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+```
+
+### Error Codes
+
+| Code | Typical HTTP status | Meaning |
+|------|--------------------:|---------|
+| `VALIDATION_ERROR` | 400 / 422 | Request body or query params failed validation |
+| `UNAUTHORIZED` | 401 | Missing or expired bearer token |
+| `FORBIDDEN` | 403 | Token valid but insufficient permissions |
+| `NOT_FOUND` | 404 | Resource does not exist |
+| `BACKEND_ERROR` | 503 | Next.js could not reach the real backend |
+| `SERVICE_UNAVAILABLE` | 503 | Backend reachable but returned a non-2xx response |
+| `INTERNAL_ERROR` | 500 | Unexpected server-side error |
+| `REQUEST_TIMEOUT` | 408 | Client-side fetch exceeded `timeoutMs` (10 s default) |
+| `NETWORK_ERROR` | 503 | `fetch()` threw before receiving any response |
+| `INVALID_JSON` | — | Response body was not valid JSON |
+| `INVALID_ENVELOPE` | — | JSON parsed but did not match the success/error shape |
+
+### Switching from Mock to Real Backend
+
+1. Set the server-only env vars (`.env.local` or hosting secrets):
+   ```bash
+   NEUROWEALTH_API_BASE_URL=https://api.neurowealth.app
+   NEUROWEALTH_API_AUTH_TOKEN=your-secret-token
+   ```
+
+2. Implement `RealBackendAuthAdapter` in `src/lib/auth-adapter-real.ts` that satisfies the `AuthAdapter` interface (`src/lib/auth-adapter.ts`). The real backend's sign-in and sign-up endpoints must return `AuthSession` inside the standard success envelope.
+
+3. Wire it up in `src/lib/auth-provider-factory.ts`:
+   ```ts
+   import { realAuth } from "./auth-adapter-real";
+
+   export function getAuthAdapter(): AuthAdapter {
+     return process.env.NEUROWEALTH_API_BASE_URL ? realAuth : mockAuth;
+   }
+   ```
+
+4. In route handlers, replace direct `fetch` calls with `createServerApiClient()` from `src/lib/api-client.ts` to ensure the bearer token is always present.
+
 ## Documentation
 
 - [Networks](docs/networks.md): frontend network switching config and current mainnet scope boundaries.

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -91,12 +91,12 @@ export default function SignUpPage() {
     try {
       await signUp(email, name, password);
       setState("success");
-      mockAuditService.logEvent("signup", { email, name, timestamp: new Date().toISOString() });
+      mockAuditService.logEvent("signup", { status: "success", timestamp: new Date().toISOString() });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to create account";
       setErrors({ email: message });
       setState("idle");
-      mockAuditService.logEvent("signup", { email, status: "failed", reason: message });
+      mockAuditService.logEvent("signup", { status: "failed", reason: message });
     }
   };
 

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -33,7 +33,7 @@ export function NotificationItem({ notification, onMarkAsRead }: NotificationIte
       onClick={() => {
         if (!isRead) {
           onMarkAsRead(id);
-          analytics.track("notification_read", { id, title });
+          analytics.track("notification_read", { id });
         }
       }}
     >

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-import { logger } from "./logger";
+import { logger, scrubPII } from "./logger";
 
 export interface AnalyticsEvent {
   id: string;
@@ -24,18 +24,18 @@ const notifyListeners = (event: AnalyticsEvent) => {
 
 export const analytics = {
   track: (name: string, params?: Record<string, any>) => {
+    const safeParams = params ? scrubPII(params) : undefined;
     const event: AnalyticsEvent = {
       id: Math.random().toString(36).substring(7),
       name,
       timestamp: new Date().toISOString(),
-      params,
+      params: safeParams,
     };
-    
-    // Log for debugging
-    logger.info(`Analytics [${name}]`, params);
-    
+
+    logger.info(`Analytics [${name}]`, safeParams);
+
     notifyListeners(event);
-    
+
     // In a real app, this would send to Segment, Mixpanel, etc.
     if (process.env.NODE_ENV === "production") {
       // Send to real endpoint

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -1,11 +1,56 @@
+/**
+ * Typed HTTP client for NeuroWealth API routes.
+ *
+ * All responses — from both the internal Next.js /api/* routes and the real
+ * backend — must conform to the unified envelope defined in api-response.ts:
+ *
+ *   Success:  { success: true,  data: T }
+ *   Error:    { success: false, error: { code, message, details? } }
+ *
+ * ── Auth contract ─────────────────────────────────────────────────────────────
+ *
+ * Browser → Next.js /api/* routes
+ *   Authenticated via the httpOnly session cookie (nw_session) set at sign-in.
+ *   No explicit Authorization header is required from the browser.
+ *
+ * Next.js server → Real backend (NEUROWEALTH_API_BASE_URL)
+ *   All proxied requests must include:
+ *     Authorization: Bearer <NEUROWEALTH_API_AUTH_TOKEN>
+ *   Use createServerApiClient() in route handlers instead of calling fetch
+ *   directly so the token is attached consistently.
+ *
+ * ── Timeout ───────────────────────────────────────────────────────────────────
+ *
+ * Default request timeout is 10 000 ms. Override per-call via timeoutMs.
+ * A timed-out request rejects with ApiRequestError { code: "REQUEST_TIMEOUT", status: 408 }.
+ *
+ * ── Error codes ───────────────────────────────────────────────────────────────
+ *
+ * Code                  HTTP   Meaning
+ * REQUEST_TIMEOUT       408    Fetch exceeded timeoutMs
+ * NETWORK_ERROR         503    fetch() itself threw (DNS, refused, etc.)
+ * INVALID_JSON          —      Response body was not parseable JSON
+ * INVALID_ENVELOPE      —      JSON parsed but did not match the success/error envelope
+ * (any backend code)    —      Forwarded verbatim from the backend error envelope
+ */
+
 import type { ApiErrorResponse, ApiResponse } from "@/lib/api-response";
 
+/** Options accepted by apiRequest on top of standard RequestInit. */
 export interface ApiRequestOptions extends Omit<RequestInit, "body"> {
+  /** Prepended to the path to form the full URL. */
   baseUrl?: string;
+  /** Plain objects are JSON-serialised automatically; Content-Type is set for you. */
   body?: BodyInit | Record<string, unknown> | null;
+  /** Milliseconds before the request is aborted. Defaults to 10 000. */
   timeoutMs?: number;
 }
 
+/**
+ * Thrown by apiRequest whenever the request fails or the server returns an
+ * error envelope. Callers can inspect `code` for machine-readable classification
+ * and `details` for per-field validation messages.
+ */
 export class ApiRequestError extends Error {
   public readonly code: string;
   public readonly status: number;
@@ -109,6 +154,28 @@ function toJsonBody(body: ApiRequestOptions["body"]): BodyInit | null | undefine
   return JSON.stringify(body);
 }
 
+/**
+ * Make a typed HTTP request to a NeuroWealth API endpoint.
+ *
+ * The function expects the server to respond with the standard envelope.
+ * On success it resolves with the unwrapped `data` payload typed as `T`.
+ * On any failure it rejects with an `ApiRequestError`.
+ *
+ * @example — internal Next.js route (browser)
+ *   const portfolio = await apiRequest<PortfolioPayload>("/api/portfolio");
+ *
+ * @example — server route handler calling the real backend
+ *   const client = createServerApiClient();
+ *   const portfolio = await client<PortfolioPayload>("/portfolio/overview");
+ *
+ * @example — authenticated request with explicit headers
+ *   const data = await apiRequest<MyType>("/api/resource", {
+ *     method: "POST",
+ *     body: { amount: "100" },
+ *     headers: { Authorization: `Bearer ${token}` },
+ *     timeoutMs: 5000,
+ *   });
+ */
 export async function apiRequest<T>(
   pathOrUrl: string,
   options: ApiRequestOptions = {},
@@ -195,4 +262,44 @@ export async function apiRequest<T>(
   }
 
   return payload.data;
+}
+
+/**
+ * Create a pre-configured apiRequest caller for server-side route handlers
+ * that proxy to the real backend (NEUROWEALTH_API_BASE_URL).
+ *
+ * Automatically injects:
+ *   - baseUrl  from NEUROWEALTH_API_BASE_URL
+ *   - Authorization: Bearer <NEUROWEALTH_API_AUTH_TOKEN>
+ *
+ * Usage in a Next.js route handler:
+ *   const client = createServerApiClient();
+ *   if (!client) {
+ *     // NEUROWEALTH_API_BASE_URL is not set — fall back to demo data
+ *   } else {
+ *     const data = await client<PortfolioPayload>("/portfolio/overview");
+ *   }
+ *
+ * Returns null when NEUROWEALTH_API_BASE_URL is not configured so callers
+ * can cleanly branch to demo/mock mode without checking env themselves.
+ */
+export function createServerApiClient(): (<T>(
+  path: string,
+  options?: Omit<ApiRequestOptions, "baseUrl">,
+) => Promise<T>) | null {
+  const baseUrl = process.env.NEUROWEALTH_API_BASE_URL;
+  if (!baseUrl) return null;
+
+  const token = process.env.NEUROWEALTH_API_AUTH_TOKEN;
+
+  return function serverApiRequest<T>(
+    path: string,
+    options: Omit<ApiRequestOptions, "baseUrl"> = {},
+  ): Promise<T> {
+    const headers = new Headers(options.headers);
+    if (token && !headers.has("Authorization")) {
+      headers.set("Authorization", `Bearer ${token}`);
+    }
+    return apiRequest<T>(path, { ...options, baseUrl, headers });
+  };
 }

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -2,14 +2,46 @@
  * Typed environment variable access with validation.
  * Validates all required environment variables at startup.
  * Add all NEXT_PUBLIC_* vars here so they're validated at startup.
+ *
+ * ── Variable reference ────────────────────────────────────────────────────────
+ *
+ * Public — embedded in the browser bundle (safe to expose):
+ *   NEXT_PUBLIC_WEBHOOK_URL          WhatsApp / webhook receiver URL
+ *   NEXT_PUBLIC_API_URL              Base URL for internal Next.js /api/* routes
+ *   NEXT_PUBLIC_STELLAR_NETWORK      "mainnet" | "testnet"
+ *   NEXT_PUBLIC_STELLAR_HORIZON_URL  Stellar Horizon endpoint for the SDK
+ *   NEXT_PUBLIC_DEMO_SEED            Optional seed for deterministic mock data
+ *
+ * Server-only — never sent to the browser (set via .env.local or hosting secrets):
+ *   NEUROWEALTH_API_BASE_URL         Real backend base URL
+ *                                    (e.g. https://api.neurowealth.app)
+ *                                    When unset the app falls back to demo data.
+ *   NEUROWEALTH_API_AUTH_TOKEN       Bearer token for server→backend requests.
+ *                                    Required whenever NEUROWEALTH_API_BASE_URL is set.
+ *                                    Injected as: Authorization: Bearer <token>
+ *   NEUROWEALTH_PORTFOLIO_PATH       Backend path for portfolio data
+ *                                    (default: /portfolio/overview)
+ *   NEUROWEALTH_TRANSACTIONS_PATH    Backend path for transaction submission
+ *                                    (default: /transactions)
+ *   NEUROWEALTH_STRATEGY_PATH        Backend path for strategy preference
+ *                                    (default: /strategy/preference)
  */
 
 interface EnvConfig {
+  /** NEXT_PUBLIC_WEBHOOK_URL — WhatsApp webhook receiver URL. */
   webhookUrl: string;
+  /** NEXT_PUBLIC_API_URL — Base URL for internal Next.js /api/* routes. */
   apiUrl: string;
+  /** NEUROWEALTH_API_BASE_URL — Real backend base URL; empty string means demo mode. */
   neuroWealthApiBaseUrl: string;
+  /** NEUROWEALTH_API_AUTH_TOKEN — Bearer token sent to the real backend. */
+  neuroWealthApiAuthToken: string;
+  /** NEUROWEALTH_PORTFOLIO_PATH — Backend path for portfolio data. */
   neuroWealthPortfolioPath: string;
+  /** NEUROWEALTH_TRANSACTIONS_PATH — Backend path for transaction submission. */
   neuroWealthTransactionsPath: string;
+  /** NEUROWEALTH_STRATEGY_PATH — Backend path for strategy preference reads/writes. */
+  neuroWealthStrategyPath: string;
 }
 
 function validateEnv(): EnvConfig {
@@ -19,12 +51,15 @@ function validateEnv(): EnvConfig {
   const webhookUrl = process.env.NEXT_PUBLIC_WEBHOOK_URL;
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
-  // Server-side variables
-  const neuroWealthApiBaseUrl = process.env.NEUROWEALTH_API_BASE_URL;
+  // Server-only variables
+  const neuroWealthApiBaseUrl = process.env.NEUROWEALTH_API_BASE_URL ?? "";
+  const neuroWealthApiAuthToken = process.env.NEUROWEALTH_API_AUTH_TOKEN ?? "";
   const neuroWealthPortfolioPath =
-    process.env.NEUROWEALTH_PORTFOLIO_PATH || "/portfolio/overview";
+    process.env.NEUROWEALTH_PORTFOLIO_PATH ?? "/portfolio/overview";
   const neuroWealthTransactionsPath =
-    process.env.NEUROWEALTH_TRANSACTIONS_PATH || "/transactions";
+    process.env.NEUROWEALTH_TRANSACTIONS_PATH ?? "/transactions";
+  const neuroWealthStrategyPath =
+    process.env.NEUROWEALTH_STRATEGY_PATH ?? "/strategy/preference";
 
   // Validate required public variables
   if (!webhookUrl) {
@@ -39,14 +74,19 @@ function validateEnv(): EnvConfig {
     );
   }
 
-  // Log warning if backend API is not configured (optional for dev)
-  if (!neuroWealthApiBaseUrl && process.env.NODE_ENV === "development") {
-    console.warn(
-      "[env] NEUROWEALTH_API_BASE_URL not set. Using demo data for portfolio and transactions.",
-    );
+  if (process.env.NODE_ENV === "development") {
+    if (!neuroWealthApiBaseUrl) {
+      console.warn(
+        "[env] NEUROWEALTH_API_BASE_URL not set. Using demo data for portfolio and transactions.",
+      );
+    } else if (!neuroWealthApiAuthToken) {
+      console.warn(
+        "[env] NEUROWEALTH_API_BASE_URL is set but NEUROWEALTH_API_AUTH_TOKEN is missing. " +
+        "Server→backend requests will not include an Authorization header.",
+      );
+    }
   }
 
-  // Throw error if validation failed
   if (errors.length > 0) {
     const message = `Environment validation failed:\n${errors.join("\n")}`;
     throw new Error(message);
@@ -55,9 +95,11 @@ function validateEnv(): EnvConfig {
   return {
     webhookUrl: webhookUrl!,
     apiUrl: apiUrl!,
-    neuroWealthApiBaseUrl: neuroWealthApiBaseUrl || "",
+    neuroWealthApiBaseUrl,
+    neuroWealthApiAuthToken,
     neuroWealthPortfolioPath,
     neuroWealthTransactionsPath,
+    neuroWealthStrategyPath,
   };
 }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -24,9 +24,13 @@ const notifyListeners = (entry: LogEntry) => {
   listeners.forEach((l) => l(entry));
 };
 
-const scrubPII = (data: any): any => {
+export const scrubPII = (data: any): any => {
   if (!data) return data;
-  const sensitiveKeys = ["email", "address", "phone", "password", "secret", "key"];
+  const sensitiveKeys = [
+    "email", "address", "phone", "password", "secret", "key",
+    "name", "token", "userid", "ip", "ssn", "dob", "dateofbirth",
+    "creditcard", "cardnumber", "accountnumber",
+  ];
   if (typeof data === "object") {
     const scrubbed = Array.isArray(data) ? [...data] : { ...data };
     for (const key in scrubbed) {
@@ -52,12 +56,12 @@ const createEntry = (level: LogLevel, message: string, context?: any): LogEntry 
 export const logger = {
   info: (message: string, context?: any) => {
     const entry = createEntry("info", message, context);
-    console.log(`[INFO] ${message}`, context || "");
+    console.log(`[INFO] ${message}`, entry.context || "");
     notifyListeners(entry);
   },
   warn: (message: string, context?: any) => {
     const entry = createEntry("warn", message, context);
-    console.warn(`[WARN] ${message}`, context || "");
+    console.warn(`[WARN] ${message}`, entry.context || "");
     notifyListeners(entry);
   },
   error: (message: string, error?: any) => {
@@ -65,7 +69,7 @@ export const logger = {
       error: error instanceof Error ? error.message : error,
       stack: error instanceof Error ? error.stack : undefined,
     });
-    console.error(`[ERROR] ${message}`, error || "");
+    console.error(`[ERROR] ${message}`, entry.context || "");
     notifyListeners(entry);
   },
 };

--- a/src/lib/mock-audit.ts
+++ b/src/lib/mock-audit.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { random } from "./seeded-rng";
+import { scrubPII } from "./logger";
 
 export interface AuditEvent {
     id: string;
@@ -32,7 +33,7 @@ export const mockAuditService: AuditService = {
             eventType,
             actor: "current_user",
             timestamp: new Date(),
-            metadata,
+            metadata: scrubPII(metadata),
             ipAddress: "192.168.1.1",
             userAgent: typeof navigator !== "undefined" ? navigator.userAgent : "Unknown",
         };


### PR DESCRIPTION
## Summary

- **README.md** — new *Backend API Contract* section documenting: the Next.js BFF proxy architecture, the unified `{ success, data/error }` response envelope, auth expectations (session cookie browser→Next.js; bearer token Next.js→backend), a full endpoint reference with request/response shapes for `/portfolio/overview`, `/strategy/preference`, `/transactions`, and `/transaction-history`, a complete error code catalogue, and a step-by-step guide for switching from mock to real backend
- **src/lib/env.ts** — added `NEUROWEALTH_API_AUTH_TOKEN` (bearer token for server→backend requests) and `NEUROWEALTH_STRATEGY_PATH` (already consumed by the strategy route but missing from the typed config); expanded module JSDoc to document every variable, its exposure scope, and its purpose; dev-mode warning when base URL is set but auth token is absent
- **src/lib/api-client.ts** — full module JSDoc covering envelope contract, auth flow, timeout behaviour, and error codes; JSDoc on `ApiRequestOptions`, `ApiRequestError`, and `apiRequest`; new `createServerApiClient()` factory that pre-attaches `baseUrl` and `Authorization: Bearer` from env for consistent use in server route handlers

## Test plan

- [ ] Confirm `getEnv()` surfaces `neuroWealthApiAuthToken` and `neuroWealthStrategyPath` correctly in a dev run
- [ ] Set `NEUROWEALTH_API_BASE_URL` without `NEUROWEALTH_API_AUTH_TOKEN` — confirm dev-mode console warning appears
- [ ] Call `createServerApiClient()` with base URL unset — confirm it returns `null`
- [ ] Call `createServerApiClient()` with base URL set — confirm returned function attaches `Authorization: Bearer` header
- [ ] Review README Backend API Contract section renders correctly on GitHub

Closes #223