### PR TITLE
perf(charts,search): defer bundles, type chart data, race-safe search

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,25 +1,22 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
-import { useRouter } from "next/navigation";
-import { Search, Settings } from "lucide-react";
-import { commandPaletteRoutes } from "@/lib/routeMetadata";
-import { cn } from "@/lib/utils";
+import { useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 
-type Command = {
-  id: string;
-  name: string;
-  icon: React.ElementType;
-  action: () => void;
-};
+// The palette body (routes, icons, dialog markup) is split into its own chunk
+// and only fetched once the palette is first opened — it lives in the global
+// layout but is rarely used, so it should not ship in the initial bundle.
+const CommandPaletteDialog = dynamic(
+  () => import("./CommandPaletteDialog").then((mod) => mod.CommandPaletteDialog),
+  { ssr: false },
+);
 
+/**
+ * Lightweight launcher that owns the Cmd/Ctrl+K shortcut and open state, and
+ * lazy-loads the heavy CommandPaletteDialog on demand.
+ */
 export function CommandPalette() {
   const [isOpen, setIsOpen] = useState(false);
-  const [query, setQuery] = useState("");
-  const [selectedIndex, setSelectedIndex] = useState(0);
-  const router = useRouter();
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLUListElement>(null);
 
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
@@ -32,149 +29,7 @@ export function CommandPalette() {
     return () => document.removeEventListener("keydown", down);
   }, []);
 
-  const mockActions = [
-    { id: "action-logout", name: "Mock: Logout", action: () => alert("Logged Out") },
-    { id: "action-theme", name: "Mock: Toggle Theme", action: () => alert("Theme Toggled") },
-  ];
-
-  const allCommands: Command[] = [
-    ...commandPaletteRoutes.map((route) => ({
-      ...route,
-      action: () => {
-        router.push(route.path);
-        setIsOpen(false);
-      },
-    })),
-    ...mockActions.map((action) => ({
-      ...action,
-      icon: Settings,
-      action: () => {
-        action.action();
-        setIsOpen(false);
-      },
-    })),
-  ];
-
-  const filteredCommands = allCommands.filter((command) =>
-    command.name.toLowerCase().includes(query.toLowerCase()),
-  );
-
-  useEffect(() => {
-    if (isOpen) {
-      setQuery("");
-      setSelectedIndex(0);
-      setTimeout(() => inputRef.current?.focus(), 50);
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    setSelectedIndex(0);
-  }, [query]);
-
-  useEffect(() => {
-    if (listRef.current && isOpen && filteredCommands.length > 0) {
-      const activeElement = listRef.current.children[selectedIndex] as HTMLElement;
-      if (activeElement) {
-        activeElement.scrollIntoView({ block: "nearest" });
-      }
-    }
-  }, [selectedIndex, isOpen, filteredCommands.length]);
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (filteredCommands.length === 0) {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        setIsOpen(false);
-      }
-      return;
-    }
-
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      setSelectedIndex((prev) => (prev + 1) % filteredCommands.length);
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      setSelectedIndex((prev) => (prev - 1 + filteredCommands.length) % filteredCommands.length);
-    } else if (e.key === "Enter") {
-      e.preventDefault();
-      const selected = filteredCommands[selectedIndex];
-      if (selected) {
-        selected.action();
-      }
-    } else if (e.key === "Escape") {
-      e.preventDefault();
-      setIsOpen(false);
-    }
-  };
-
   if (!isOpen) return null;
 
-  return (
-    <div className="fixed inset-0 z-[9999] flex items-start justify-center px-0 pt-[10vh] sm:px-4 sm:pt-[20vh]">
-      <div
-        className="fixed inset-0 bg-black/60 backdrop-blur-sm"
-        onClick={() => setIsOpen(false)}
-        aria-hidden="true"
-      />
-      <div
-        role="dialog"
-        aria-modal="true"
-        aria-label="Command Palette"
-        className="relative w-full max-w-full overflow-hidden border border-slate-800 bg-slate-900 shadow-2xl animate-in fade-in zoom-in-95 duration-200 motion-reduce:animate-none motion-reduce:duration-0 motion-reduce:transform-none sm:max-w-[640px] sm:rounded-xl"
-      >
-        <div className="flex min-h-[56px] items-center border-b border-slate-800 px-4">
-          <Search className="mr-3 h-5 w-5 shrink-0 text-slate-400" />
-          <input
-            ref={inputRef}
-            type="text"
-            placeholder="Search routes and actions... (Cmd+K)"
-            className="flex-1 border-none bg-transparent pt-[1px] text-slate-200 outline-none placeholder:text-slate-500"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={handleKeyDown}
-            aria-autocomplete="list"
-            aria-controls="command-palette-results"
-            aria-activedescendant={
-              filteredCommands[selectedIndex] ? filteredCommands[selectedIndex].id : undefined
-            }
-          />
-        </div>
-
-        <ul
-          id="command-palette-results"
-          ref={listRef}
-          role="listbox"
-          className="max-h-[300px] overflow-y-auto p-2 sm:max-h-[400px]"
-        >
-          {filteredCommands.length === 0 && (
-            <li className="p-4 text-center text-sm text-slate-500">
-              No results found for &quot;{query}&quot;
-            </li>
-          )}
-          {filteredCommands.map((command, index) => {
-            const isSelected = index === selectedIndex;
-            return (
-              <li
-                key={command.id}
-                id={command.id}
-                role="option"
-                aria-selected={isSelected}
-                className={cn(
-                  "flex min-h-[44px] cursor-pointer items-center rounded-md px-4 py-2 text-sm transition-colors motion-reduce:transition-none",
-                  isSelected
-                    ? "bg-slate-800 text-sky-400"
-                    : "text-slate-400 hover:bg-slate-800/50 hover:text-slate-200",
-                )}
-                onClick={() => command.action()}
-                onMouseEnter={() => setSelectedIndex(index)}
-              >
-                <command.icon className="mr-3 h-4 w-4 shrink-0" />
-                <span>{command.name}</span>
-              </li>
-            );
-          })}
-        </ul>
-      </div>
-    </div>
-  );
+  return <CommandPaletteDialog onClose={() => setIsOpen(false)} />;
 }

--- a/src/components/CommandPaletteDialog.tsx
+++ b/src/components/CommandPaletteDialog.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Search, Settings } from "lucide-react";
+import { commandPaletteRoutes } from "@/lib/routeMetadata";
+import { cn } from "@/lib/utils";
+
+type Command = {
+  id: string;
+  name: string;
+  icon: React.ElementType;
+  action: () => void;
+};
+
+interface CommandPaletteDialogProps {
+  onClose: () => void;
+}
+
+/**
+ * The command palette UI. Loaded lazily by `CommandPalette` only after the
+ * palette is first opened, so its routes/icons/markup stay out of the initial
+ * bundle. Always mounted in the open state — open/close is owned by the parent.
+ */
+export function CommandPaletteDialog({ onClose }: CommandPaletteDialogProps) {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const mockActions = [
+    { id: "action-logout", name: "Mock: Logout", action: () => alert("Logged Out") },
+    { id: "action-theme", name: "Mock: Toggle Theme", action: () => alert("Theme Toggled") },
+  ];
+
+  const allCommands: Command[] = [
+    ...commandPaletteRoutes.map((route) => ({
+      ...route,
+      action: () => {
+        router.push(route.path);
+        onClose();
+      },
+    })),
+    ...mockActions.map((action) => ({
+      ...action,
+      icon: Settings,
+      action: () => {
+        action.action();
+        onClose();
+      },
+    })),
+  ];
+
+  const filteredCommands = allCommands.filter((command) =>
+    command.name.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  useEffect(() => {
+    const timer = setTimeout(() => inputRef.current?.focus(), 50);
+    return () => clearTimeout(timer);
+  }, []);
+
+  useEffect(() => {
+    setSelectedIndex(0);
+  }, [query]);
+
+  useEffect(() => {
+    if (listRef.current && filteredCommands.length > 0) {
+      const activeElement = listRef.current.children[selectedIndex] as HTMLElement;
+      if (activeElement) {
+        activeElement.scrollIntoView({ block: "nearest" });
+      }
+    }
+  }, [selectedIndex, filteredCommands.length]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (filteredCommands.length === 0) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+      return;
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((prev) => (prev + 1) % filteredCommands.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((prev) => (prev - 1 + filteredCommands.length) % filteredCommands.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const selected = filteredCommands[selectedIndex];
+      if (selected) {
+        selected.action();
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-start justify-center px-0 pt-[10vh] sm:px-4 sm:pt-[20vh]">
+      <div
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command Palette"
+        className="relative w-full max-w-full overflow-hidden border border-slate-800 bg-slate-900 shadow-2xl animate-in fade-in zoom-in-95 duration-200 motion-reduce:animate-none motion-reduce:duration-0 motion-reduce:transform-none sm:max-w-[640px] sm:rounded-xl"
+      >
+        <div className="flex min-h-[56px] items-center border-b border-slate-800 px-4">
+          <Search className="mr-3 h-5 w-5 shrink-0 text-slate-400" />
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search routes and actions... (Cmd+K)"
+            className="flex-1 border-none bg-transparent pt-[1px] text-slate-200 outline-none placeholder:text-slate-500"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-autocomplete="list"
+            aria-controls="command-palette-results"
+            aria-activedescendant={
+              filteredCommands[selectedIndex] ? filteredCommands[selectedIndex].id : undefined
+            }
+          />
+        </div>
+
+        <ul
+          id="command-palette-results"
+          ref={listRef}
+          role="listbox"
+          className="max-h-[300px] overflow-y-auto p-2 sm:max-h-[400px]"
+        >
+          {filteredCommands.length === 0 && (
+            <li className="p-4 text-center text-sm text-slate-500">
+              No results found for &quot;{query}&quot;
+            </li>
+          )}
+          {filteredCommands.map((command, index) => {
+            const isSelected = index === selectedIndex;
+            return (
+              <li
+                key={command.id}
+                id={command.id}
+                role="option"
+                aria-selected={isSelected}
+                className={cn(
+                  "flex min-h-[44px] cursor-pointer items-center rounded-md px-4 py-2 text-sm transition-colors motion-reduce:transition-none",
+                  isSelected
+                    ? "bg-slate-800 text-sky-400"
+                    : "text-slate-400 hover:bg-slate-800/50 hover:text-slate-200",
+                )}
+                onClick={() => command.action()}
+                onMouseEnter={() => setSelectedIndex(index)}
+              >
+                <command.icon className="mr-3 h-4 w-4 shrink-0" />
+                <span>{command.name}</span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/charts/AreaChartWrapper.tsx
+++ b/src/components/charts/AreaChartWrapper.tsx
@@ -3,10 +3,10 @@
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
 import { BaseChart, ChartTooltip, usePrefersReducedMotion } from "./BaseChart";
 import { chartTheme, chartDimensions } from "@/lib/chart-theme";
-import { ChartDataPoint } from "@/lib/mock-chart-data";
+import type { ChartDatum } from "@/lib/mock-chart-data";
 
-interface AreaChartWrapperProps {
-  data: ChartDataPoint[];
+interface AreaChartWrapperProps<T extends ChartDatum> {
+  data: T[];
   dataKey?: string;
   xAxisKey?: string;
   height?: number;
@@ -17,7 +17,7 @@ interface AreaChartWrapperProps {
   formatter?: (value: any, name: string) => [string, string];
 }
 
-export function AreaChartWrapper({
+export function AreaChartWrapper<T extends ChartDatum = ChartDatum>({
   data,
   dataKey = "value",
   xAxisKey = "name",
@@ -27,7 +27,7 @@ export function AreaChartWrapper({
   fillOpacity = 0.3,
   color = chartTheme.colors.primary,
   formatter,
-}: AreaChartWrapperProps) {
+}: AreaChartWrapperProps<T>) {
   return (
     <BaseChart height={height}>
       <AreaChart data={data} margin={chartDimensions.margin}>

--- a/src/components/charts/BarChartWrapper.tsx
+++ b/src/components/charts/BarChartWrapper.tsx
@@ -3,10 +3,10 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
 import { BaseChart, ChartTooltip } from "./BaseChart";
 import { chartTheme, chartDimensions } from "@/lib/chart-theme";
-import { ChartDataPoint } from "@/lib/mock-chart-data";
+import type { ChartDatum } from "@/lib/mock-chart-data";
 
-interface BarChartWrapperProps {
-  data: ChartDataPoint[];
+interface BarChartWrapperProps<T extends ChartDatum> {
+  data: T[];
   dataKey?: string;
   xAxisKey?: string;
   height?: number;
@@ -17,7 +17,7 @@ interface BarChartWrapperProps {
   formatter?: (value: any, name: string) => [string, string];
 }
 
-export function BarChartWrapper({
+export function BarChartWrapper<T extends ChartDatum = ChartDatum>({
   data,
   dataKey = "value",
   xAxisKey = "name",
@@ -27,7 +27,7 @@ export function BarChartWrapper({
   color = chartTheme.colors.primary,
   barSize,
   formatter,
-}: BarChartWrapperProps) {
+}: BarChartWrapperProps<T>) {
   return (
     <BaseChart height={height}>
       <BarChart data={data} margin={chartDimensions.margin} barCategoryGap="20%">

--- a/src/components/charts/DonutChartWrapper.tsx
+++ b/src/components/charts/DonutChartWrapper.tsx
@@ -3,11 +3,10 @@
 import { PieChart, Pie, Cell, Tooltip, Legend } from "recharts";
 import { BaseChart, ChartTooltip, usePrefersReducedMotion } from "./BaseChart";
 import { chartTheme, chartDimensions, getChartColor } from "@/lib/chart-theme";
-import { ChartDataPoint } from "@/lib/mock-chart-data";
-import { ChartTone } from "@/lib/portfolio";
+import type { AssetAllocationSlice } from "@/lib/mock-chart-data";
 
 interface DonutChartWrapperProps {
-  data: (ChartDataPoint & { tone?: ChartTone })[];
+  data: AssetAllocationSlice[];
   height?: number;
   innerRadius?: number;
   outerRadius?: number;

--- a/src/components/charts/LineChartWrapper.tsx
+++ b/src/components/charts/LineChartWrapper.tsx
@@ -3,10 +3,10 @@
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
 import { BaseChart, ChartTooltip } from "./BaseChart";
 import { chartTheme, chartDimensions } from "@/lib/chart-theme";
-import { ChartDataPoint } from "@/lib/mock-chart-data";
+import type { ChartDatum } from "@/lib/mock-chart-data";
 
-interface LineChartWrapperProps {
-  data: ChartDataPoint[];
+interface LineChartWrapperProps<T extends ChartDatum> {
+  data: T[];
   dataKey?: string;
   xAxisKey?: string;
   height?: number;
@@ -18,7 +18,7 @@ interface LineChartWrapperProps {
   formatter?: (value: any, name: string) => [string, string];
 }
 
-export function LineChartWrapper({
+export function LineChartWrapper<T extends ChartDatum = ChartDatum>({
   data,
   dataKey = "value",
   xAxisKey = "name",
@@ -29,7 +29,7 @@ export function LineChartWrapper({
   strokeWidth = 2,
   dot = false,
   formatter,
-}: LineChartWrapperProps) {
+}: LineChartWrapperProps<T>) {
   return (
     <BaseChart height={height}>
       <LineChart data={data} margin={chartDimensions.margin}>

--- a/src/components/dashboard/AllocationChart.tsx
+++ b/src/components/dashboard/AllocationChart.tsx
@@ -4,7 +4,9 @@ import dynamic from "next/dynamic";
 import { SkeletonCircle } from "@/components/ui/Skeleton";
 
 import { ComponentProps } from "react";
-import { DonutChartWrapper } from "@/components/charts/DonutChartWrapper";
+// Type-only import: keeps DonutChartWrapper (and recharts) out of the initial
+// bundle so the dynamic() import below is the sole code path that loads it.
+import type { DonutChartWrapper } from "@/components/charts/DonutChartWrapper";
 
 // Dynamically load the DonutChartWrapper with a skeleton fallback
 export const AllocationChart = dynamic<ComponentProps<typeof DonutChartWrapper>>(

--- a/src/components/search/GlobalSearch.tsx
+++ b/src/components/search/GlobalSearch.tsx
@@ -50,6 +50,10 @@ export function GlobalSearch({
 
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  // Monotonic id for the latest in-flight search. A response is applied only
+  // when its id still matches, so a slow search can never overwrite a newer
+  // one (or results that were cleared / navigated away from).
+  const requestIdRef = useRef(0);
 
   useOnClickOutside(rootRef, () => {
     setIsOpen(false);
@@ -73,9 +77,9 @@ export function GlobalSearch({
   }, [query]);
 
   useEffect(() => {
-    let cancelled = false;
-
     if (!debouncedQuery) {
+      // Invalidate any in-flight search so a late response can't repopulate.
+      requestIdRef.current += 1;
       setResults(EMPTY_RESULTS);
       setErrorMessage(null);
       setIsLoading(false);
@@ -83,31 +87,33 @@ export function GlobalSearch({
       return;
     }
 
+    const requestId = ++requestIdRef.current;
     setIsLoading(true);
     setErrorMessage(null);
 
     getSearchDataProvider()
       .search(debouncedQuery)
       .then((grouped) => {
-        if (cancelled) return;
+        if (requestId !== requestIdRef.current) return;
         setResults(grouped);
         const nextFlat = flattenResults(grouped);
         setActiveIndex(nextFlat.length > 0 ? 0 : -1);
       })
       .catch(() => {
-        if (cancelled) return;
+        if (requestId !== requestIdRef.current) return;
         setResults(EMPTY_RESULTS);
         setActiveIndex(-1);
         setErrorMessage("Search is temporarily unavailable. Please try again.");
       })
       .finally(() => {
-        if (!cancelled) {
+        if (requestId === requestIdRef.current) {
           setIsLoading(false);
         }
       });
 
     return () => {
-      cancelled = true;
+      // A newer query (or unmount) supersedes this run; ignore its result.
+      requestIdRef.current += 1;
     };
   }, [debouncedQuery]);
 
@@ -127,14 +133,17 @@ export function GlobalSearch({
   };
 
   const clearQuery = () => {
+    requestIdRef.current += 1; // drop any in-flight search so it can't repopulate
     setQuery("");
     setResults(EMPTY_RESULTS);
     setErrorMessage(null);
+    setIsLoading(false);
     setActiveIndex(-1);
     inputRef.current?.focus();
   };
 
   const navigateToResult = (item: SearchResultItem) => {
+    requestIdRef.current += 1; // drop any in-flight search before navigating away
     router.push(item.href);
     setIsOpen(false);
     setQuery("");

--- a/src/lib/mock-chart-data.ts
+++ b/src/lib/mock-chart-data.ts
@@ -1,33 +1,55 @@
 import { randomInt } from "./seeded-rng";
+import type { ChartTone } from "./portfolio";
 
-// Mock data for chart examples
-export interface ChartDataPoint {
+// Chart input types modelled on real domain concepts rather than a loose
+// `{ name; value; [key: string]: any }` shape. Each chart consumes the
+// specific datum type it actually renders.
+
+/** Base datum for single-series charts: a label and a numeric value. */
+export interface ChartDatum {
   name: string;
   value: number;
-  [key: string]: any;
+}
+
+/** Portfolio value at a point in time, plus the yield earned that period. */
+export interface PortfolioValuePoint extends ChartDatum {
+  /** Yield earned during the period, in the portfolio's base currency. */
+  yield: number;
+}
+
+/** A slice of the asset-allocation donut, themed by tone. */
+export interface AssetAllocationSlice extends ChartDatum {
+  tone?: ChartTone;
+}
+
+/** Portfolio value vs. a benchmark for a given period (multi-series line). */
+export interface BenchmarkComparisonPoint {
+  name: string;
+  portfolio: number;
+  benchmark: number;
 }
 
 const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
 // Line/Area chart data: Portfolio value over time
-export const portfolioValueData: ChartDataPoint[] = months.map((month, i) => {
+export const portfolioValueData: PortfolioValuePoint[] = months.map((month, i) => {
   const baseValue = 10000 + (i * 450);
   const noise = randomInt(-300, 300);
   return {
     name: month,
     value: baseValue + noise,
-    yield: randomInt(80, 450)
+    yield: randomInt(80, 450),
   };
 });
 
 // Bar chart data: Monthly yield
-export const monthlyYieldData: ChartDataPoint[] = portfolioValueData.map(p => ({
+export const monthlyYieldData: ChartDatum[] = portfolioValueData.map((p) => ({
   name: p.name,
-  value: p.yield
+  value: p.yield,
 }));
 
 // Donut chart data: Asset allocation
-export const assetAllocationData: ChartDataPoint[] = [
+export const assetAllocationData: AssetAllocationSlice[] = [
   { name: "USDC", value: randomInt(35, 50), tone: "primary" },
   { name: "USDT", value: randomInt(20, 30), tone: "accent" },
   { name: "XLM", value: randomInt(15, 25), tone: "warning" },
@@ -35,18 +57,18 @@ export const assetAllocationData: ChartDataPoint[] = [
 ];
 
 // Time series data for multiple lines
-export const multiLineData = months.map((month, i) => {
+export const multiLineData: BenchmarkComparisonPoint[] = months.map((month, i) => {
   const portfolio = portfolioValueData[i].value;
   const benchmarkBase = 9800 + (i * 400);
   return {
     name: month,
     portfolio,
-    benchmark: benchmarkBase + randomInt(-200, 200)
+    benchmark: benchmarkBase + randomInt(-200, 200),
   };
 });
 
 // Categorical bar data
-export const categoricalBarData: ChartDataPoint[] = [
+export const categoricalBarData: ChartDatum[] = [
   { name: "Deposits", value: randomInt(12000, 18000) },
   { name: "Withdrawals", value: randomInt(2000, 5000) },
   { name: "Yield", value: randomInt(2000, 3500) },


### PR DESCRIPTION
## Summary

Four frontend correctness/perf fixes across the chart and search/command surfaces.

### #225 — Lazy-load chart-heavy components — Closes #225
`AllocationChart` already used `next/dynamic` for `DonutChartWrapper`, but it also imported the component **as a value** (`import { DonutChartWrapper }`) for `ComponentProps<typeof …>`, which pulls the wrapper (and recharts) back into the bundle and defeats the split. Changed it to `import type`, so the `dynamic()` import is the only code path that loads recharts. (The Area/Bar/Line wrappers aren't referenced by any route and are already tree-shaken.)

### #226 — Align chart data types with domain models — Closes #226
Replaced the loose `ChartDataPoint { name; value; [key: string]: any }` in `src/lib/mock-chart-data.ts` with explicit domain types: `ChartDatum`, `PortfolioValuePoint` (adds `yield`), `AssetAllocationSlice` (adds `tone`), and `BenchmarkComparisonPoint`. The chart wrappers are now generic over `ChartDatum` (and the donut consumes `AssetAllocationSlice`), so inputs are typed by real domain concepts instead of an `any` index signature.

### #227 — Trim the command/search initial bundle — Closes #227
`CommandPalette` lives in the global layout but is only used on Cmd/Ctrl+K. Split the dialog UI into `CommandPaletteDialog` and load it via `next/dynamic` from a tiny launcher that owns only the shortcut + open state — so its routes/icons/markup ship in a separate chunk fetched on first open. `GlobalSearch` is left eager (it renders in the navbar, above the fold).

### #228 — Make global search cancellable and race-safe — Closes #228
`GlobalSearch` now tracks the latest search with a monotonic `requestId`; a response is applied only if its id is still current. The id is also bumped on clear, navigate, and effect cleanup, so a slow in-flight search can never overwrite newer results (or repopulate after the user clears/navigates).

## Test plan
- [x] `npm run typecheck` — no new type errors introduced (changed files clean).
- [x] `npm test` — full suite passes (39/39).
- [x] Manual: charts render; Cmd+K opens the palette (chunk loads on first open) and Esc/navigation close it; typing/clearing search no longer flashes stale results.

## Notes / out of scope
- `npm run typecheck` reports **8 pre-existing type errors on `main`** in unrelated files — confirmed identical with this change stashed (zero introduced here). Because `next build`/`next build --analyze` type-check the project, those pre-existing errors block a full production bundle analysis in this environment, so #227's decision is based on what each component contributes to the initial bundle (global Cmd+K modal → defer; navbar search → keep) rather than an analyzer run.

Closes #225
Closes #226
Closes #227
Closes #228