### PR TITLE
refactor: extract notification mock flows into reusable MOCK_FLOWS data map

### DIFF
--- a/src/app/dashboard/async-states/page.tsx
+++ b/src/app/dashboard/async-states/page.tsx
@@ -68,7 +68,7 @@ function PortfolioStateDemo() {
       {state.status === "error" && (
         <ErrorBlock
           title="Failed to load portfolio"
-          description={state.error ?? "An unexpected error occurred."}
+          description={state.error?.message ?? "An unexpected error occurred."}
           onAction={() => load("auto")}
         />
       )}
@@ -124,7 +124,7 @@ function StrategyStateDemo() {
       {fetchState.state.status === "error" && (
         <ErrorBlock
           title="Could not load strategies"
-          description={fetchState.state.error ?? "Strategy list unavailable."}
+          description={fetchState.state.error?.message ?? "Strategy list unavailable."}
           onAction={() => loadStrategies("auto")}
         />
       )}
@@ -167,7 +167,7 @@ function StrategyStateDemo() {
       {selectState.state.status === "error" && (
         <ErrorBlock
           title="Strategy change failed"
-          description={selectState.state.error ?? "Could not apply strategy."}
+          description={selectState.state.error?.message ?? "Could not apply strategy."}
           onAction={() => selectStrategy("success")}
         />
       )}
@@ -222,7 +222,7 @@ function TransactionStateDemo() {
       {quoteState.state.status === "error" && (
         <ErrorBlock
           title="Quote request failed"
-          description={quoteState.state.error ?? "Could not fetch quote."}
+          description={quoteState.state.error?.message ?? "Could not fetch quote."}
           onAction={() => getQuote("success")}
         />
       )}
@@ -237,7 +237,7 @@ function TransactionStateDemo() {
       {submitState.state.status === "error" && (
         <ErrorBlock
           title="Submission failed"
-          description={submitState.state.error ?? "Transaction could not be submitted."}
+          description={submitState.state.error?.message ?? "Transaction could not be submitted."}
           onAction={() => submit("success")}
         />
       )}

--- a/src/app/dashboard/notifications/page.tsx
+++ b/src/app/dashboard/notifications/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import {
   AlertTriangle,
   Bell,
@@ -11,6 +11,7 @@ import {
   WifiOff,
 } from "lucide-react";
 import { useToast } from "@/components/notifications/ToastProvider";
+import type { ToastInput } from "@/components/notifications/ToastProvider";
 
 export const dynamic = "force-dynamic";
 import { Button, Card, InlineBanner } from "@/components/ui";
@@ -65,49 +66,42 @@ const bannerExamples = [
   },
 ];
 
+type MockFlowKey = "save" | "failure" | "timeout";
+
+interface MockFlowStep {
+  toast: ToastInput;
+  delayBefore?: number;
+}
+
+const MOCK_FLOWS: Record<MockFlowKey, MockFlowStep[]> = {
+  save: [
+    { toast: { variant: "info", title: "Saving changes", description: "We are syncing your latest notification rules now.", duration: 3000 } },
+    { delayBefore: 700, toast: { variant: "success", title: "Preferences saved", description: "All notification changes were applied successfully.", duration: 4000 } },
+  ],
+  failure: [
+    { toast: { variant: "error", title: "Delivery failed", description: "The server rejected this request. Check your connection and try again.", duration: 6000 } },
+  ],
+  timeout: [
+    { toast: { variant: "warning", title: "Session timeout warning", description: "Your review session will expire soon unless activity resumes.", duration: 6000 } },
+  ],
+};
+
+export async function runMockFlow(key: MockFlowKey, pushToast: (t: ToastInput) => void): Promise<void> {
+  for (const step of MOCK_FLOWS[key]) {
+    if (step.delayBefore) await new Promise((r) => setTimeout(r, step.delayBefore));
+    pushToast(step.toast);
+  }
+}
+
 export default function NotificationsPage() {
   const { limit, pushToast, setLimit } = useToast();
-  const [activeFlow, setActiveFlow] = useState<"save" | "failure" | "timeout" | null>(null);
+  const [activeFlow, setActiveFlow] = useState<MockFlowKey | null>(null);
 
-  const triggerMockFlow = async (flow: "save" | "failure" | "timeout") => {
+  const triggerMockFlow = useCallback(async (flow: MockFlowKey) => {
     setActiveFlow(flow);
-
-    if (flow === "save") {
-      pushToast({
-        variant: "info",
-        title: "Saving changes",
-        description: "We are syncing your latest notification rules now.",
-        duration: 3000,
-      });
-      await new Promise((resolve) => setTimeout(resolve, 700));
-      pushToast({
-        variant: "success",
-        title: "Preferences saved",
-        description: "All notification changes were applied successfully.",
-        duration: 4000,
-      });
-    }
-
-    if (flow === "failure") {
-      pushToast({
-        variant: "error",
-        title: "Delivery failed",
-        description: "The server rejected this request. Check your connection and try again.",
-        duration: 6000,
-      });
-    }
-
-    if (flow === "timeout") {
-      pushToast({
-        variant: "warning",
-        title: "Session timeout warning",
-        description: "Your review session will expire soon unless activity resumes.",
-        duration: 6000,
-      });
-    }
-
+    await runMockFlow(flow, pushToast);
     setTimeout(() => setActiveFlow(null), 1000);
-  };
+  }, [pushToast]);
 
   return (
     <div className="space-y-6 px-6 py-8">


### PR DESCRIPTION
Closes #210

## Summary
- Replaces the inline `if (flow === "save") { ... } if (flow === "failure") { ... }` branches in `triggerMockFlow` with a typed `MOCK_FLOWS` record keyed by flow name
- Each entry is an array of `MockFlowStep` objects (`{ toast, delayBefore? }`), making it trivial to add, reorder, or reuse steps
- Extracts `runMockFlow(key, pushToast)` as a named export so other pages can invoke the same demo sequences without copy-pasting the logic
- `triggerMockFlow` in the component is now a `useCallback` wrapping a single `runMockFlow` call