### PR TITLE
a11y: add aria-live announcements to filters and pagination, table caption

### DIFF
--- a/src/app/dashboard/async-states/page.tsx
+++ b/src/app/dashboard/async-states/page.tsx
@@ -68,7 +68,7 @@ function PortfolioStateDemo() {
       {state.status === "error" && (
         <ErrorBlock
           title="Failed to load portfolio"
-          description={state.error ?? "An unexpected error occurred."}
+          description={state.error?.message ?? "An unexpected error occurred."}
           onAction={() => load("auto")}
         />
       )}
@@ -124,7 +124,7 @@ function StrategyStateDemo() {
       {fetchState.state.status === "error" && (
         <ErrorBlock
           title="Could not load strategies"
-          description={fetchState.state.error ?? "Strategy list unavailable."}
+          description={fetchState.state.error?.message ?? "Strategy list unavailable."}
           onAction={() => loadStrategies("auto")}
         />
       )}
@@ -167,7 +167,7 @@ function StrategyStateDemo() {
       {selectState.state.status === "error" && (
         <ErrorBlock
           title="Strategy change failed"
-          description={selectState.state.error ?? "Could not apply strategy."}
+          description={selectState.state.error?.message ?? "Could not apply strategy."}
           onAction={() => selectStrategy("success")}
         />
       )}
@@ -222,7 +222,7 @@ function TransactionStateDemo() {
       {quoteState.state.status === "error" && (
         <ErrorBlock
           title="Quote request failed"
-          description={quoteState.state.error ?? "Could not fetch quote."}
+          description={quoteState.state.error?.message ?? "Could not fetch quote."}
           onAction={() => getQuote("success")}
         />
       )}
@@ -237,7 +237,7 @@ function TransactionStateDemo() {
       {submitState.state.status === "error" && (
         <ErrorBlock
           title="Submission failed"
-          description={submitState.state.error ?? "Transaction could not be submitted."}
+          description={submitState.state.error?.message ?? "Transaction could not be submitted."}
           onAction={() => submit("success")}
         />
       )}

--- a/src/components/pagination-filters/FilterChips.tsx
+++ b/src/components/pagination-filters/FilterChips.tsx
@@ -30,6 +30,10 @@ export default function FilterChips({ options, selected, onChange, className = "
   const clearAll = () => onChange([]);
   const hasActive = selected.length > 0;
 
+  const activeLabel = selected.length === 0
+    ? "No filters active"
+    : `${selected.length} filter${selected.length > 1 ? "s" : ""} active`;
+
   return (
     <div
       role="group"
@@ -37,6 +41,10 @@ export default function FilterChips({ options, selected, onChange, className = "
       className={className}
       style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}
     >
+      {/* Announces filter state changes to screen readers */}
+      <span role="status" aria-live="polite" aria-atomic="true" style={{ position: "absolute", width: 1, height: 1, overflow: "hidden", clip: "rect(0,0,0,0)", whiteSpace: "nowrap" }}>
+        {activeLabel}
+      </span>
       {options.map((opt) => {
         const active = selected.includes(opt.id);
         return (

--- a/src/components/pagination-filters/Pagination.tsx
+++ b/src/components/pagination-filters/Pagination.tsx
@@ -80,6 +80,10 @@ export default function Pagination({
 
   return (
     <nav aria-label="Pagination" className={className} style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+      {/* Live region announces page changes to screen readers */}
+      <span role="status" aria-live="polite" aria-atomic="true" style={{ position: "absolute", width: 1, height: 1, overflow: "hidden", clip: "rect(0,0,0,0)", whiteSpace: "nowrap" }}>
+        Page {current} of {totalPages}
+      </span>
       {/* Prev */}
       <button
         onClick={() => go(current - 1)}

--- a/src/components/pagination-filters/TransactionList.tsx
+++ b/src/components/pagination-filters/TransactionList.tsx
@@ -35,7 +35,10 @@ export default function TransactionList() {
 
       {/* Table */}
       <div style={{ overflowX: "auto" }}>
-        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }} aria-label="Transaction history">
+          <caption style={{ position: "absolute", width: 1, height: 1, overflow: "hidden", clip: "rect(0,0,0,0)", whiteSpace: "nowrap" }}>
+            Transaction history, {totalItems} results
+          </caption>
           <thead>
             <tr style={{ borderBottom: "0.5px solid #21262d" }}>
               {["Date", "Description", "Type", "Amount", "Status"].map((h) => (


### PR DESCRIPTION
Closes #213

## Summary
- `Pagination`: adds a visually-hidden `role="status" aria-live="polite"` span that reads "Page N of M" whenever the current page changes — screen readers now announce page navigation
- `FilterChips`: adds a visually-hidden live region that announces "N filter(s) active" / "No filters active" whenever the selection changes
- `TransactionList`: adds a visually-hidden `<caption>` with total result count and an `aria-label` on the `<table>` element so assistive technology can identify it without relying on surrounding prose