### PR TITLE
fix(dashboard): add route loading states for key pages (#220)

### DIFF
--- a/src/app/dashboard/audit/loading.tsx
+++ b/src/app/dashboard/audit/loading.tsx
@@ -1,0 +1,5 @@
+import { AuditTableSkeleton } from "@/components/ui/Skeleton";
+
+export default function AuditLoading() {
+  return <AuditTableSkeleton rows={6} />;
+}

--- a/src/app/dashboard/history/loading.tsx
+++ b/src/app/dashboard/history/loading.tsx
@@ -1,0 +1,10 @@
+import { TableSkeleton } from "@/components/ui/Skeleton";
+
+export default function HistoryLoading() {
+  return (
+    <div className="px-6 pt-8" aria-busy="true" aria-label="Loading history">
+      <div className="mb-4 h-8 w-24 animate-pulse rounded-lg bg-white/5" />
+      <TableSkeleton rows={6} cols={5} />
+    </div>
+  );
+}

--- a/src/app/dashboard/notifications/loading.tsx
+++ b/src/app/dashboard/notifications/loading.tsx
@@ -1,0 +1,9 @@
+import { NotificationListSkeleton } from "@/components/ui/Skeleton";
+
+export default function NotificationsLoading() {
+  return (
+    <div className="px-6 py-8" aria-busy="true" aria-label="Loading notifications">
+      <NotificationListSkeleton items={4} />
+    </div>
+  );
+}

--- a/src/app/dashboard/sandbox/loading.tsx
+++ b/src/app/dashboard/sandbox/loading.tsx
@@ -1,0 +1,13 @@
+import { CardSkeleton } from "@/components/ui/Skeleton";
+
+export default function SandboxLoading() {
+  return (
+    <div className="space-y-6 px-6 py-8" aria-busy="true" aria-label="Loading sandbox">
+      <div className="h-9 w-56 animate-pulse rounded-lg bg-white/5" />
+      <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+        <CardSkeleton lines={4} showFooter />
+        <CardSkeleton lines={3} showFooter />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #220
Closes #220
Closes #219
Closes #177

## Changes
- Added route-level `loading.tsx` fallbacks for four dashboard routes:
  - `dashboard/audit`
  - `dashboard/history`
  - `dashboard/notifications`
  - `dashboard/sandbox`
- Reused the existing skeleton components so the loading states stay consistent with the current dashboard UI.

## Testing
- `git diff --check`