### PR TITLE
Fix package.json Tailwind duplicates and /signin middleware coverage

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -56,9 +56,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Install native Tailwind CSS binding
-        run: npm install @tailwindcss/oxide-linux-x64-gnu --legacy-peer-deps
-
       - name: Lint
         run: yarn lint
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -54,5 +54,6 @@ export const config = {
     "/settings/:path*",
     "/login",
     "/signup",
+    "/signin",
   ],
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11,7 +11,6 @@
         "@creit.tech/stellar-wallets-kit": "^1.8.0",
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^14.4.3",
-        "@tailwindcss/postcss": "^4.2.2",
         "clsx": "^2.1.0",
         "lucide-react": "^0.447.0",
         "next": "14.2.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "zod": "^3.25.76"
   },
   "optionalDependencies": {
-    "@tailwindcss/oxide-linux-x64-gnu": "^4.2.2"
+    "@tailwindcss/oxide-linux-x64-gnu": "4.2.2"
   },
   "overrides": {
     "csstype": "3.1.3"

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "@creit.tech/stellar-wallets-kit": "^1.8.0",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.4.3",
-    "@tailwindcss/oxide-linux-x64-gnu": "^4.2.2",
-    "@tailwindcss/postcss": "^4.2.2",
     "clsx": "^2.1.0",
     "lucide-react": "^0.447.0",
     "next": "14.2.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "zod": "^3.25.76"
   },
   "optionalDependencies": {
-    "@tailwindcss/oxide-linux-x64-gnu": "4.2.2"
+    "@tailwindcss/oxide-linux-x64-gnu": "^4.2.2"
   },
   "overrides": {
     "csstype": "3.1.3"

--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from "next/navigation";
+import { SIGN_IN_PATH } from "@/lib/auth-constants";
 
 interface SignInPageProps {
   searchParams?: { from?: string };
@@ -6,8 +7,8 @@ interface SignInPageProps {
 
 export default function SignInPage({ searchParams }: SignInPageProps) {
   const destination = searchParams?.from
-    ? `/login?from=${encodeURIComponent(searchParams.from)}`
-    : "/login";
+    ? `${SIGN_IN_PATH}?from=${encodeURIComponent(searchParams.from)}`
+    : SIGN_IN_PATH;
 
   redirect(destination);
 }

--- a/src/components/auth/ProtectedRoute.test.ts
+++ b/src/components/auth/ProtectedRoute.test.ts
@@ -168,6 +168,10 @@ test("ProtectedRoute — isAuthOnlyPath: /signup redirects authenticated users",
   assert.equal(isAuthOnlyPath("/signup"), true);
 });
 
+test("ProtectedRoute — isAuthOnlyPath: /signin redirects authenticated users", () => {
+  assert.equal(isAuthOnlyPath("/signin"), true);
+});
+
 test("ProtectedRoute — isAuthOnlyPath: /dashboard is accessible when authenticated", () => {
   assert.equal(isAuthOnlyPath("/dashboard"), false);
 });

--- a/src/components/auth/ProtectedRoute.test.ts
+++ b/src/components/auth/ProtectedRoute.test.ts
@@ -150,6 +150,10 @@ test("ProtectedRoute — isProtectedPath: /signup is public", () => {
   assert.equal(isProtectedPath("/signup"), false);
 });
 
+test("ProtectedRoute — isProtectedPath: /signin is public", () => {
+  assert.equal(isProtectedPath("/signin"), false);
+});
+
 test("ProtectedRoute — isProtectedPath: / (root) is public", () => {
   assert.equal(isProtectedPath("/"), false);
 });

--- a/src/lib/auth-constants.ts
+++ b/src/lib/auth-constants.ts
@@ -34,7 +34,7 @@ export const PROTECTED_PREFIXES = [
 ] as const;
 
 /** Routes that should redirect authenticated users away (e.g. /login → /dashboard) */
-export const AUTH_ONLY_PATHS = ["/login", "/signup"] as const;
+export const AUTH_ONLY_PATHS = ["/login", "/signup", "/signin"] as const;
 
 /** Checks whether a pathname requires authentication */
 export function isProtectedPath(pathname: string): boolean {


### PR DESCRIPTION
## Summary
- Remove duplicate `@tailwindcss/postcss` and `@tailwindcss/oxide-linux-x64-gnu` production dependency entries; keep PostCSS in devDependencies and the Linux oxide binding under optionalDependencies only.
- Sync `npm-shrinkwrap.json` and drop the redundant CI step that re-installed the oxide package via npm.
- Add `/signin` to middleware and auth-only route constants so authenticated users are redirected consistently, with tests and a sign-in alias that uses `SIGN_IN_PATH`.

## Verification
- Confirmed `package.json` lists `@tailwindcss/postcss` only in `devDependencies` and oxide only in `optionalDependencies`.
- `yarn install --frozen-lockfile` succeeds with the updated manifest.
- Auth helpers and middleware include `/signin`; unit tests cover auth-only and public behavior for the alias route.

Closes #233
Closes #249

Made with [Cursor](https://cursor.com)