### PR TITLE
Fix wallet storage consistency and network mismatch warnings

### DIFF
--- a/docs/wallet-architecture.md
+++ b/docs/wallet-architecture.md
@@ -4,14 +4,17 @@ This document describes how NeuroWealth manages wallet connections, persistence,
 
 ## Metadata Dictionary (LocalStorage)
 
-The `WalletProvider` persists minimal connection metadata to `localStorage` to enable auto-reconnection across page refreshes.
+The `WalletProvider` persists minimal connection metadata to `localStorage` via `src/lib/wallet-persistence.ts`. All keys are defined in `src/lib/storage-keys.ts`.
 
-| Key | Value Type | Description |
+| Key (`STORAGE_KEYS`) | localStorage value | Description |
 |:---|:---|:---|
-| `stellar_wallet_connected` | `"true" \| undefined` | Boolean flag indicating if a wallet was previously connected. |
-| `stellar_wallet_id` | `string` | The ID of the wallet provider (e.g., `"freighter"`, `"albedo"`). Matches `@creit.tech/stellar-wallets-kit` IDs. |
-| `stellar_wallet_address` | `string` | The public G-address of the connected account. |
-| `stellar_wallet_name` | `string` | Human-readable name of the wallet (e.g., `"Freighter"`). |
+| `WALLET_CONNECTED` | `"true" \| undefined` | Boolean flag indicating if a wallet was previously connected. |
+| `WALLET_PROVIDER` | `string` | Wallet provider ID (e.g., `"freighter"`, `"albedo"`). Matches `@creit.tech/stellar-wallets-kit` IDs. |
+| `WALLET_PUBLIC_KEY` | `string` | Public G-address of the connected account. |
+| `WALLET_DISPLAY_NAME` | `string` | Human-readable wallet name (e.g., `"Freighter"`). |
+| `WALLET_NETWORK` | `string` | Stellar network passphrase the app used when the wallet was connected. |
+
+Legacy `stellar_wallet_*` keys are migrated automatically on first read.
 
 > [!IMPORTANT]
 > These keys ONLY track the UI connection state. They do not represent a secure session.
@@ -34,11 +37,14 @@ It is critical to distinguish between the **Wallet Connection** and **Applicatio
 ## WalletProvider Behavior
 
 ### Auto-Reconnect Logic
-On mount, the `WalletProvider` checks for `stellar_wallet_connected === 'true'`. If found, it attempts to:
-1.  Initialize the `stellar-wallets-kit` with the saved `stellar_wallet_id`.
+On mount, the `WalletProvider` calls `readPersistedWalletState()`. If a saved connection exists, it attempts to:
+1.  Initialize the `stellar-wallets-kit` with the saved `WALLET_PROVIDER`.
 2.  Silently request the address from the extension.
-3.  If the address matches the saved `stellar_wallet_address`, the connection is restored.
-4.  If any step fails (e.g., wallet locked, extension uninstalled), the localStorage is cleared.
+3.  If the address matches the saved `WALLET_PUBLIC_KEY`, the connection is restored and network mismatch is re-checked.
+4.  If any step fails (e.g., wallet locked, extension uninstalled), persisted wallet keys are cleared.
+
+### Network mismatch warnings
+When Freighter is the active provider, the app compares the extension network to `NEXT_PUBLIC_STELLAR_NETWORK` and surfaces a warning in the navbar and connect button if they differ.
 
 ### Transaction Signing
 When `sendPayment` is called:

--- a/src/components/WalletConnectButton.tsx
+++ b/src/components/WalletConnectButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useWallet } from '@/contexts';
+import { NetworkMismatchWarning } from '@/components/wallet/NetworkMismatchWarning';
 
 const WalletIcon = () => (
   <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -20,7 +21,7 @@ interface WalletConnectButtonProps {
   theme?: 'light' | 'dark';
 }
 export default function WalletConnectButton({ theme = 'light' }: WalletConnectButtonProps) {
-  const { connected, isRestoring, connect, disconnect, walletName } = useWallet();
+  const { connected, isRestoring, connect, disconnect, walletName, networkStatus } = useWallet();
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -115,30 +116,35 @@ export default function WalletConnectButton({ theme = 'light' }: WalletConnectBu
   };
 
   return (
-    isRestoring ? (
-      <button
-        disabled
-        className="px-6 py-2.5 text-sm font-medium rounded-full bg-black text-white opacity-75 cursor-not-allowed"
-      >
-        <span className="flex items-center gap-2">
-          <LoaderIcon />
-        </span>
-      </button>
-    ) : (
-    <button 
-      onClick={handleClick}
-      disabled={isLoading}
-      className={`px-6 py-2.5 text-sm font-medium rounded-full transition-colors ${
-        theme === 'light' 
-          ? 'bg-black text-white hover:bg-gray-800' 
-          : 'bg-white text-black hover:bg-gray-200'
-      } ${isLoading ? 'opacity-75 cursor-not-allowed' : ''}`}
-    >
-      <span className="flex items-center gap-2">
-        {getIcon()}
-        {getButtonText()}
-      </span>
-    </button>
-    )
+    <div className="flex flex-col items-end gap-2">
+      {connected && networkStatus.hasMismatch && (
+        <NetworkMismatchWarning status={networkStatus} compact />
+      )}
+      {isRestoring ? (
+        <button
+          disabled
+          className="px-6 py-2.5 text-sm font-medium rounded-full bg-black text-white opacity-75 cursor-not-allowed"
+        >
+          <span className="flex items-center gap-2">
+            <LoaderIcon />
+          </span>
+        </button>
+      ) : (
+        <button
+          onClick={handleClick}
+          disabled={isLoading}
+          className={`px-6 py-2.5 text-sm font-medium rounded-full transition-colors ${
+            theme === 'light'
+              ? 'bg-black text-white hover:bg-gray-800'
+              : 'bg-white text-black hover:bg-gray-200'
+          } ${isLoading ? 'opacity-75 cursor-not-allowed' : ''}`}
+        >
+          <span className="flex items-center gap-2">
+            {getIcon()}
+            {getButtonText()}
+          </span>
+        </button>
+      )}
+    </div>
   );
 }

--- a/src/components/navbar/NavWalletStatus.tsx
+++ b/src/components/navbar/NavWalletStatus.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useWallet, useWalletConfig } from "@/contexts";
+import { NetworkMismatchWarning } from "@/components/wallet/NetworkMismatchWarning";
 
 function truncateAddress(address: string) {
   if (!address || address.length < 12) return address;
@@ -16,21 +17,32 @@ function formatNetworkLabel(network?: string) {
 }
 
 export function NavWalletStatus() {
-  const { connected, isRestoring, publicKey } = useWallet();
+  const { connected, isRestoring, publicKey, networkStatus } = useWallet();
   const config = useWalletConfig();
   const networkLabel = formatNetworkLabel(config?.network);
 
   if (isRestoring || !connected || !publicKey) return null;
 
   return (
-    <div className="hidden sm:flex items-center gap-2">
-      <span className="inline-flex items-center rounded-full border border-cyan-500/30 bg-cyan-500/10 px-3 py-1.5 text-xs font-semibold tracking-wide text-cyan-300">
-        {networkLabel}
-      </span>
-      <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-4 py-1.5 text-xs font-mono text-emerald-400">
-        <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
-        {truncateAddress(publicKey)}
-      </span>
+    <div className="hidden sm:flex flex-col items-end gap-2">
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs font-semibold tracking-wide ${
+            networkStatus.hasMismatch
+              ? "border-amber-500/40 bg-amber-500/10 text-amber-300"
+              : "border-cyan-500/30 bg-cyan-500/10 text-cyan-300"
+          }`}
+        >
+          {networkLabel}
+        </span>
+        <span className="inline-flex items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-4 py-1.5 text-xs font-mono text-emerald-400">
+          <span className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+          {truncateAddress(publicKey)}
+        </span>
+      </div>
+      {networkStatus.hasMismatch && (
+        <NetworkMismatchWarning status={networkStatus} className="max-w-sm" />
+      )}
     </div>
   );
 }

--- a/src/components/wallet/NetworkMismatchWarning.tsx
+++ b/src/components/wallet/NetworkMismatchWarning.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import type { WalletNetworkStatus } from "@/lib/wallet-network-detection";
+
+interface NetworkMismatchWarningProps {
+  status: WalletNetworkStatus;
+  className?: string;
+  compact?: boolean;
+}
+
+export function NetworkMismatchWarning({
+  status,
+  className = "",
+  compact = false,
+}: NetworkMismatchWarningProps) {
+  if (!status.hasMismatch) return null;
+
+  const walletLabel = status.walletNetworkLabel ?? "another network";
+  const appLabel = status.appNetworkLabel;
+
+  if (compact) {
+    return (
+      <p
+        role="alert"
+        className={`text-xs text-amber-300 ${className}`.trim()}
+      >
+        Wallet is on {walletLabel}; app expects {appLabel}.
+      </p>
+    );
+  }
+
+  return (
+    <div
+      role="alert"
+      className={`rounded-lg border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100 ${className}`.trim()}
+    >
+      <p className="font-semibold text-amber-200">Network mismatch</p>
+      <p className="mt-1 text-amber-100/90">
+        Your wallet is set to <span className="font-medium">{walletLabel}</span>,
+        but this app is configured for{" "}
+        <span className="font-medium">{appLabel}</span> (
+        <code className="text-amber-200/80">NEXT_PUBLIC_STELLAR_NETWORK</code>
+        ). Switch your wallet network or update the app configuration before
+        signing transactions.
+      </p>
+    </div>
+  );
+}

--- a/src/contexts/WalletProvider.tsx
+++ b/src/contexts/WalletProvider.tsx
@@ -17,6 +17,11 @@ import {
   persistWalletState,
   readPersistedWalletState,
 } from '@/lib/wallet-persistence';
+import {
+  detectWalletNetworkMismatch,
+  type WalletNetworkStatus,
+} from '@/lib/wallet-network-detection';
+import { formatConfiguredNetworkLabel } from '@/lib/stellar-network';
 
 const Server = Horizon.Server;
 
@@ -40,6 +45,8 @@ interface WalletContextState {
   isRestoring: boolean;
   publicKey?: string;
   walletName?: string;
+  walletProviderId?: string;
+  networkStatus: WalletNetworkStatus;
   balances: Balance[];
   connect: () => Promise<void>;
   disconnect: () => void;
@@ -69,8 +76,19 @@ export function WalletProvider({
   const [isRestoring, setIsRestoring] = useState(true);
   const [publicKey, setPublicKey] = useState<string>();
   const [walletName, setWalletName] = useState<string>();
+  const [walletProviderId, setWalletProviderId] = useState<string>();
+  const [networkStatus, setNetworkStatus] = useState<WalletNetworkStatus>(() => ({
+    hasMismatch: false,
+    appNetworkLabel: formatConfiguredNetworkLabel(),
+  }));
   const [balances, setBalances] = useState<Balance[]>([]);
   const [server] = useState(() => new Server(horizonUrl));
+
+  const refreshNetworkStatus = useCallback(async (providerId?: string) => {
+    const status = await detectWalletNetworkMismatch(providerId);
+    setNetworkStatus(status);
+    return status;
+  }, []);
 
   const connect = useCallback(async () => {
     try {
@@ -86,7 +104,9 @@ export function WalletProvider({
 
           setPublicKey(address);
           setWalletName(name);
+          setWalletProviderId(option.id);
           setConnected(true);
+          await refreshNetworkStatus(option.id);
 
           persistWalletState({
             connected: true,
@@ -114,7 +134,7 @@ export function WalletProvider({
       console.error('Failed to connect wallet:', error);
       throw error;
     }
-  }, [server, network]);
+  }, [server, network, refreshNetworkStatus]);
 
   const disconnect = useCallback(async () => {
     try {
@@ -122,13 +142,15 @@ export function WalletProvider({
       setConnected(false);
       setPublicKey(undefined);
       setWalletName(undefined);
+      setWalletProviderId(undefined);
       setBalances([]);
+      await refreshNetworkStatus();
 
       clearPersistedWalletState();
     } catch (error) {
       console.error('Failed to disconnect wallet:', error);
     }
-  }, []);
+  }, [refreshNetworkStatus]);
 
   const refreshBalances = useCallback(async () => {
     if (!publicKey) return;
@@ -215,7 +237,14 @@ export function WalletProvider({
           if (address === saved.publicKey) {
             setPublicKey(address);
             setWalletName(saved.displayName);
+            setWalletProviderId(saved.providerId);
             setConnected(true);
+            await refreshNetworkStatus(saved.providerId);
+
+            persistWalletState({
+              ...saved,
+              networkPassphrase: network,
+            });
 
             try {
               const account = await server.accounts().accountId(address).call();
@@ -239,13 +268,20 @@ export function WalletProvider({
     };
 
     autoReconnect();
-  }, [server]);
+  }, [server, network, refreshNetworkStatus]);
+
+  useEffect(() => {
+    if (!connected || !walletProviderId) return;
+    void refreshNetworkStatus(walletProviderId);
+  }, [connected, walletProviderId, refreshNetworkStatus]);
 
   const walletValue: WalletContextState = {
     connected,
     isRestoring,
     publicKey,
     walletName,
+    walletProviderId,
+    networkStatus,
     balances,
     connect,
     disconnect,

--- a/src/contexts/WalletProvider.tsx
+++ b/src/contexts/WalletProvider.tsx
@@ -114,7 +114,7 @@ export function WalletProvider({
       console.error('Failed to connect wallet:', error);
       throw error;
     }
-  }, [server]);
+  }, [server, network]);
 
   const disconnect = useCallback(async () => {
     try {
@@ -124,12 +124,7 @@ export function WalletProvider({
       setWalletName(undefined);
       setBalances([]);
 
-      if (typeof window !== 'undefined') {
-        localStorage.removeItem('stellar_wallet_connected');
-        localStorage.removeItem('stellar_wallet_id');
-        localStorage.removeItem('stellar_wallet_address');
-        localStorage.removeItem('stellar_wallet_name');
-      }
+      clearPersistedWalletState();
     } catch (error) {
       console.error('Failed to disconnect wallet:', error);
     }
@@ -209,20 +204,17 @@ export function WalletProvider({
     const autoReconnect = async () => {
       if (typeof window === 'undefined') return;
 
-      const wasConnected = localStorage.getItem('stellar_wallet_connected');
-      const savedWalletId = localStorage.getItem('stellar_wallet_id');
-      const savedAddress = localStorage.getItem('stellar_wallet_address');
-      const savedName = localStorage.getItem('stellar_wallet_name');
+      const saved = readPersistedWalletState();
 
-      if (wasConnected === 'true' && savedWalletId && savedAddress) {
+      if (saved) {
         try {
           const currentKit = kit();
-          currentKit.setWallet(savedWalletId);
+          currentKit.setWallet(saved.providerId);
           const { address } = await currentKit.getAddress();
 
-          if (address === savedAddress) {
+          if (address === saved.publicKey) {
             setPublicKey(address);
-            setWalletName(savedName || 'Unknown');
+            setWalletName(saved.displayName);
             setConnected(true);
 
             try {
@@ -239,12 +231,7 @@ export function WalletProvider({
           }
         } catch {
           console.log('Auto-reconnect failed');
-          if (typeof window !== 'undefined') {
-            localStorage.removeItem('stellar_wallet_connected');
-            localStorage.removeItem('stellar_wallet_id');
-            localStorage.removeItem('stellar_wallet_address');
-            localStorage.removeItem('stellar_wallet_name');
-          }
+          clearPersistedWalletState();
         }
       }
 

--- a/src/contexts/WalletProvider.tsx
+++ b/src/contexts/WalletProvider.tsx
@@ -12,6 +12,11 @@ import {
 } from '@stellar/stellar-sdk';
 import { ISupportedWallet } from "@creit.tech/stellar-wallets-kit";
 import { kit } from '../lib/stellar-wallet-kit';
+import {
+  clearPersistedWalletState,
+  persistWalletState,
+  readPersistedWalletState,
+} from '@/lib/wallet-persistence';
 
 const Server = Horizon.Server;
 
@@ -83,12 +88,13 @@ export function WalletProvider({
           setWalletName(name);
           setConnected(true);
 
-          if (typeof window !== 'undefined') {
-            localStorage.setItem('stellar_wallet_connected', 'true');
-            localStorage.setItem('stellar_wallet_id', option.id);
-            localStorage.setItem('stellar_wallet_address', address);
-            localStorage.setItem('stellar_wallet_name', name);
-          }
+          persistWalletState({
+            connected: true,
+            providerId: option.id,
+            publicKey: address,
+            displayName: name,
+            networkPassphrase: network,
+          });
 
           try {
             const account = await server.accounts().accountId(address).call();

--- a/src/lib/stellar-network.ts
+++ b/src/lib/stellar-network.ts
@@ -1,0 +1,29 @@
+import { Networks } from "@stellar/stellar-sdk";
+
+export type ConfiguredStellarNetwork = "testnet" | "mainnet";
+
+/**
+ * Resolves NEXT_PUBLIC_STELLAR_NETWORK to a normalized app network id.
+ */
+export function getConfiguredStellarNetwork(): ConfiguredStellarNetwork {
+  const raw = (process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet").toLowerCase();
+  return raw === "mainnet" || raw === "public" ? "mainnet" : "testnet";
+}
+
+export function getConfiguredNetworkPassphrase(): string {
+  return getConfiguredStellarNetwork() === "mainnet"
+    ? Networks.PUBLIC
+    : Networks.TESTNET;
+}
+
+export function formatConfiguredNetworkLabel(): string {
+  return getConfiguredStellarNetwork() === "mainnet" ? "PUBLIC" : "TESTNET";
+}
+
+export function networkPassphrasesMatch(
+  expected: string,
+  actual?: string | null,
+): boolean {
+  if (!actual) return true;
+  return expected === actual;
+}

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -30,6 +30,21 @@ export const STORAGE_KEYS = {
   ONBOARDING_STATE: "onboarding-state",
   ONBOARDING_USER_STRATEGY: "user-strategy",
   ONBOARDING_FIRST_DEPOSIT: "first-deposit",
+
+  // Stellar wallet connection (WalletProvider)
+  WALLET_CONNECTED: "nw_wallet_connected",
+  WALLET_PUBLIC_KEY: "nw_wallet_public_key",
+  WALLET_NETWORK: "nw_wallet_network",
+  WALLET_PROVIDER: "nw_wallet_provider",
+  WALLET_DISPLAY_NAME: "nw_wallet_display_name",
+} as const;
+
+/** Legacy keys used before centralization; migrated on read. */
+export const LEGACY_WALLET_STORAGE_KEYS = {
+  CONNECTED: "stellar_wallet_connected",
+  PROVIDER: "stellar_wallet_id",
+  PUBLIC_KEY: "stellar_wallet_address",
+  DISPLAY_NAME: "stellar_wallet_name",
 } as const;
 
 /**

--- a/src/lib/wallet-network-detection.ts
+++ b/src/lib/wallet-network-detection.ts
@@ -1,0 +1,70 @@
+import { getNetwork as getFreighterNetwork } from "@stellar/freighter-api";
+import { FREIGHTER_ID } from "@creit.tech/stellar-wallets-kit";
+import {
+  formatConfiguredNetworkLabel,
+  getConfiguredNetworkPassphrase,
+  networkPassphrasesMatch,
+} from "@/lib/stellar-network";
+
+export interface WalletNetworkStatus {
+  hasMismatch: boolean;
+  appNetworkLabel: string;
+  walletNetworkLabel?: string;
+  walletPassphrase?: string;
+}
+
+async function detectFreighterPassphrase(): Promise<string | undefined> {
+  if (typeof window === "undefined") return undefined;
+
+  try {
+    const { networkPassphrase, error } = await getFreighterNetwork();
+    if (error || !networkPassphrase) return undefined;
+    return networkPassphrase;
+  } catch {
+    return undefined;
+  }
+}
+
+function labelFromPassphrase(passphrase: string): string {
+  const lower = passphrase.toLowerCase();
+  if (lower.includes("test")) return "TESTNET";
+  if (lower.includes("public") || lower.includes("main")) return "PUBLIC";
+  return "UNKNOWN";
+}
+
+/**
+ * Compares the wallet extension network (when available) to NEXT_PUBLIC_STELLAR_NETWORK.
+ */
+export async function detectWalletNetworkMismatch(
+  walletProviderId?: string,
+): Promise<WalletNetworkStatus> {
+  const expectedPassphrase = getConfiguredNetworkPassphrase();
+  const appNetworkLabel = formatConfiguredNetworkLabel();
+
+  if (!walletProviderId || walletProviderId !== FREIGHTER_ID) {
+    return {
+      hasMismatch: false,
+      appNetworkLabel,
+    };
+  }
+
+  const walletPassphrase = await detectFreighterPassphrase();
+  if (!walletPassphrase) {
+    return {
+      hasMismatch: false,
+      appNetworkLabel,
+    };
+  }
+
+  const hasMismatch = !networkPassphrasesMatch(
+    expectedPassphrase,
+    walletPassphrase,
+  );
+
+  return {
+    hasMismatch,
+    appNetworkLabel,
+    walletNetworkLabel: labelFromPassphrase(walletPassphrase),
+    walletPassphrase,
+  };
+}

--- a/src/lib/wallet-persistence.ts
+++ b/src/lib/wallet-persistence.ts
@@ -1,0 +1,101 @@
+import {
+  LEGACY_WALLET_STORAGE_KEYS,
+  STORAGE_KEYS,
+} from "@/lib/storage-keys";
+
+export interface PersistedWalletState {
+  connected: boolean;
+  providerId: string;
+  publicKey: string;
+  displayName: string;
+  networkPassphrase?: string;
+}
+
+function readKey(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(key);
+}
+
+function writeKey(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(key, value);
+}
+
+function removeKey(key: string): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(key);
+}
+
+/**
+ * One-time migration from pre-centralization stellar_wallet_* keys.
+ */
+export function migrateLegacyWalletStorage(): void {
+  if (typeof window === "undefined") return;
+
+  const hasNewKeys = readKey(STORAGE_KEYS.WALLET_CONNECTED) !== null;
+  const legacyConnected = readKey(LEGACY_WALLET_STORAGE_KEYS.CONNECTED);
+  if (hasNewKeys || legacyConnected === null) return;
+
+  const providerId = readKey(LEGACY_WALLET_STORAGE_KEYS.PROVIDER);
+  const publicKey = readKey(LEGACY_WALLET_STORAGE_KEYS.PUBLIC_KEY);
+  const displayName = readKey(LEGACY_WALLET_STORAGE_KEYS.DISPLAY_NAME);
+
+  if (legacyConnected === "true" && providerId && publicKey) {
+    writeKey(STORAGE_KEYS.WALLET_CONNECTED, "true");
+    writeKey(STORAGE_KEYS.WALLET_PROVIDER, providerId);
+    writeKey(STORAGE_KEYS.WALLET_PUBLIC_KEY, publicKey);
+    if (displayName) {
+      writeKey(STORAGE_KEYS.WALLET_DISPLAY_NAME, displayName);
+    }
+  }
+
+  removeKey(LEGACY_WALLET_STORAGE_KEYS.CONNECTED);
+  removeKey(LEGACY_WALLET_STORAGE_KEYS.PROVIDER);
+  removeKey(LEGACY_WALLET_STORAGE_KEYS.PUBLIC_KEY);
+  removeKey(LEGACY_WALLET_STORAGE_KEYS.DISPLAY_NAME);
+}
+
+export function readPersistedWalletState(): PersistedWalletState | null {
+  migrateLegacyWalletStorage();
+
+  const connected = readKey(STORAGE_KEYS.WALLET_CONNECTED);
+  const providerId = readKey(STORAGE_KEYS.WALLET_PROVIDER);
+  const publicKey = readKey(STORAGE_KEYS.WALLET_PUBLIC_KEY);
+  const displayName = readKey(STORAGE_KEYS.WALLET_DISPLAY_NAME);
+  const networkPassphrase =
+    readKey(STORAGE_KEYS.WALLET_NETWORK) ?? undefined;
+
+  if (connected !== "true" || !providerId || !publicKey) {
+    return null;
+  }
+
+  return {
+    connected: true,
+    providerId,
+    publicKey,
+    displayName: displayName ?? "Unknown",
+    networkPassphrase,
+  };
+}
+
+export function persistWalletState(state: PersistedWalletState): void {
+  writeKey(STORAGE_KEYS.WALLET_CONNECTED, state.connected ? "true" : "false");
+  writeKey(STORAGE_KEYS.WALLET_PROVIDER, state.providerId);
+  writeKey(STORAGE_KEYS.WALLET_PUBLIC_KEY, state.publicKey);
+  writeKey(STORAGE_KEYS.WALLET_DISPLAY_NAME, state.displayName);
+  if (state.networkPassphrase) {
+    writeKey(STORAGE_KEYS.WALLET_NETWORK, state.networkPassphrase);
+  }
+}
+
+export function clearPersistedWalletState(): void {
+  removeKey(STORAGE_KEYS.WALLET_CONNECTED);
+  removeKey(STORAGE_KEYS.WALLET_PROVIDER);
+  removeKey(STORAGE_KEYS.WALLET_PUBLIC_KEY);
+  removeKey(STORAGE_KEYS.WALLET_DISPLAY_NAME);
+  removeKey(STORAGE_KEYS.WALLET_NETWORK);
+  removeKey(LEGACY_WALLET_STORAGE_KEYS.CONNECTED);
+  removeKey(LEGACY_WALLET_STORAGE_KEYS.PROVIDER);
+  removeKey(LEGACY_WALLET_STORAGE_KEYS.PUBLIC_KEY);
+  removeKey(LEGACY_WALLET_STORAGE_KEYS.DISPLAY_NAME);
+}


### PR DESCRIPTION
## Summary

- Centralize wallet connection metadata under `STORAGE_KEYS.WALLET_*` with `wallet-persistence.ts`, legacy `stellar_wallet_*` migration, and updated `WalletProvider` read/write/clear paths.
- Detect when Freighter’s network passphrase disagrees with `NEXT_PUBLIC_STELLAR_NETWORK` and warn users in the navbar wallet status and connect button.

## Verification

- Set `NEXT_PUBLIC_STELLAR_NETWORK=testnet`, connect Freighter on mainnet/public, and confirm amber network mismatch warnings appear in the navbar and beside Connect Wallet.
- Connect on matching networks and confirm warnings stay hidden while the network badge remains cyan.
- Connect, refresh the page, and confirm auto-reconnect still restores the wallet using `nw_wallet_*` keys (legacy keys migrate once).
- Disconnect and confirm all `nw_wallet_*` entries are removed from localStorage.

Closes #262
Closes #263

Made with [Cursor](https://cursor.com)