### PR TITLE
fix: use shared logger in sandbox

### DIFF
--- a/src/app/dashboard/sandbox/SandboxClientPage.tsx
+++ b/src/app/dashboard/sandbox/SandboxClientPage.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { STORAGE_KEYS } from "@/lib/storage-keys";
+import { logger } from "@/lib/logger";
 
 type ScenarioType = "success" | "empty" | "loading" | "partial-failure" | "timeout";
 type ModuleType = "portfolio" | "history" | "transactions";
@@ -45,7 +46,7 @@ export default function SandboxClientPage() {
       try {
         setScenarios(JSON.parse(saved));
       } catch (e) {
-        console.error("Failed to load sandbox scenarios:", e);
+        logger.error("Failed to load sandbox scenarios", e);
       }
     }
   }, [sandboxStorageKey]);

--- a/src/contexts/SandboxContext.tsx
+++ b/src/contexts/SandboxContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, ReactNode } from "react";
 import { STORAGE_KEYS } from "@/lib/storage-keys";
+import { logger } from "@/lib/logger";
 
 export type ScenarioType = "success" | "empty" | "loading" | "partial-failure" | "timeout";
 type ModuleType = "portfolio" | "history" | "transactions";
@@ -53,7 +54,7 @@ export function SandboxProvider({ children }: SandboxProviderProps) {
         try {
           setScenarios(JSON.parse(saved));
         } catch (e) {
-          console.error("Failed to load sandbox scenarios:", e);
+          logger.error("Failed to load sandbox scenarios", e);
         }
       }
     }


### PR DESCRIPTION
Closes #221

Replaces the remaining direct `console.error` calls in the sandbox flow with the shared `logger` utility.

Changes:
- `SandboxClientPage.tsx`: log sandbox scenario parse failures with `logger.error`
- `SandboxContext.tsx`: log sandbox scenario load failures with `logger.error`

This keeps sandbox logging consistent with the rest of the app.