### PR TITLE
feat: add profile and onboarding route error boundaries

### DIFF
--- a/src/app/onboarding/error.tsx
+++ b/src/app/onboarding/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { ErrorPage } from "@/components/ui/ErrorPage";
+
+export default function OnboardingError({
+  error: _error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorPage
+      statusCode={500}
+      title="Onboarding unavailable"
+      description="We could not load the onboarding flow. Your current progress remains safe, and you can retry the route when ready."
+      icon={<AlertTriangle size={32} />}
+      primaryAction={{ label: "Back to home", href: "/" }}
+      secondaryAction={{ label: "Try again", onClick: reset }}
+    />
+  );
+}

--- a/src/app/profile/error.tsx
+++ b/src/app/profile/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+import { ErrorPage } from "@/components/ui/ErrorPage";
+
+export default function ProfileError({
+  error: _error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <ErrorPage
+      statusCode={500}
+      title="Profile unavailable"
+      description="We could not load your profile view. Your saved preferences remain unchanged, and you can try loading this route again."
+      icon={<AlertTriangle size={32} />}
+      primaryAction={{ label: "Back to dashboard", href: "/dashboard" }}
+      secondaryAction={{ label: "Try again", onClick: reset }}
+    />
+  );
+}


### PR DESCRIPTION
closes #298 
Summary
Added error.tsx route-level error boundaries for /profile and /onboarding.
Reused the existing shared ErrorPage component.
Added route-specific recovery copy and retry behavior through Next.js reset().
Matched the existing app error UI pattern with AlertTriangle from lucide-react.

Reason
These routes were missing localized App Router error boundaries. Adding them prevents profile and onboarding runtime errors from falling directly to broader parent boundaries and gives users a focused recovery path.