### PR TITLE
test: add smoke tests for OG preview routes

### DIFF
--- a/src/app/api/preview-routes.test.ts
+++ b/src/app/api/preview-routes.test.ts
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import React from "react";
+import {
+  parseTransactionPreviewSearchParams,
+  parseWidgetPreviewSearchParams,
+} from "@/lib/preview-route-query";
+
+const TRANSACTION_PREVIEW_URL = "https://neurowealth.test/api/transaction-preview";
+const WIDGET_PREVIEW_URL = "https://neurowealth.test/api/widget-preview";
+
+type TransactionPreviewRoute = typeof import("./transaction-preview/route");
+type WidgetPreviewRoute = typeof import("./widget-preview/route");
+
+async function loadTransactionPreviewRoute() {
+  const route = await import("./transaction-preview/route");
+  const compatRoute = route as TransactionPreviewRoute & {
+    default?: TransactionPreviewRoute;
+  };
+  return compatRoute.default ?? route;
+}
+
+async function loadWidgetPreviewRoute() {
+  const route = await import("./widget-preview/route");
+  const compatRoute = route as WidgetPreviewRoute & {
+    default?: WidgetPreviewRoute;
+  };
+  return compatRoute.default ?? route;
+}
+
+function installReactForJsxRuntime() {
+  // Next compiles route JSX automatically; the Node smoke test needs React on
+  // globalThis when importing the TSX route modules directly through tsx.
+  Object.assign(globalThis, { React });
+}
+
+test("transaction preview route parses supported query parameters", async () => {
+  const params = new URLSearchParams({
+    theme: "dark",
+    kind: "withdrawal",
+    preview: "failure",
+  });
+
+  assert.deepEqual(parseTransactionPreviewSearchParams(params), {
+    theme: "dark",
+    kind: "withdrawal",
+    preview: "failure",
+  });
+});
+
+test("transaction preview route falls back for invalid query parameters", async () => {
+  const params = new URLSearchParams({
+    theme: "sepia",
+    kind: "transfer",
+    preview: "receipt",
+  });
+
+  assert.deepEqual(parseTransactionPreviewSearchParams(params), {
+    theme: "light",
+    kind: "deposit",
+    preview: "interactive",
+  });
+});
+
+test("transaction preview route returns an OG image response for valid queries", async () => {
+  installReactForJsxRuntime();
+  const route = await loadTransactionPreviewRoute();
+
+  const response = await route.GET(
+    new Request(
+      `${TRANSACTION_PREVIEW_URL}?theme=dark&kind=withdrawal&preview=confirm`,
+    ),
+  );
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type") ?? "", /^image\/png/);
+});
+
+test("widget preview route parses supported query parameters", async () => {
+  const params = new URLSearchParams({ theme: "dark" });
+
+  assert.deepEqual(parseWidgetPreviewSearchParams(params), {
+    theme: "dark",
+  });
+});
+
+test("widget preview route falls back for invalid query parameters", async () => {
+  const params = new URLSearchParams({ theme: "high-contrast" });
+
+  assert.deepEqual(parseWidgetPreviewSearchParams(params), {
+    theme: "light",
+  });
+});
+
+test("widget preview route returns an OG image response for invalid query fallbacks", async () => {
+  installReactForJsxRuntime();
+  const route = await loadWidgetPreviewRoute();
+
+  const response = await route.GET(
+    new Request(`${WIDGET_PREVIEW_URL}?theme=high-contrast`),
+  );
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type") ?? "", /^image\/png/);
+});

--- a/src/app/api/transaction-preview/route.tsx
+++ b/src/app/api/transaction-preview/route.tsx
@@ -3,9 +3,8 @@ import {
   buildPreviewSnapshot,
   buildStatusChips,
   getTransactionContext,
-  parsePreviewState,
-  parseTransactionKind,
 } from "@/lib/transactions";
+import { parseTransactionPreviewSearchParams } from "@/lib/preview-route-query";
 import { ImageResponse } from "next/og";
 
 export const dynamic = "force-dynamic";
@@ -50,9 +49,8 @@ function getToneColor(tone: "success" | "warning" | "error") {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const theme = searchParams.get("theme") === "dark" ? "dark" : "light";
-  const kind = parseTransactionKind(searchParams.get("kind"));
-  const preview = parsePreviewState(searchParams.get("preview"));
+  const { theme, kind, preview } =
+    parseTransactionPreviewSearchParams(searchParams);
   const palette = getThemePalette(theme);
   const context = getTransactionContext(kind);
   const snapshot = buildPreviewSnapshot(kind, preview);

--- a/src/app/api/widget-preview/route.tsx
+++ b/src/app/api/widget-preview/route.tsx
@@ -5,6 +5,7 @@ import {
   formatSignedPercent,
 } from "@/lib/formatters";
 import { buildScenarioPayload } from "@/lib/portfolio";
+import { parseWidgetPreviewSearchParams } from "@/lib/preview-route-query";
 import { ImageResponse } from "next/og";
 
 export const dynamic = "force-dynamic";
@@ -56,7 +57,7 @@ function chartColor(index: number) {
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const theme = searchParams.get("theme") === "dark" ? "dark" : "light";
+  const { theme } = parseWidgetPreviewSearchParams(searchParams);
   const palette = getThemePalette(theme);
   const portfolio = buildScenarioPayload("live", {
     source: "demo",

--- a/src/lib/preview-route-query.ts
+++ b/src/lib/preview-route-query.ts
@@ -1,0 +1,36 @@
+import {
+  parsePreviewState,
+  parseTransactionKind,
+  type TransactionKind,
+  type TransactionPreviewState,
+} from "@/lib/transactions";
+
+export type PreviewThemeMode = "light" | "dark";
+
+export interface TransactionPreviewSearchParams {
+  theme: PreviewThemeMode;
+  kind: TransactionKind;
+  preview: TransactionPreviewState;
+}
+
+export interface WidgetPreviewSearchParams {
+  theme: PreviewThemeMode;
+}
+
+export function parseTransactionPreviewSearchParams(
+  searchParams: URLSearchParams,
+): TransactionPreviewSearchParams {
+  return {
+    theme: searchParams.get("theme") === "dark" ? "dark" : "light",
+    kind: parseTransactionKind(searchParams.get("kind")),
+    preview: parsePreviewState(searchParams.get("preview")),
+  };
+}
+
+export function parseWidgetPreviewSearchParams(
+  searchParams: URLSearchParams,
+): WidgetPreviewSearchParams {
+  return {
+    theme: searchParams.get("theme") === "dark" ? "dark" : "light",
+  };
+}


### PR DESCRIPTION
closes #300 
Summary
Added smoke tests for api/transaction-preview and api/widget-preview.
Covered valid query parsing for both preview routes.
Covered invalid query fallback behavior for unsupported query values.
Added lightweight shared query parsing helpers in src/lib/preview-route-query.ts.
Verified both route handlers return an OG image response with image/png.

Reason
The OG preview routes needed test coverage for query parsing and error/fallback cases to reduce regression risk around dynamic preview generation.