### PR TITLE
PR: Component tests for ProtectedRoute + landing hero visual regression

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,71 @@
+# PR: Component tests for ProtectedRoute + landing hero visual regression
+
+Closes #308 · Closes #309
+
+---
+
+## Summary
+
+- **#308 — ProtectedRoute component tests**: Extended the existing
+  `src/components/auth/ProtectedRoute.test.ts` suite from 29 to 36 tests
+  by adding edge-case scenarios across all three guard branches
+  (loading / unauthenticated / authenticated).
+
+- **#309 — Landing hero visual regression**: Extended
+  `scripts/capture-visual-baselines.mjs` (`qa:visual-baseline`) with
+  dedicated landing-hero scenarios captured at every Tailwind responsive
+  breakpoint used by `src/features/landing/HeroSection.tsx`.
+
+---
+
+## Changes
+
+### `src/components/auth/ProtectedRoute.test.ts` (#308)
+
+Added 7 new tests that fill gaps not covered by the original 29:
+
+| New test | What it verifies |
+|---|---|
+| `'from' handles paths with query strings` | Query params survive `encodeURIComponent` round-trip |
+| `'from' preserves hash fragments` | Hash anchors (e.g. `#security`) survive encoding |
+| `'from' handles root path` | `/` is correctly encoded and decoded |
+| `default redirectTo is /login` | `SIGN_IN_PATH` constant matches expected value |
+| `all three outcomes are distinct` | `loading`, `redirect`, `children` are mutually exclusive |
+| `/onboarding requires auth` | `/onboarding` prefix is in `PROTECTED_PREFIXES` |
+| `/onboarding/step/1 nested requires auth` | Nested onboarding paths are also protected |
+
+All 36 tests pass (`node --import tsx --test`).
+
+### `scripts/capture-visual-baselines.mjs` (#309)
+
+**New viewports** covering the responsive breakpoints in `HeroSection.tsx`:
+
+| Viewport constant | Width | Tailwind tier triggered |
+|---|---|---|
+| `SM_VIEWPORT` | 640 px | `sm:text-5xl` activates |
+| `MD_VIEWPORT` | 768 px | `md:text-6xl` activates |
+| `LG_VIEWPORT` | 1024 px | `lg:` utilities activate |
+
+(Mobile 390 px and Desktop 1440 px were already present.)
+
+**New `LANDING_SCENARIOS`** targeting `src/features/landing/**`:
+
+| Scenario | State | What is captured |
+|---|---|---|
+| `landing-hero` | `above-fold` | Hero at initial scroll position |
+| `landing-hero` | `stats-visible` | Scrolled to the stats grid row |
+| `landing-hero` | `wallet-error` | Connect Wallet clicked — error message visible |
+
+All three scenarios run against all 5 viewports in `LANDING_VIEWPORTS`,
+adding **15 new screenshots** per baseline run on top of the existing 48.
+
+---
+
+## Test plan
+
+- [x] `npm run test` — all 36 ProtectedRoute tests pass, no regressions
+- [x] `node --check scripts/capture-visual-baselines.mjs` — script is
+  syntactically valid
+- [ ] Run `npm run qa:visual-baseline` against a live dev server to verify
+  the 15 new screenshots are generated correctly (requires a running
+  Next.js instance)

--- a/scripts/capture-visual-baselines.mjs
+++ b/scripts/capture-visual-baselines.mjs
@@ -37,6 +37,90 @@ const MOBILE_VIEWPORT = {
   },
 };
 
+// Tailwind sm: breakpoint — triggers text-5xl on the hero headline
+const SM_VIEWPORT = {
+  name: "sm-640x900",
+  options: {
+    viewport: { width: 640, height: 900 },
+    isMobile: false,
+    hasTouch: false,
+    colorScheme: "dark",
+    locale: "en-US",
+  },
+};
+
+// Tailwind md: breakpoint — triggers text-6xl on the hero headline
+const MD_VIEWPORT = {
+  name: "md-768x1024",
+  options: {
+    viewport: { width: 768, height: 1024 },
+    isMobile: false,
+    hasTouch: false,
+    colorScheme: "dark",
+    locale: "en-US",
+  },
+};
+
+// Tailwind lg: breakpoint — wide tablet / small desktop
+const LG_VIEWPORT = {
+  name: "lg-1024x768",
+  options: {
+    viewport: { width: 1024, height: 768 },
+    isMobile: false,
+    hasTouch: false,
+    colorScheme: "dark",
+    locale: "en-US",
+  },
+};
+
+// All breakpoints relevant to landing hero responsive styles
+const LANDING_VIEWPORTS = [
+  MOBILE_VIEWPORT,
+  SM_VIEWPORT,
+  MD_VIEWPORT,
+  LG_VIEWPORT,
+  DESKTOP_VIEWPORT,
+];
+
+// Landing-hero-specific scenarios targeting src/features/landing/**
+const LANDING_SCENARIOS = [
+  {
+    page: "landing-hero",
+    state: "above-fold",
+    path: "/",
+    waitForText: "AI-Powered",
+  },
+  {
+    page: "landing-hero",
+    state: "stats-visible",
+    path: "/",
+    waitForText: "AI-Powered",
+    action: async (page) => {
+      // Scroll to the stats row inside the hero section
+      await page.evaluate(() => {
+        const stats = document.querySelector(".grid.grid-cols-3");
+        if (stats) stats.scrollIntoView({ behavior: "instant" });
+      });
+      await page.waitForTimeout(300);
+    },
+  },
+  {
+    page: "landing-hero",
+    state: "wallet-error",
+    path: "/",
+    waitForText: "AI-Powered",
+    action: async (page) => {
+      // Trigger the Connect Wallet button without Freighter installed so the
+      // error message renders — confirms the error state is visually correct.
+      const btn = page.getByRole("button", { name: /connect wallet/i });
+      if (await btn.isVisible()) {
+        await btn.click();
+        await page.waitForTimeout(800);
+      }
+    },
+  },
+];
+
 const AUTH_SESSION = {
   user: {
     id: "u1",
@@ -408,6 +492,16 @@ async function main() {
   try {
     for (const scenario of scenarios) {
       for (const viewport of [DESKTOP_VIEWPORT, MOBILE_VIEWPORT]) {
+        const result = await captureScenario(browser, viewport, scenario);
+        manifest.push(result);
+        console.log(`captured ${result.relativeFile}`);
+      }
+    }
+
+    // Landing hero — capture at every Tailwind breakpoint so responsive
+    // styles (text-4xl / sm:text-5xl / md:text-6xl) are all exercised.
+    for (const scenario of LANDING_SCENARIOS) {
+      for (const viewport of LANDING_VIEWPORTS) {
         const result = await captureScenario(browser, viewport, scenario);
         manifest.push(result);
         console.log(`captured ${result.relativeFile}`);

--- a/src/components/auth/ProtectedRoute.test.ts
+++ b/src/components/auth/ProtectedRoute.test.ts
@@ -187,3 +187,52 @@ test("ProtectedRoute — isAuthOnlyPath: /profile is accessible when authenticat
 test("ProtectedRoute — isAuthOnlyPath: / (root) is not auth-only", () => {
   assert.equal(isAuthOnlyPath("/"), false);
 });
+
+// ── Additional redirect URL edge cases ────────────────────────────────────────
+
+test("ProtectedRoute — unauthenticated: 'from' handles paths with query strings", () => {
+  const original = "/dashboard?tab=settings";
+  const url = buildRedirectUrl(SIGN_IN_PATH, original);
+  const fromParam = new URLSearchParams(url.split("?")[1]).get("from");
+  assert.equal(fromParam, original);
+});
+
+test("ProtectedRoute — unauthenticated: 'from' preserves hash fragments", () => {
+  const original = "/dashboard/settings#security";
+  const url = buildRedirectUrl(SIGN_IN_PATH, original);
+  const fromParam = new URLSearchParams(url.split("?")[1]).get("from");
+  assert.equal(fromParam, original);
+});
+
+test("ProtectedRoute — unauthenticated: 'from' handles root path", () => {
+  const url = buildRedirectUrl(SIGN_IN_PATH, "/");
+  const fromParam = new URLSearchParams(url.split("?")[1]).get("from");
+  assert.equal(fromParam, "/");
+});
+
+// ── SIGN_IN_PATH default value ────────────────────────────────────────────────
+
+test("ProtectedRoute — default redirectTo is /login", () => {
+  assert.equal(SIGN_IN_PATH, "/login");
+});
+
+// ── Guard outcomes are mutually exclusive ─────────────────────────────────────
+
+test("ProtectedRoute — guard: all three outcomes are distinct", () => {
+  const outcomes = [
+    resolveGuard(true, null),
+    resolveGuard(false, null),
+    resolveGuard(false, AUTHED_USER),
+  ];
+  assert.equal(new Set(outcomes).size, 3);
+});
+
+// ── isProtectedPath — /onboarding ─────────────────────────────────────────────
+
+test("ProtectedRoute — isProtectedPath: /onboarding requires auth", () => {
+  assert.equal(isProtectedPath("/onboarding"), true);
+});
+
+test("ProtectedRoute — isProtectedPath: /onboarding/step/1 nested requires auth", () => {
+  assert.equal(isProtectedPath("/onboarding/step/1"), true);
+});


### PR DESCRIPTION


Closes #308 · 
Closes #309

---

## Summary

- **#308 — ProtectedRoute component tests**: Extended the existing
  `src/components/auth/ProtectedRoute.test.ts` suite from 29 to 36 tests
  by adding edge-case scenarios across all three guard branches
  (loading / unauthenticated / authenticated).

- **#309 — Landing hero visual regression**: Extended
  `scripts/capture-visual-baselines.mjs` (`qa:visual-baseline`) with
  dedicated landing-hero scenarios captured at every Tailwind responsive
  breakpoint used by `src/features/landing/HeroSection.tsx`.

---

## Changes

### `src/components/auth/ProtectedRoute.test.ts` (#308)

Added 7 new tests that fill gaps not covered by the original 29:

| New test | What it verifies |
|---|---|
| `'from' handles paths with query strings` | Query params survive `encodeURIComponent` round-trip |
| `'from' preserves hash fragments` | Hash anchors (e.g. `#security`) survive encoding |
| `'from' handles root path` | `/` is correctly encoded and decoded |
| `default redirectTo is /login` | `SIGN_IN_PATH` constant matches expected value |
| `all three outcomes are distinct` | `loading`, `redirect`, `children` are mutually exclusive |
| `/onboarding requires auth` | `/onboarding` prefix is in `PROTECTED_PREFIXES` |
| `/onboarding/step/1 nested requires auth` | Nested onboarding paths are also protected |

All 36 tests pass (`node --import tsx --test`).

### `scripts/capture-visual-baselines.mjs` (#309)

**New viewports** covering the responsive breakpoints in `HeroSection.tsx`:

| Viewport constant | Width | Tailwind tier triggered |
|---|---|---|
| `SM_VIEWPORT` | 640 px | `sm:text-5xl` activates |
| `MD_VIEWPORT` | 768 px | `md:text-6xl` activates |
| `LG_VIEWPORT` | 1024 px | `lg:` utilities activate |

(Mobile 390 px and Desktop 1440 px were already present.)

**New `LANDING_SCENARIOS`** targeting `src/features/landing/**`:

| Scenario | State | What is captured |
|---|---|---|
| `landing-hero` | `above-fold` | Hero at initial scroll position |
| `landing-hero` | `stats-visible` | Scrolled to the stats grid row |
| `landing-hero` | `wallet-error` | Connect Wallet clicked — error message visible |

All three scenarios run against all 5 viewports in `LANDING_VIEWPORTS`,
adding **15 new screenshots** per baseline run on top of the existing 48.

---

## Test plan

- [x] `npm run test` — all 36 ProtectedRoute tests pass, no regressions
- [x] `node --check scripts/capture-visual-baselines.mjs` — script is
  syntactically valid
- [ ] Run `npm run qa:visual-baseline` against a live dev server to verify
  the 15 new screenshots are generated correctly (requires a running
  Next.js instance)
