### PR TITLE
feat(landing): align marketing page with design spec palette, typogra…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,16 +6,16 @@
 @import "tailwindcss";
 
 @theme {
-  --color-dark-900: #020617;
+  --color-dark-900: #0b1220;
   --color-dark-800: #0f172a;
   --color-dark-700: #1e293b;
   --color-brand-400: #38bdf8;
-  --shadow-card: 0 8px 30px rgba(2, 6, 23, 0.35);
+  --shadow-card: 0 1px 2px rgb(0 0 0 / 0.2);
 }
 
 :root {
   --font-sans: Inter, "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
-  --font-mono: "IBM Plex Mono", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --font-mono: "Roboto Mono", "IBM Plex Mono", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   --positive: #10b981;
   --negative: #ef4444;
   --neutral: #94a3b8;
@@ -53,7 +53,7 @@ html {
 body {
   margin: 0;
   min-height: 100vh;
-  background: #020617;
+  background: #0b1220;
   color: #e2e8f0;
   font-family: var(--font-sans);
 }

--- a/src/features/landing/CtaSection.tsx
+++ b/src/features/landing/CtaSection.tsx
@@ -20,7 +20,7 @@ export function CtaSection() {
         </span>
 
         {/* Spec: 36px heading */}
-        <h2 className="mt-5 text-4xl font-bold leading-tight text-slate-50 md:text-5xl">
+        <h2 className="mt-5 text-4xl font-bold leading-normal text-slate-50 md:text-5xl">
           {messages.cta.title}
         </h2>
 

--- a/src/features/landing/HeroSection.tsx
+++ b/src/features/landing/HeroSection.tsx
@@ -26,7 +26,7 @@ export function HeroSection() {
         </span>
 
         {/* Headline — spec: 36px / line-height 1.4–1.6 */}
-        <h1 className="mt-4 text-4xl font-bold leading-tight tracking-tight text-slate-50 sm:text-5xl md:text-6xl">
+        <h1 className="mt-4 text-4xl font-bold leading-normal tracking-tight text-slate-50 sm:text-5xl md:text-6xl">
           {messages.hero.titleBeforeAccent}{" "}
           <span className="text-sky-400">{messages.hero.titleAccent}</span>{" "}
           {messages.hero.titleAfterAccent}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -27,7 +27,7 @@ const config: Config = {
         "primary": "#0EA5E9",
         "primary-hover": "#0284C7",
         // Text
-        "text-primary": "#F9FAFB",
+        "text-primary": "#F8FAFC",
         "text-secondary": "#9CA3AF",
         "text-muted": "#6B7280",
         // Status
@@ -38,7 +38,7 @@ const config: Config = {
       },
       fontFamily: {
         sans: ["Inter", "system-ui", "sans-serif"],
-        mono: ["JetBrains Mono", "monospace"],
+        mono: ["Roboto Mono", "JetBrains Mono", "monospace"],
       },
       fontWeight: {
         // Issue 29 spec: headings 600/700, body 400/500


### PR DESCRIPTION
…phy, shadows

- Page background #0B1220 (was #020617) per spec
- Card shadow updated to spec: 0 1px 2px rgb(0 0 0 / 0.2)
- Text primary #F8FAFC (was #F9FAFB) per spec
- Added Roboto Mono as preferred monospace font for numeric text
- Updated heading line-height to 1.5 within spec 1.4-1.6 range
- Monospace font stack now prefers Roboto Mono as spec requires

Closes #471