### PR TITLE
feat(ui): login page with all 4 states + reusable modal/drawer patterns

### DIFF
--- a/src/app/dashboard/sandbox/ui-demo/page.tsx
+++ b/src/app/dashboard/sandbox/ui-demo/page.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useState } from "react";
+import { WithdrawConfirmModal } from "@/components/ui/demos/WithdrawConfirmModal";
+import { StrategyChangeDrawer } from "@/components/ui/demos/StrategyChangeDrawer";
+import {
+  ActivityDetailDrawer,
+  type ActivityItem,
+} from "@/components/ui/demos/ActivityDetailDrawer";
+import { Button } from "@/components/ui/Button";
+
+const MOCK_ACTIVITY: ActivityItem = {
+  id: "tx-001",
+  type: "withdrawal",
+  asset: "USDC",
+  amount: "250.00",
+  status: "completed",
+  timestamp: "Jun 23, 2026 · 14:32 UTC",
+  from: "GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H",
+  to: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+  txHash:
+    "a9e6b5c4f3d2e1a0b9c8d7e6f5a4b3c2d1e0f9a8b7c6d5e4f3a2b1c0d9e8f7",
+  notes: "Quarterly rebalance",
+};
+
+export default function UiDemoPage() {
+  const [showWithdraw, setShowWithdraw] = useState(false);
+  const [showStrategy, setShowStrategy] = useState(false);
+  const [showActivity, setShowActivity] = useState(false);
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-10 space-y-10">
+      <div>
+        <h1 className="text-2xl font-bold text-text-primary mb-1">
+          UI Component Demo
+        </h1>
+        <p className="text-sm text-text-secondary">
+          Modal and Drawer patterns used across the three core mock flows.
+        </p>
+      </div>
+
+      {/* Flow 1 — Withdraw confirm (Modal) */}
+      <section className="card space-y-3">
+        <h2 className="text-base font-semibold text-text-primary">
+          Flow 1 · Withdraw confirm
+        </h2>
+        <p className="text-sm text-text-secondary">
+          Uses <code className="text-sky-400">{"<Modal>"}</code> with{" "}
+          <code className="text-sky-400">preventClose</code> while the mock
+          transaction is processing. Keyboard Escape and backdrop click are
+          blocked until the call resolves.
+        </p>
+        <Button variant="primary" onClick={() => setShowWithdraw(true)}>
+          Open withdraw confirm
+        </Button>
+      </section>
+
+      {/* Flow 2 — Strategy change (Drawer) */}
+      <section className="card space-y-3">
+        <h2 className="text-base font-semibold text-text-primary">
+          Flow 2 · Strategy change
+        </h2>
+        <p className="text-sm text-text-secondary">
+          Uses <code className="text-sky-400">{"<Drawer>"}</code> (360 px
+          desktop, full-width mobile) to present strategy options before the
+          user confirms. Escape key closes; focus is trapped inside the panel.
+        </p>
+        <Button variant="primary" onClick={() => setShowStrategy(true)}>
+          Open strategy drawer
+        </Button>
+      </section>
+
+      {/* Flow 3 — Activity detail (Drawer) */}
+      <section className="card space-y-3">
+        <h2 className="text-base font-semibold text-text-primary">
+          Flow 3 · Activity detail
+        </h2>
+        <p className="text-sm text-text-secondary">
+          Uses <code className="text-sky-400">{"<Drawer>"}</code> to surface
+          full transaction metadata — hash, addresses, status — for a selected
+          activity row. Includes copy-to-clipboard and Stellar Explorer link.
+        </p>
+        <Button variant="primary" onClick={() => setShowActivity(true)}>
+          Open activity detail
+        </Button>
+      </section>
+
+      {/* Modals / Drawers */}
+      <WithdrawConfirmModal
+        isOpen={showWithdraw}
+        onClose={() => setShowWithdraw(false)}
+        amount="250.00"
+        asset="USDC"
+        destination="GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+      />
+      <StrategyChangeDrawer
+        isOpen={showStrategy}
+        onClose={() => setShowStrategy(false)}
+        currentStrategy="balanced"
+      />
+      <ActivityDetailDrawer
+        isOpen={showActivity}
+        onClose={() => setShowActivity(false)}
+        activity={MOCK_ACTIVITY}
+      />
+    </div>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,19 +4,26 @@ import { Suspense, useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts";
 import { MAIN_CONTENT_LANDMARK_ID } from "@/lib/app-landmarks";
-import { Loader2, Zap } from "lucide-react";
+import { Loader2, Zap, Eye, EyeOff, Github, Chrome } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 export const dynamic = "force-dynamic";
 
-// Split out the inner component so useSearchParams is inside Suspense
+type LoginState = "idle" | "loading" | "error" | "success";
+
 function LoginContent() {
   const { signIn, user, loading } = useAuth();
   const router = useRouter();
   const searchParams = useSearchParams();
   const from = searchParams.get("from") ?? "/dashboard";
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [state, setState] = useState<LoginState>("idle");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!loading && user) {
@@ -24,27 +31,80 @@ function LoginContent() {
     }
   }, [loading, user, router, from]);
 
-  const handleDemoSignIn = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      await new Promise((r) => setTimeout(r, 800));
-      await signIn("demo@neurowealth.app", "password123");
-      router.replace(from);
-    } catch {
-      setError("Sign-in failed. Please try again.");
-    } finally {
-      setIsLoading(false);
+  const validate = () => {
+    let valid = true;
+    if (!email) {
+      setEmailError("Email is required.");
+      valid = false;
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      setEmailError("Enter a valid email address.");
+      valid = false;
+    } else {
+      setEmailError(null);
     }
-  }, [signIn, router, from]);
+
+    if (!password) {
+      setPasswordError("Password is required.");
+      valid = false;
+    } else if (password.length < 6) {
+      setPasswordError("Password must be at least 6 characters.");
+      valid = false;
+    } else {
+      setPasswordError(null);
+    }
+
+    return valid;
+  };
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setFormError(null);
+      if (!validate()) return;
+
+      setState("loading");
+      try {
+        await new Promise((r) => setTimeout(r, 900));
+        // Mock: treat demo credentials as valid
+        if (
+          email === "demo@neurowealth.app" ||
+          password === "password123"
+        ) {
+          await signIn(email, password);
+          setState("success");
+          setTimeout(() => router.replace(from), 800);
+        } else {
+          setState("error");
+          setFormError("Invalid credentials. Try demo@neurowealth.app / password123.");
+        }
+      } catch {
+        setState("error");
+        setFormError("Sign-in failed. Please try again.");
+      }
+    },
+    [email, password, signIn, router, from],
+  );
+
+  const handleDemoFill = () => {
+    setEmail("demo@neurowealth.app");
+    setPassword("password123");
+    setEmailError(null);
+    setPasswordError(null);
+    setFormError(null);
+    setState("idle");
+  };
+
+  const isLoading = state === "loading";
+  const isSuccess = state === "success";
 
   return (
     <main
       id={MAIN_CONTENT_LANDMARK_ID}
       tabIndex={-1}
-      className="min-h-screen bg-app-bg flex items-center justify-center px-4"
+      className="min-h-screen bg-app-bg flex items-center justify-center px-4 py-12"
     >
       <div className="w-full max-w-[420px]">
+        {/* Logo */}
         <div className="flex items-center justify-center gap-2 mb-8">
           <div className="w-9 h-9 rounded-lg bg-primary/20 flex items-center justify-center">
             <Zap className="w-5 h-5 text-primary" />
@@ -53,43 +113,200 @@ function LoginContent() {
         </div>
 
         <div className="card space-y-6">
+          {/* Heading */}
           <div>
             <h1 className="text-xl font-bold text-text-primary">
               Sign in to your account
             </h1>
             <p className="mt-1 text-sm text-text-secondary">
-              Connect your wallet to access your dashboard.
+              Connect your wallet or use a demo account.
             </p>
           </div>
 
-          {error && (
+          {/* Success state */}
+          {isSuccess && (
             <div
-              role="alert"
-              className="rounded-lg bg-error/10 border border-error/20 px-4 py-3 text-sm text-error"
+              role="status"
+              aria-live="polite"
+              className="rounded-lg bg-green-500/10 border border-green-500/20 px-4 py-3 text-sm text-green-400 flex items-center gap-2"
             >
-              {error}
+              <Zap className="w-4 h-4 shrink-0" aria-hidden="true" />
+              Signed in! Redirecting…
             </div>
           )}
 
-          <button
-            onClick={handleDemoSignIn}
-            disabled={isLoading}
-            data-qa="login-demo-button"
-            className="btn-primary w-full flex items-center justify-center gap-2 min-h-11 py-3 text-sm"
-            aria-label="Continue with demo account"
-          >
-            {isLoading ? (
-              <>
-                <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
-                Connecting…
-              </>
-            ) : (
-              <>
-                <Zap className="w-4 h-4" aria-hidden="true" />
-                Continue with Demo Account
-              </>
-            )}
-          </button>
+          {/* Form error (invalid credentials) */}
+          {state === "error" && formError && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="rounded-lg bg-error/10 border border-error/20 px-4 py-3 text-sm text-error"
+            >
+              {formError}
+            </div>
+          )}
+
+          {/* Login form */}
+          <form onSubmit={handleSubmit} noValidate className="space-y-4">
+            {/* Email */}
+            <div className="space-y-1">
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-text-primary"
+              >
+                Email address
+              </label>
+              <input
+                id="email"
+                type="email"
+                autoComplete="email"
+                value={email}
+                onChange={(e) => {
+                  setEmail(e.target.value);
+                  setEmailError(null);
+                  setFormError(null);
+                  if (state === "error") setState("idle");
+                }}
+                disabled={isLoading || isSuccess}
+                aria-describedby={emailError ? "email-error" : undefined}
+                aria-invalid={!!emailError}
+                placeholder="you@example.com"
+                className={cn(
+                  "w-full rounded-lg border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors",
+                  "focus:ring-2 focus:ring-primary/40 focus:border-primary/60",
+                  emailError
+                    ? "border-error focus:ring-error/30"
+                    : "border-border",
+                  (isLoading || isSuccess) && "opacity-50 cursor-not-allowed",
+                )}
+              />
+              {emailError && (
+                <p id="email-error" role="alert" className="text-[14px] text-error">
+                  {emailError}
+                </p>
+              )}
+            </div>
+
+            {/* Password */}
+            <div className="space-y-1">
+              <label
+                htmlFor="password"
+                className="block text-sm font-medium text-text-primary"
+              >
+                Password
+              </label>
+              <div className="relative">
+                <input
+                  id="password"
+                  type={showPassword ? "text" : "password"}
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={(e) => {
+                    setPassword(e.target.value);
+                    setPasswordError(null);
+                    setFormError(null);
+                    if (state === "error") setState("idle");
+                  }}
+                  disabled={isLoading || isSuccess}
+                  aria-describedby={passwordError ? "password-error" : undefined}
+                  aria-invalid={!!passwordError}
+                  placeholder="••••••••"
+                  className={cn(
+                    "w-full rounded-lg border bg-surface px-3 py-2 pr-10 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors",
+                    "focus:ring-2 focus:ring-primary/40 focus:border-primary/60",
+                    passwordError
+                      ? "border-error focus:ring-error/30"
+                      : "border-border",
+                    (isLoading || isSuccess) && "opacity-50 cursor-not-allowed",
+                  )}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-secondary transition-colors"
+                >
+                  {showPassword ? (
+                    <EyeOff className="w-4 h-4" aria-hidden="true" />
+                  ) : (
+                    <Eye className="w-4 h-4" aria-hidden="true" />
+                  )}
+                </button>
+              </div>
+              {passwordError && (
+                <p id="password-error" role="alert" className="text-[14px] text-error">
+                  {passwordError}
+                </p>
+              )}
+            </div>
+
+            {/* Submit */}
+            <button
+              type="submit"
+              disabled={isLoading || isSuccess}
+              data-qa="login-submit-button"
+              className="btn-primary w-full flex items-center justify-center gap-2 min-h-[44px] text-sm"
+              aria-label="Sign in"
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+                  Signing in…
+                </>
+              ) : isSuccess ? (
+                <>
+                  <Zap className="w-4 h-4" aria-hidden="true" />
+                  Redirecting…
+                </>
+              ) : (
+                "Sign in"
+              )}
+            </button>
+          </form>
+
+          {/* Divider */}
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center" aria-hidden="true">
+              <div className="w-full border-t border-border" />
+            </div>
+            <div className="relative flex justify-center text-xs">
+              <span className="bg-card px-2 text-text-muted">or continue with</span>
+            </div>
+          </div>
+
+          {/* Social placeholders */}
+          <div className="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              onClick={() => alert("Google sign-in coming soon.")}
+              className="flex items-center justify-center gap-2 rounded-lg border border-border bg-surface px-4 min-h-[44px] text-sm text-text-secondary hover:bg-surface/80 transition-colors"
+              aria-label="Sign in with Google (coming soon)"
+            >
+              <Chrome className="w-4 h-4 shrink-0" aria-hidden="true" />
+              Google
+            </button>
+            <button
+              type="button"
+              onClick={() => alert("GitHub sign-in coming soon.")}
+              className="flex items-center justify-center gap-2 rounded-lg border border-border bg-surface px-4 min-h-[44px] text-sm text-text-secondary hover:bg-surface/80 transition-colors"
+              aria-label="Sign in with GitHub (coming soon)"
+            >
+              <Github className="w-4 h-4 shrink-0" aria-hidden="true" />
+              GitHub
+            </button>
+          </div>
+
+          {/* Demo shortcut */}
+          <p className="text-center text-xs text-text-muted">
+            No account?{" "}
+            <button
+              type="button"
+              onClick={handleDemoFill}
+              className="text-primary underline-offset-2 hover:underline"
+            >
+              Fill demo credentials
+            </button>
+          </p>
 
           <p className="text-center text-xs text-text-muted">
             Wallet integration (Freighter) coming soon.
@@ -100,7 +317,6 @@ function LoginContent() {
   );
 }
 
-// Wrap in Suspense to satisfy Next.js prerender requirements for useSearchParams
 export default function LoginPage() {
   return (
     <Suspense fallback={null}>

--- a/src/components/ui/demos/ActivityDetailDrawer.tsx
+++ b/src/components/ui/demos/ActivityDetailDrawer.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { ArrowUpRight, ArrowDownLeft, ExternalLink, Copy, CheckCircle2 } from "lucide-react";
+import { useState } from "react";
+import { Drawer } from "@/components/ui/Drawer";
+import { Button } from "@/components/ui/Button";
+
+export interface ActivityItem {
+  id: string;
+  type: "deposit" | "withdrawal" | "yield";
+  asset: string;
+  amount: string;
+  status: "completed" | "pending" | "failed";
+  timestamp: string;
+  txHash?: string;
+  from?: string;
+  to?: string;
+  notes?: string;
+}
+
+interface ActivityDetailDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  activity: ActivityItem | null;
+}
+
+const STATUS_STYLES: Record<ActivityItem["status"], string> = {
+  completed: "bg-green-500/10 text-green-400 border-green-500/20",
+  pending: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+  failed: "bg-red-500/10 text-red-400 border-red-500/20",
+};
+
+export function ActivityDetailDrawer({
+  isOpen,
+  onClose,
+  activity,
+}: ActivityDetailDrawerProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyHash = () => {
+    if (!activity?.txHash) return;
+    navigator.clipboard.writeText(activity.txHash).catch(() => {});
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const Icon =
+    activity?.type === "withdrawal" ? ArrowUpRight : ArrowDownLeft;
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Transaction detail"
+      footer={
+        <Button onClick={onClose} variant="ghost">
+          Close
+        </Button>
+      }
+    >
+      {activity ? (
+        <div className="space-y-5">
+          {/* Amount + type */}
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-zinc-800 flex items-center justify-center shrink-0">
+              <Icon className="w-5 h-5 text-zinc-400" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="text-lg font-bold text-text-primary">
+                {activity.amount} {activity.asset}
+              </p>
+              <p className="text-sm capitalize text-text-secondary">{activity.type}</p>
+            </div>
+            <span
+              className={`ml-auto text-xs font-medium px-2 py-1 rounded-full border capitalize ${STATUS_STYLES[activity.status]}`}
+            >
+              {activity.status}
+            </span>
+          </div>
+
+          {/* Details */}
+          <dl className="space-y-3 text-sm border-t border-zinc-800 pt-4">
+            <div className="flex justify-between">
+              <dt className="text-text-secondary">Date</dt>
+              <dd className="text-text-primary">{activity.timestamp}</dd>
+            </div>
+            {activity.from && (
+              <div className="flex justify-between gap-4">
+                <dt className="text-text-secondary shrink-0">From</dt>
+                <dd className="font-mono text-xs text-text-primary truncate">{activity.from}</dd>
+              </div>
+            )}
+            {activity.to && (
+              <div className="flex justify-between gap-4">
+                <dt className="text-text-secondary shrink-0">To</dt>
+                <dd className="font-mono text-xs text-text-primary truncate">{activity.to}</dd>
+              </div>
+            )}
+            {activity.notes && (
+              <div className="flex justify-between gap-4">
+                <dt className="text-text-secondary shrink-0">Notes</dt>
+                <dd className="text-text-primary text-right">{activity.notes}</dd>
+              </div>
+            )}
+          </dl>
+
+          {/* Tx hash */}
+          {activity.txHash && (
+            <div className="space-y-1 border-t border-zinc-800 pt-4">
+              <p className="text-xs text-text-muted">Transaction hash</p>
+              <div className="flex items-center gap-2 rounded-lg bg-zinc-800 px-3 py-2">
+                <code className="text-xs text-zinc-300 flex-1 truncate">
+                  {activity.txHash}
+                </code>
+                <button
+                  type="button"
+                  onClick={copyHash}
+                  aria-label="Copy transaction hash"
+                  className="text-zinc-400 hover:text-zinc-200 transition-colors shrink-0"
+                >
+                  {copied ? (
+                    <CheckCircle2 className="w-4 h-4 text-green-400" aria-hidden="true" />
+                  ) : (
+                    <Copy className="w-4 h-4" aria-hidden="true" />
+                  )}
+                </button>
+                <a
+                  href={`https://stellar.expert/explorer/public/tx/${activity.txHash}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="View on Stellar Explorer"
+                  className="text-zinc-400 hover:text-sky-400 transition-colors shrink-0"
+                >
+                  <ExternalLink className="w-4 h-4" aria-hidden="true" />
+                </a>
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-text-secondary">No activity selected.</p>
+      )}
+    </Drawer>
+  );
+}

--- a/src/components/ui/demos/StrategyChangeDrawer.tsx
+++ b/src/components/ui/demos/StrategyChangeDrawer.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { TrendingUp, ShieldCheck, Zap, Loader2, CheckCircle2 } from "lucide-react";
+import { Drawer } from "@/components/ui/Drawer";
+import { Button } from "@/components/ui/Button";
+
+type StrategyKey = "conservative" | "balanced" | "aggressive";
+
+interface Strategy {
+  key: StrategyKey;
+  label: string;
+  apy: string;
+  risk: string;
+  description: string;
+  Icon: React.ElementType;
+}
+
+const STRATEGIES: Strategy[] = [
+  {
+    key: "conservative",
+    label: "Conservative",
+    apy: "3–5%",
+    risk: "Low",
+    description: "Stable yields with minimal exposure. Suitable for capital preservation.",
+    Icon: ShieldCheck,
+  },
+  {
+    key: "balanced",
+    label: "Balanced",
+    apy: "8–12%",
+    risk: "Medium",
+    description: "Diversified across lending and liquidity pools for steady growth.",
+    Icon: TrendingUp,
+  },
+  {
+    key: "aggressive",
+    label: "Aggressive",
+    apy: "18–30%",
+    risk: "High",
+    description: "High-yield DeFi positions. Suitable for risk-tolerant investors.",
+    Icon: Zap,
+  },
+];
+
+interface StrategyChangeDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  currentStrategy?: StrategyKey;
+}
+
+type SaveState = "idle" | "saving" | "success";
+
+export function StrategyChangeDrawer({
+  isOpen,
+  onClose,
+  currentStrategy = "balanced",
+}: StrategyChangeDrawerProps) {
+  const [selected, setSelected] = useState<StrategyKey>(currentStrategy);
+  const [saveState, setSaveState] = useState<SaveState>("idle");
+
+  const handleSave = async () => {
+    setSaveState("saving");
+    await new Promise((r) => setTimeout(r, 1200));
+    setSaveState("success");
+    setTimeout(() => {
+      setSaveState("idle");
+      onClose();
+    }, 1000);
+  };
+
+  const hasChanged = selected !== currentStrategy;
+  const isSaving = saveState === "saving";
+  const isSuccess = saveState === "success";
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Change strategy"
+      footer={
+        <Button
+          onClick={handleSave}
+          variant="primary"
+          disabled={!hasChanged || isSaving || isSuccess}
+          aria-label="Save strategy change"
+        >
+          {isSaving ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin mr-2" aria-hidden="true" />
+              Saving…
+            </>
+          ) : isSuccess ? (
+            <>
+              <CheckCircle2 className="w-4 h-4 mr-2" aria-hidden="true" />
+              Saved!
+            </>
+          ) : (
+            "Apply strategy"
+          )}
+        </Button>
+      }
+    >
+      <div className="space-y-3">
+        <p className="text-sm text-text-secondary mb-4">
+          Select a yield strategy. Changes take effect on the next rebalancing cycle.
+        </p>
+
+        {STRATEGIES.map((s) => {
+          const isActive = selected === s.key;
+          return (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() => setSelected(s.key)}
+              aria-pressed={isActive}
+              className={`w-full text-left rounded-xl border p-4 transition-colors ${
+                isActive
+                  ? "border-sky-500/60 bg-sky-500/10"
+                  : "border-zinc-700 bg-zinc-800/50 hover:border-zinc-600"
+              }`}
+            >
+              <div className="flex items-center gap-3 mb-1">
+                <s.Icon
+                  className={`w-5 h-5 shrink-0 ${isActive ? "text-sky-400" : "text-zinc-400"}`}
+                  aria-hidden="true"
+                />
+                <span
+                  className={`font-semibold text-sm ${
+                    isActive ? "text-sky-300" : "text-text-primary"
+                  }`}
+                >
+                  {s.label}
+                </span>
+                <span className="ml-auto text-xs text-text-muted">{s.risk} risk</span>
+              </div>
+              <p className="text-xs text-text-secondary pl-8">{s.description}</p>
+              <p className={`text-xs font-medium mt-2 pl-8 ${isActive ? "text-sky-400" : "text-text-muted"}`}>
+                Expected APY: {s.apy}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+    </Drawer>
+  );
+}

--- a/src/components/ui/demos/WithdrawConfirmModal.tsx
+++ b/src/components/ui/demos/WithdrawConfirmModal.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2, AlertTriangle, CheckCircle2 } from "lucide-react";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+
+interface WithdrawConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  amount: string;
+  asset: string;
+  destination: string;
+}
+
+type WithdrawState = "confirm" | "pending" | "success";
+
+export function WithdrawConfirmModal({
+  isOpen,
+  onClose,
+  amount,
+  asset,
+  destination,
+}: WithdrawConfirmModalProps) {
+  const [step, setStep] = useState<WithdrawState>("confirm");
+
+  const handleConfirm = async () => {
+    setStep("pending");
+    // Mock async withdrawal
+    await new Promise((r) => setTimeout(r, 1500));
+    setStep("success");
+  };
+
+  const handleClose = () => {
+    setStep("confirm");
+    onClose();
+  };
+
+  const isPending = step === "pending";
+  const isSuccess = step === "success";
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleClose}
+      title={isSuccess ? "Withdrawal submitted" : "Confirm withdrawal"}
+      preventClose={isPending}
+      footer={
+        isSuccess ? (
+          <Button onClick={handleClose} variant="primary">
+            Done
+          </Button>
+        ) : (
+          <>
+            <Button onClick={handleClose} variant="ghost" disabled={isPending}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleConfirm}
+              variant="primary"
+              disabled={isPending}
+              aria-label="Confirm withdrawal"
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin mr-2" aria-hidden="true" />
+                  Processing…
+                </>
+              ) : (
+                "Confirm"
+              )}
+            </Button>
+          </>
+        )
+      }
+    >
+      {isSuccess ? (
+        <div className="flex flex-col items-center gap-4 py-4 text-center">
+          <CheckCircle2 className="w-12 h-12 text-green-400" aria-hidden="true" />
+          <p className="text-text-secondary text-sm">
+            Your withdrawal of{" "}
+            <span className="font-semibold text-text-primary">
+              {amount} {asset}
+            </span>{" "}
+            has been submitted and will arrive within 1–3 business days.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <div className="rounded-lg bg-amber-500/10 border border-amber-500/20 px-4 py-3 flex gap-3">
+            <AlertTriangle
+              className="w-4 h-4 text-amber-400 shrink-0 mt-0.5"
+              aria-hidden="true"
+            />
+            <p className="text-sm text-amber-300">
+              This action cannot be undone once processing begins.
+            </p>
+          </div>
+
+          <dl className="space-y-3 text-sm">
+            <div className="flex justify-between">
+              <dt className="text-text-secondary">Amount</dt>
+              <dd className="font-semibold text-text-primary">
+                {amount} {asset}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-text-secondary">Destination</dt>
+              <dd className="font-mono text-text-primary text-xs truncate max-w-[220px]">
+                {destination}
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-text-secondary">Network fee</dt>
+              <dd className="text-text-primary">~0.001 XLM</dd>
+            </div>
+          </dl>
+        </div>
+      )}
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary

### #445 — Login page UI (mock auth)

- Email/password form with always-visible labels and 14px helper/error text
- Client-side validation with per-field error messages (`aria-invalid` + `aria-describedby`)
- Show/hide password toggle
- 420px max-width card on desktop, full-width with 16px gutters on mobile
- Primary CTA min-height 44px
- All four states implemented:
  - **Default** — empty form, idle
  - **Error** — invalid credentials alert with `role="alert"` / `aria-live="assertive"`
  - **Loading** — spinner + "Signing in…" with disabled inputs
  - **Success** — green confirmation banner + redirect after 800ms (`role="status"` / `aria-live="polite"`)
- Social placeholder buttons (Google, GitHub) with `aria-label="… (coming soon)"`
- Demo-fill shortcut prefills `demo@neurowealth.app / password123`

### #450 — Reusable modal and drawer patterns

Existing `Modal` (560px max, focus trap, Escape, 16/24/16 spacing) and `Drawer` (360px desktop / full-width mobile, slide animation) wired into **three mock flows**:

| Flow | Component | Trigger |
|------|-----------|---------|
| Withdraw confirm | `<Modal>` | Confirm → pending (blocks dismiss) → success |
| Strategy change | `<Drawer>` | Select strategy → save with loading feedback |
| Activity detail | `<Drawer>` | Show tx metadata, copy hash, Stellar Explorer link |

Demo page at `/dashboard/sandbox/ui-demo` exercises all three flows interactively.

closes #445
closes #450