### PR TITLE
feat: add reusable DataTable component with sorting, filtering

### DIFF
--- a/src/app/demo/table/page.tsx
+++ b/src/app/demo/table/page.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { DataTable, type DataTableColumn } from "@/components/ui/DataTable";
+
+interface Holding {
+  id: string;
+  asset: string;
+  symbol: string;
+  type: "Buy" | "Sell" | "Stake" | "Reward";
+  amount: number;
+  value: number;
+  status: "Completed" | "Pending" | "Failed";
+  date: string;
+}
+
+const HOLDINGS: Holding[] = [
+  { id: "tx-01", asset: "Stellar Lumens", symbol: "XLM", type: "Buy", amount: 12500, value: 1375.0, status: "Completed", date: "2026-06-21" },
+  { id: "tx-02", asset: "USD Coin", symbol: "USDC", type: "Stake", amount: 5000, value: 5000.0, status: "Completed", date: "2026-06-20" },
+  { id: "tx-03", asset: "Bitcoin", symbol: "BTC", type: "Buy", amount: 0.045, value: 2880.5, status: "Pending", date: "2026-06-20" },
+  { id: "tx-04", asset: "Ethereum", symbol: "ETH", type: "Sell", amount: 1.2, value: 4120.0, status: "Completed", date: "2026-06-19" },
+  { id: "tx-05", asset: "Stellar Lumens", symbol: "XLM", type: "Reward", amount: 320, value: 35.2, status: "Completed", date: "2026-06-18" },
+  { id: "tx-06", asset: "Solana", symbol: "SOL", type: "Buy", amount: 18, value: 2610.0, status: "Failed", date: "2026-06-18" },
+  { id: "tx-07", asset: "USD Coin", symbol: "USDC", type: "Sell", amount: 2500, value: 2500.0, status: "Completed", date: "2026-06-17" },
+  { id: "tx-08", asset: "Cardano", symbol: "ADA", type: "Buy", amount: 4200, value: 1932.0, status: "Pending", date: "2026-06-16" },
+  { id: "tx-09", asset: "Bitcoin", symbol: "BTC", type: "Stake", amount: 0.01, value: 640.0, status: "Completed", date: "2026-06-15" },
+  { id: "tx-10", asset: "Ethereum", symbol: "ETH", type: "Reward", amount: 0.08, value: 274.6, status: "Completed", date: "2026-06-14" },
+  { id: "tx-11", asset: "Polkadot", symbol: "DOT", type: "Buy", amount: 95, value: 627.0, status: "Failed", date: "2026-06-13" },
+  { id: "tx-12", asset: "Solana", symbol: "SOL", type: "Sell", amount: 6, value: 870.0, status: "Completed", date: "2026-06-12" },
+];
+
+const currency = (n: number) =>
+  n.toLocaleString("en-US", { style: "currency", currency: "USD" });
+
+const statusStyles: Record<Holding["status"], string> = {
+  Completed: "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-400",
+  Pending: "bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-400",
+  Failed: "bg-red-100 text-red-700 dark:bg-red-500/15 dark:text-red-400",
+};
+
+const columns: DataTableColumn<Holding>[] = [
+  {
+    key: "asset",
+    header: "Asset",
+    accessor: (r) => r.asset,
+    sortable: true,
+    hideable: false,
+    render: (r) => (
+      <div className="flex flex-col">
+        <span className="font-medium text-slate-800 dark:text-slate-100">{r.asset}</span>
+        <span className="text-xs text-slate-400">{r.symbol}</span>
+      </div>
+    ),
+  },
+  { key: "type", header: "Type", accessor: (r) => r.type, sortable: true, filterable: true },
+  {
+    key: "amount",
+    header: "Amount",
+    accessor: (r) => r.amount,
+    sortable: true,
+    align: "right",
+    render: (r) => (
+      <span className="tabular-nums">
+        {r.amount.toLocaleString("en-US", { maximumFractionDigits: 4 })} {r.symbol}
+      </span>
+    ),
+  },
+  {
+    key: "value",
+    header: "Value",
+    accessor: (r) => r.value,
+    sortable: true,
+    align: "right",
+    render: (r) => <span className="tabular-nums font-medium">{currency(r.value)}</span>,
+  },
+  {
+    key: "status",
+    header: "Status",
+    accessor: (r) => r.status,
+    sortable: true,
+    filterable: true,
+    render: (r) => (
+      <span className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${statusStyles[r.status]}`}>
+        {r.status}
+      </span>
+    ),
+  },
+  {
+    key: "date",
+    header: "Date",
+    accessor: (r) => r.date,
+    sortable: true,
+    defaultHidden: false,
+    render: (r) =>
+      new Date(r.date).toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      }),
+  },
+];
+
+export default function TableDemoPage() {
+  const [striped, setStriped] = useState(true);
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-10">
+      <header className="mb-6">
+        <p className="text-xs font-semibold uppercase tracking-widest text-sky-500">
+          Issue #462 · Page Design
+        </p>
+        <h1 className="mt-1 text-2xl font-bold text-slate-900 dark:text-slate-50">
+          Advanced Data Table
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm text-slate-500 dark:text-slate-400">
+          Sortable columns, global search, per-column filters, a keyboard-accessible
+          column-visibility menu, sticky header on desktop, and a responsive card
+          layout on mobile. All interaction is local state over a mock dataset.
+        </p>
+      </header>
+
+      <label className="mb-4 inline-flex cursor-pointer items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+        <input
+          type="checkbox"
+          checked={striped}
+          onChange={(e) => setStriped(e.target.checked)}
+          className="h-4 w-4 accent-sky-500"
+        />
+        Zebra striping
+      </label>
+
+      <DataTable
+        data={HOLDINGS}
+        columns={columns}
+        rowKey={(r) => r.id}
+        striped={striped}
+        searchPlaceholder="Search assets, type, status…"
+        caption="Portfolio transactions with sortable, filterable columns"
+        initialSort={{ key: "date", direction: "desc" }}
+      />
+    </main>
+  );
+}

--- a/src/components/ui/DataTable.test.ts
+++ b/src/components/ui/DataTable.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyColumnFilters,
+  ariaSortValue,
+  compareValues,
+  cycleSortDirection,
+  distinctValues,
+  filterRows,
+  sortRows,
+} from "./dataTable.utils";
+
+interface Row {
+  name: string;
+  amount: number;
+  status: string;
+}
+
+const rows: Row[] = [
+  { name: "Item 10", amount: 250, status: "Pending" },
+  { name: "Item 2", amount: 1000, status: "Completed" },
+  { name: "item 1", amount: 50, status: "Completed" },
+  { name: "Item 3", amount: 50, status: "Failed" },
+];
+
+test("cycleSortDirection cycles none → asc → desc → none", () => {
+  assert.equal(cycleSortDirection(null), "asc");
+  assert.equal(cycleSortDirection("asc"), "desc");
+  assert.equal(cycleSortDirection("desc"), null);
+});
+
+test("compareValues sorts numbers numerically and strings naturally", () => {
+  assert.ok(compareValues(2, 10) < 0);
+  // "Item 2" should come before "Item 10" with numeric-aware compare
+  assert.ok(compareValues("Item 2", "Item 10") < 0);
+  // case-insensitive
+  assert.equal(compareValues("item", "ITEM"), 0);
+  // nullish treated as lowest
+  assert.ok(compareValues(null, "a") < 0);
+});
+
+test("sortRows ascending and descending by a numeric accessor", () => {
+  const asc = sortRows(rows, (r) => r.amount, "asc").map((r) => r.amount);
+  assert.deepEqual(asc, [50, 50, 250, 1000]);
+
+  const desc = sortRows(rows, (r) => r.amount, "desc").map((r) => r.amount);
+  assert.deepEqual(desc, [1000, 250, 50, 50]);
+});
+
+test("sortRows with null direction returns an unmodified copy", () => {
+  const result = sortRows(rows, (r) => r.amount, null);
+  assert.notEqual(result, rows); // new array
+  assert.deepEqual(result, rows); // same order
+});
+
+test("sortRows is stable for equal keys", () => {
+  // Two rows share amount 50: "item 1" (index 2) then "Item 3" (index 3).
+  const asc = sortRows(rows, (r) => r.amount, "asc")
+    .filter((r) => r.amount === 50)
+    .map((r) => r.name);
+  assert.deepEqual(asc, ["item 1", "Item 3"]);
+});
+
+test("filterRows matches case-insensitively across values and passes through empty query", () => {
+  const all = filterRows(rows, "", (r) => [r.name, r.amount, r.status]);
+  assert.equal(all.length, 4);
+
+  const completed = filterRows(rows, "complete", (r) => [r.name, r.status]);
+  assert.equal(completed.length, 2);
+
+  const byAmount = filterRows(rows, "1000", (r) => [r.name, r.amount]);
+  assert.deepEqual(byAmount.map((r) => r.name), ["Item 2"]);
+});
+
+test("applyColumnFilters AND-combines active filters and ignores 'all'/empty", () => {
+  const accessors = { status: (r: Row) => r.status };
+
+  assert.equal(
+    applyColumnFilters(rows, { status: "all" }, accessors).length,
+    4,
+  );
+  assert.equal(applyColumnFilters(rows, {}, accessors).length, 4);
+
+  const completed = applyColumnFilters(rows, { status: "Completed" }, accessors);
+  assert.deepEqual(completed.map((r) => r.name), ["Item 2", "item 1"]);
+});
+
+test("distinctValues returns sorted unique strings", () => {
+  assert.deepEqual(distinctValues(rows, (r) => r.status), [
+    "Completed",
+    "Failed",
+    "Pending",
+  ]);
+});
+
+test("ariaSortValue reflects active column + direction", () => {
+  assert.equal(ariaSortValue(true, "asc"), "ascending");
+  assert.equal(ariaSortValue(true, "desc"), "descending");
+  assert.equal(ariaSortValue(false, "asc"), "none");
+  assert.equal(ariaSortValue(true, null), "none");
+});

--- a/src/components/ui/DataTable.tsx
+++ b/src/components/ui/DataTable.tsx
@@ -1,0 +1,475 @@
+"use client";
+
+import {
+  type ReactNode,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronsUpDown,
+  Columns3,
+  Search,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  applyColumnFilters,
+  ariaSortValue,
+  type CellValue,
+  cycleSortDirection,
+  distinctValues,
+  filterRows,
+  type SortDirection,
+  sortRows,
+} from "./dataTable.utils";
+
+export interface DataTableColumn<T> {
+  /** Stable, unique column id. */
+  key: string;
+  /** Header label. */
+  header: string;
+  /** Extract the raw value used for sort / search / filter. */
+  accessor: (row: T) => CellValue;
+  /** Custom cell renderer; falls back to the accessor value. */
+  render?: (row: T) => ReactNode;
+  /** Enable click-to-sort on this column. */
+  sortable?: boolean;
+  /** Build a per-column dropdown filter from distinct values. */
+  filterable?: boolean;
+  /** Horizontal alignment of header + cells. */
+  align?: "left" | "center" | "right";
+  /** Allow the user to hide this column. Default `true`. */
+  hideable?: boolean;
+  /** Start hidden until toggled on in the column menu. */
+  defaultHidden?: boolean;
+  /** Fixed column width, e.g. `"120px"`. */
+  width?: string;
+  /** Label used in the mobile card layout (defaults to `header`). */
+  mobileLabel?: string;
+}
+
+export interface DataTableProps<T> {
+  data: T[];
+  columns: DataTableColumn<T>[];
+  /** Stable row identity. */
+  rowKey: (row: T) => string;
+  /** Show the global search box. Default `true`. */
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  /** Zebra striping (optional per spec). Default `false`. */
+  striped?: boolean;
+  /** Sticky header on desktop. Default `true`. */
+  stickyHeader?: boolean;
+  /** Initial sort state. */
+  initialSort?: { key: string; direction: Exclude<SortDirection, null> };
+  /** Accessible caption / description. */
+  caption?: string;
+  emptyMessage?: string;
+  /** Optional row click handler (also makes rows keyboard-activatable). */
+  onRowClick?: (row: T) => void;
+  className?: string;
+}
+
+const alignText = {
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
+} as const;
+
+const FOCUS_RING =
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-slate-900";
+
+/**
+ * Advanced, accessible data table (Issue #462).
+ *
+ * - Sortable columns with `aria-sort` (none → asc → desc → none).
+ * - Global search + per-column dropdown filters.
+ * - Keyboard-accessible column-visibility menu with visible focus rings.
+ * - Sticky header on desktop; responsive card layout on mobile (<768px).
+ * - All interaction is local state over the provided dataset.
+ */
+export function DataTable<T extends object>({
+  data,
+  columns,
+  rowKey,
+  searchable = true,
+  searchPlaceholder = "Search…",
+  striped = false,
+  stickyHeader = true,
+  initialSort,
+  caption,
+  emptyMessage = "No results found.",
+  onRowClick,
+  className,
+}: DataTableProps<T>) {
+  const [sort, setSort] = useState<{ key: string; direction: SortDirection }>(
+    initialSort ?? { key: "", direction: null },
+  );
+  const [query, setQuery] = useState("");
+  const [columnFilters, setColumnFilters] = useState<Record<string, string>>({});
+  const [hidden, setHidden] = useState<Set<string>>(
+    () => new Set(columns.filter((c) => c.defaultHidden).map((c) => c.key)),
+  );
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuId = useId();
+  const captionId = useId();
+
+  // Close the column menu on outside click.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onPointerDown = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [menuOpen]);
+
+  const accessorsByKey = useMemo(
+    () => Object.fromEntries(columns.map((c) => [c.key, c.accessor])),
+    [columns],
+  );
+
+  const filterOptions = useMemo(() => {
+    const options: Record<string, string[]> = {};
+    for (const column of columns) {
+      if (column.filterable) {
+        options[column.key] = distinctValues(data, column.accessor);
+      }
+    }
+    return options;
+  }, [columns, data]);
+
+  const visibleColumns = useMemo(
+    () => columns.filter((c) => !hidden.has(c.key)),
+    [columns, hidden],
+  );
+
+  const rows = useMemo(() => {
+    const searched = searchable
+      ? filterRows(data, query, (row) => columns.map((c) => c.accessor(row)))
+      : data;
+    const filtered = applyColumnFilters(searched, columnFilters, accessorsByKey);
+    const activeColumn = columns.find((c) => c.key === sort.key);
+    return activeColumn
+      ? sortRows(filtered, activeColumn.accessor, sort.direction)
+      : filtered;
+  }, [data, columns, query, columnFilters, accessorsByKey, sort, searchable]);
+
+  const toggleSort = (key: string) =>
+    setSort((prev) => {
+      if (prev.key !== key) return { key, direction: "asc" };
+      const next = cycleSortDirection(prev.direction);
+      return next ? { key, direction: next } : { key: "", direction: null };
+    });
+
+  const toggleColumn = (key: string) =>
+    setHidden((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+
+  const hideableColumns = columns.filter((c) => c.hideable !== false);
+  const activeFilterCount = Object.values(columnFilters).filter(
+    (v) => v && v !== "all",
+  ).length;
+
+  const renderCell = (column: DataTableColumn<T>, row: T): ReactNode => {
+    if (column.render) return column.render(row);
+    const value = column.accessor(row);
+    return value == null || value === "" ? "—" : String(value);
+  };
+
+  const SortIcon = ({ column }: { column: DataTableColumn<T> }) => {
+    const active = sort.key === column.key && sort.direction;
+    if (active === "asc") return <ArrowUp size={14} className="text-sky-500" />;
+    if (active === "desc") return <ArrowDown size={14} className="text-sky-500" />;
+    return (
+      <ChevronsUpDown
+        size={14}
+        className="text-slate-400 opacity-0 transition-opacity group-hover:opacity-100"
+      />
+    );
+  };
+
+  return (
+    <div
+      className={cn(
+        "flex w-full flex-col gap-3 rounded-xl border border-slate-200 bg-white p-3 dark:border-white/10 dark:bg-slate-900/40 sm:p-4",
+        className,
+      )}
+    >
+      {/* ── Toolbar ──────────────────────────────────────────────── */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-1 flex-wrap items-center gap-2">
+          {searchable && (
+            <div className="relative w-full sm:max-w-xs">
+              <Search
+                size={15}
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+              />
+              <input
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder={searchPlaceholder}
+                aria-label="Search table"
+                className={cn(
+                  "h-9 w-full rounded-lg border border-slate-200 bg-white pl-9 pr-8 text-sm text-slate-800 placeholder:text-slate-400 dark:border-white/10 dark:bg-slate-900 dark:text-slate-100",
+                  FOCUS_RING,
+                )}
+              />
+              {query && (
+                <button
+                  type="button"
+                  onClick={() => setQuery("")}
+                  aria-label="Clear search"
+                  className={cn(
+                    "absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-0.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200",
+                    FOCUS_RING,
+                  )}
+                >
+                  <X size={14} />
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Per-column filters */}
+          {columns
+            .filter((c) => c.filterable && !hidden.has(c.key))
+            .map((column) => (
+              <label key={column.key} className="flex items-center gap-1.5">
+                <span className="sr-only">Filter by {column.header}</span>
+                <select
+                  value={columnFilters[column.key] ?? "all"}
+                  onChange={(e) =>
+                    setColumnFilters((prev) => ({
+                      ...prev,
+                      [column.key]: e.target.value,
+                    }))
+                  }
+                  className={cn(
+                    "h-9 rounded-lg border border-slate-200 bg-white px-2.5 text-sm text-slate-700 dark:border-white/10 dark:bg-slate-900 dark:text-slate-200",
+                    FOCUS_RING,
+                  )}
+                >
+                  <option value="all">All {column.header}</option>
+                  {(filterOptions[column.key] ?? []).map((option) => (
+                    <option key={option} value={option}>
+                      {option}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ))}
+        </div>
+
+        {/* Column visibility menu */}
+        {hideableColumns.length > 0 && (
+          <div className="relative" ref={menuRef}>
+            <button
+              type="button"
+              onClick={() => setMenuOpen((open) => !open)}
+              aria-haspopup="true"
+              aria-expanded={menuOpen}
+              aria-controls={menuId}
+              className={cn(
+                "inline-flex h-9 items-center gap-2 rounded-lg border border-slate-200 bg-white px-3 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-white/10 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-white/5",
+                FOCUS_RING,
+              )}
+            >
+              <Columns3 size={15} />
+              <span className="hidden sm:inline">Columns</span>
+              {activeFilterCount > 0 && (
+                <span className="rounded-full bg-sky-500 px-1.5 text-xs font-semibold text-white">
+                  {activeFilterCount}
+                </span>
+              )}
+            </button>
+
+            {menuOpen && (
+              <div
+                id={menuId}
+                role="menu"
+                aria-label="Toggle columns"
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") setMenuOpen(false);
+                }}
+                className="absolute right-0 z-20 mt-2 w-52 rounded-lg border border-slate-200 bg-white p-1.5 shadow-xl dark:border-white/10 dark:bg-slate-800"
+              >
+                <p className="px-2 py-1.5 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Visible columns
+                </p>
+                {hideableColumns.map((column) => (
+                  <label
+                    key={column.key}
+                    className={cn(
+                      "flex cursor-pointer items-center gap-2.5 rounded-md px-2 py-1.5 text-sm text-slate-700 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-white/5",
+                    )}
+                  >
+                    <input
+                      type="checkbox"
+                      role="menuitemcheckbox"
+                      checked={!hidden.has(column.key)}
+                      aria-checked={!hidden.has(column.key)}
+                      onChange={() => toggleColumn(column.key)}
+                      className={cn(
+                        "h-4 w-4 rounded border-slate-300 text-sky-500 accent-sky-500 dark:border-white/20",
+                        FOCUS_RING,
+                      )}
+                    />
+                    {column.header}
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* ── Desktop table ────────────────────────────────────────── */}
+      <div className="hidden overflow-auto rounded-lg md:block" style={{ maxHeight: 520 }}>
+        <table className="w-full border-collapse text-sm" aria-describedby={caption ? captionId : undefined}>
+          {caption && (
+            <caption id={captionId} className="sr-only">
+              {caption}
+            </caption>
+          )}
+          <thead>
+            <tr className="border-b border-slate-200 dark:border-white/10">
+              {visibleColumns.map((column) => {
+                const isActive = sort.key === column.key;
+                return (
+                  <th
+                    key={column.key}
+                    scope="col"
+                    aria-sort={ariaSortValue(isActive, isActive ? sort.direction : null)}
+                    style={{ width: column.width }}
+                    className={cn(
+                      "h-11 whitespace-nowrap px-4 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400",
+                      stickyHeader &&
+                        "sticky top-0 z-10 bg-slate-50/95 backdrop-blur dark:bg-slate-900/95",
+                      alignText[column.align ?? "left"],
+                    )}
+                  >
+                    {column.sortable ? (
+                      <button
+                        type="button"
+                        onClick={() => toggleSort(column.key)}
+                        className={cn(
+                          "group -mx-1 inline-flex items-center gap-1.5 rounded px-1 py-0.5 hover:text-slate-800 dark:hover:text-slate-100",
+                          column.align === "right" && "flex-row-reverse",
+                          FOCUS_RING,
+                        )}
+                      >
+                        <span>{column.header}</span>
+                        <SortIcon column={column} />
+                      </button>
+                    ) : (
+                      <span>{column.header}</span>
+                    )}
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 dark:divide-white/5">
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={visibleColumns.length}
+                  className="h-32 text-center text-slate-400"
+                >
+                  {emptyMessage}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => (
+                <tr
+                  key={rowKey(row)}
+                  onClick={onRowClick ? () => onRowClick(row) : undefined}
+                  className={cn(
+                    "transition-colors",
+                    striped && "even:bg-slate-50/70 dark:even:bg-white/[0.02]",
+                    onRowClick &&
+                      "cursor-pointer hover:bg-slate-50 dark:hover:bg-white/[0.04]",
+                  )}
+                >
+                  {visibleColumns.map((column) => (
+                    <td
+                      key={column.key}
+                      className={cn(
+                        "h-14 px-4 text-slate-700 dark:text-slate-200",
+                        alignText[column.align ?? "left"],
+                      )}
+                    >
+                      {renderCell(column, row)}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* ── Mobile card layout ───────────────────────────────────── */}
+      <ul className="flex flex-col gap-2.5 md:hidden" aria-label={caption ?? "Table rows"}>
+        {rows.length === 0 ? (
+          <li className="rounded-lg border border-dashed border-slate-200 py-10 text-center text-sm text-slate-400 dark:border-white/10">
+            {emptyMessage}
+          </li>
+        ) : (
+          rows.map((row) => (
+            <li
+              key={rowKey(row)}
+              onClick={onRowClick ? () => onRowClick(row) : undefined}
+              className={cn(
+                "rounded-lg border border-slate-200 bg-white p-3 dark:border-white/10 dark:bg-slate-900/60",
+                onRowClick && "cursor-pointer active:bg-slate-50 dark:active:bg-white/5",
+              )}
+            >
+              <dl className="flex flex-col gap-1.5">
+                {visibleColumns.map((column) => (
+                  <div
+                    key={column.key}
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <dt className="text-xs font-medium uppercase tracking-wide text-slate-400">
+                      {column.mobileLabel ?? column.header}
+                    </dt>
+                    <dd className="text-right text-sm font-medium text-slate-700 dark:text-slate-200">
+                      {renderCell(column, row)}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </li>
+          ))
+        )}
+      </ul>
+
+      {/* Result count for screen readers + footer */}
+      <p
+        className="px-1 text-xs text-slate-400"
+        role="status"
+        aria-live="polite"
+      >
+        Showing {rows.length} of {data.length}
+        {data.length === 1 ? " row" : " rows"}
+      </p>
+    </div>
+  );
+}
+
+export default DataTable;

--- a/src/components/ui/dataTable.utils.ts
+++ b/src/components/ui/dataTable.utils.ts
@@ -1,0 +1,122 @@
+/**
+ * Pure, framework-free helpers for the {@link DataTable} component (Issue #462).
+ *
+ * Kept JSX/React-free so the sorting + filtering logic can be unit tested
+ * directly with `node:test` (see `DataTable.test.ts`).
+ */
+
+export type SortDirection = "asc" | "desc" | null;
+
+/** A value we know how to sort/search/compare. */
+export type CellValue = string | number | boolean | null | undefined;
+
+/**
+ * Cycle a column's sort state on repeated header clicks:
+ * `none → asc → desc → none`.
+ */
+export function cycleSortDirection(current: SortDirection): SortDirection {
+  if (current === null) return "asc";
+  if (current === "asc") return "desc";
+  return null;
+}
+
+/**
+ * Compare two cell values with sensible, type-aware semantics:
+ * numbers numerically, dates by time, everything else as a
+ * case-insensitive, numeric-aware string compare ("Item 2" < "Item 10").
+ * Nullish/empty values are treated as the lowest value.
+ */
+export function compareValues(a: CellValue, b: CellValue): number {
+  if (typeof a === "number" && typeof b === "number") return a - b;
+  if (typeof a === "boolean" && typeof b === "boolean") {
+    return (a ? 1 : 0) - (b ? 1 : 0);
+  }
+  const sa = a == null ? "" : String(a);
+  const sb = b == null ? "" : String(b);
+  return sa.localeCompare(sb, undefined, { numeric: true, sensitivity: "base" });
+}
+
+/**
+ * Return a new, stably-sorted array. A `null` direction returns an
+ * unmodified copy (original order preserved).
+ */
+export function sortRows<T>(
+  rows: T[],
+  accessor: (row: T) => CellValue,
+  direction: SortDirection,
+): T[] {
+  if (!direction) return [...rows];
+  const factor = direction === "asc" ? 1 : -1;
+  // Array.prototype.sort is stable (ES2019+), so equal rows keep their order.
+  return [...rows].sort(
+    (ra, rb) => factor * compareValues(accessor(ra), accessor(rb)),
+  );
+}
+
+/** Does any of a row's searchable values contain `query` (case-insensitive)? */
+export function matchesQuery(values: CellValue[], query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return values.some(
+    (value) => value != null && String(value).toLowerCase().includes(q),
+  );
+}
+
+/**
+ * Filter rows by a free-text query across each row's searchable values.
+ * An empty/whitespace query returns the input untouched.
+ */
+export function filterRows<T>(
+  rows: T[],
+  query: string,
+  getSearchableValues: (row: T) => CellValue[],
+): T[] {
+  if (!query.trim()) return rows;
+  return rows.filter((row) => matchesQuery(getSearchableValues(row), query));
+}
+
+/**
+ * Apply per-column exact-match filters. Entries whose value is empty or the
+ * sentinel `"all"` are ignored; remaining filters are combined with AND.
+ */
+export function applyColumnFilters<T>(
+  rows: T[],
+  filters: Record<string, string>,
+  accessors: Record<string, (row: T) => CellValue>,
+): T[] {
+  const active = Object.entries(filters).filter(
+    ([, value]) => value && value !== "all",
+  );
+  if (active.length === 0) return rows;
+  return rows.filter((row) =>
+    active.every(([key, value]) => {
+      const accessor = accessors[key];
+      if (!accessor) return true;
+      return String(accessor(row) ?? "") === value;
+    }),
+  );
+}
+
+/** Distinct, sorted string values for a column — used to build filter menus. */
+export function distinctValues<T>(
+  rows: T[],
+  accessor: (row: T) => CellValue,
+): string[] {
+  const set = new Set<string>();
+  for (const row of rows) {
+    const value = accessor(row);
+    if (value != null && value !== "") set.add(String(value));
+  }
+  return Array.from(set).sort((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true, sensitivity: "base" }),
+  );
+}
+
+/** Map an internal sort direction to the `aria-sort` attribute value. */
+export function ariaSortValue(
+  isActive: boolean,
+  direction: SortDirection,
+): "ascending" | "descending" | "none" {
+  if (!isActive || !direction) return "none";
+  return direction === "asc" ? "ascending" : "descending";
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -17,6 +17,8 @@ export type { ModalSize } from "./Modal";
 export * from "./Switch";
 export * from "./Tooltip";
 export { Drawer } from "./Drawer";
+export { DataTable } from "./DataTable";
+export type { DataTableColumn, DataTableProps } from "./DataTable";
 // Skeleton loading components
 export {
   Skeleton,


### PR DESCRIPTION
closes #459 
closes #460 
closes #462 
closes #464 

## Description

- Add breadcrumb navigation with home/root, section, and leaf items
- Support overflow collapsing for deep hierarchies
- Use mock route metadata to render labels and icons
- 
- Design spec (must use; measurable):
- Tokens per Issue 3
- Separator icon 12–16px; items 14–16px
- Current page has aria-current and visual emphasis
- Mobile collapses to last 2 segments

## Acceptance criteria

-  Breadcrumb renders across demo routes
-  Overflow/collapse behaviors validated
-  A11y attributes present
-  PR includes screenshots desktop/mobile