### PR TITLE
docs: folder structure, CHANGELOG, and verification for issues 427 428 429 449

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Versions are tagged in GitHub Releases and linked from this file.
 
 ---
 
+## [Unreleased] — 2026-06-24
+
+### Added
+- Folder structure documentation in `README.md` covering all top-level `src/` directories (closes #428)
+
+### Documented
+- Release notes process confirmed as manual Keep-a-Changelog; no Changesets automation required at this stage (closes #427)
+- Authenticated dashboard shell verified: protected route, responsive layout (sidebar + top header / mobile bottom nav), skeleton loading states, and error boundary all in place (closes #429)
+- Error pages verified: 401, 403, 404, and 500 pages implemented with recovery actions; dev-only mock triggers available at `/dashboard/dev-errors` (closes #449)
+
+---
+
 ## [Unreleased] — 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,36 @@ What this repo contains
 - Edge middleware (`middleware.ts`) that protects routes under `/dashboard`, `/profile`, and `/settings` and redirects unauthenticated users to `/login?from=...`.
 - Tests using the Node test runner (match: `src/**/*.test.ts`).
 
+Folder structure
+----------------
+
+```
+src/
+├── app/                   # Next.js App Router — routes and layouts
+│   ├── (auth)/            # Auth-gated route group (login, onboarding)
+│   ├── (errors)/          # Standalone error pages (401 unauthorized, 403 forbidden)
+│   ├── api/               # Route handlers
+│   ├── dashboard/         # Protected dashboard shell and sub-routes
+│   │   ├── dev-errors/    # Dev-only error trigger routes (hidden in production)
+│   │   ├── portfolio/
+│   │   ├── activity/
+│   │   ├── strategy/
+│   │   └── settings/
+│   ├── not-found.tsx      # Global 404 page
+│   └── error.tsx          # Global 500 / uncaught error boundary
+├── components/            # Shared UI components (ui/, dashboard/, auth/, layout/)
+├── features/              # Feature-scoped logic co-located with its UI
+├── hooks/                 # Reusable React hooks
+├── lib/                   # Pure utilities, constants, and adapters
+│   ├── mock-auth.ts       # Client-side mock auth session
+│   ├── auth-constants.ts  # Canonical storage/cookie key names
+│   └── …
+└── types/                 # Shared TypeScript types and interfaces
+```
+
+TypeScript strict mode is enabled (`tsconfig.json` → `"strict": true`).
+Lint runs via `yarn lint` (ESLint + `eslint-config-next`).
+
 Auth syncing note
 -----------------
 The mock auth flow stores the session in `localStorage` using `SESSION_STORAGE_KEY` and mirrors it into a cookie named `SESSION_COOKIE_NAME`. This allows the browser UI and Next.js middleware to agree on authentication state in demo setups. See `src/lib/auth-constants.ts` for the canonical values.

--- a/src/app/(errors)/server-error/page.tsx
+++ b/src/app/(errors)/server-error/page.tsx
@@ -1,0 +1,17 @@
+import { ServerCrash } from "lucide-react";
+import { ErrorPage } from "@/components/ui/ErrorPage";
+
+export const dynamic = "force-dynamic";
+
+export default function ServerErrorPage() {
+  return (
+    <ErrorPage
+      statusCode={500}
+      title="Something went wrong"
+      description="We ran into an unexpected server error. Your account and funds remain safe. Try again or return home while we look into it."
+      icon={<ServerCrash size={32} />}
+      primaryAction={{ label: "Back to home", href: "/" }}
+      secondaryAction={{ label: "Go to dashboard", href: "/dashboard" }}
+    />
+  );
+}

--- a/src/app/dashboard/dev-errors/page.tsx
+++ b/src/app/dashboard/dev-errors/page.tsx
@@ -9,27 +9,61 @@ export default function DashboardDevErrorsPage() {
   }
 
   return (
-    <main className="space-y-6">
+    <main className="space-y-8">
       <header>
         <h1 className="text-2xl font-semibold text-text-primary">
-          Dashboard error boundary dev routes
+          Error page dev triggers
         </h1>
         <p className="mt-2 text-sm text-text-secondary">
-          These routes intentionally trigger errors so we can verify route-level and client-boundary recovery.
+          Dev-only routes for verifying every error page and recovery action. Hidden in production.
         </p>
       </header>
-      <ul className="list-disc pl-5 text-sm text-text-primary space-y-2">
-        <li>
-          <Link className="text-primary hover:underline" href="/dashboard/dev-errors/route-error">
-            Trigger route-level error
-          </Link>
-        </li>
-        <li>
-          <Link className="text-primary hover:underline" href="/dashboard/dev-errors/boundary-error">
-            Trigger client ErrorBoundary fallback
-          </Link>
-        </li>
-      </ul>
+
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">
+          Named error pages (401 / 403 / 404 / 500)
+        </h2>
+        <ul className="list-disc pl-5 text-sm text-text-primary space-y-2">
+          <li>
+            <Link className="text-primary hover:underline" href="/unauthorized">
+              401 — Unauthorized (authentication required)
+            </Link>
+          </li>
+          <li>
+            <Link className="text-primary hover:underline" href="/forbidden">
+              403 — Forbidden (access denied)
+            </Link>
+          </li>
+          <li>
+            <Link className="text-primary hover:underline" href="/dev-errors/nonexistent-route-trigger">
+              404 — Not found (navigate to a missing route)
+            </Link>
+          </li>
+          <li>
+            <Link className="text-primary hover:underline" href="/server-error">
+              500 — Server error (static error page)
+            </Link>
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-text-secondary">
+          Error boundary triggers
+        </h2>
+        <ul className="list-disc pl-5 text-sm text-text-primary space-y-2">
+          <li>
+            <Link className="text-primary hover:underline" href="/dashboard/dev-errors/route-error">
+              Trigger route-level error (dashboard error boundary)
+            </Link>
+          </li>
+          <li>
+            <Link className="text-primary hover:underline" href="/dashboard/dev-errors/boundary-error">
+              Trigger client ErrorBoundary fallback
+            </Link>
+          </li>
+        </ul>
+      </section>
     </main>
   );
 }

--- a/src/app/dashboard/help/loading.tsx
+++ b/src/app/dashboard/help/loading.tsx
@@ -1,0 +1,38 @@
+import { Skeleton, SkeletonText } from "@/components/ui/Skeleton";
+
+export default function HelpLoading() {
+  return (
+    <div
+      className="px-6 py-8 space-y-6 animate-fade-in"
+      aria-busy="true"
+      aria-label="Loading help center"
+    >
+      {/* Page header */}
+      <div className="space-y-2">
+        <Skeleton height={20} width="28%" />
+        <Skeleton height={14} width="55%" />
+      </div>
+
+      {/* Tab bar */}
+      <div className="flex gap-1 rounded-xl border border-slate-700/50 bg-slate-950/35 p-1 w-fit">
+        {[80, 120, 130].map((w, i) => (
+          <Skeleton key={i} height={36} width={w} radius={8} />
+        ))}
+      </div>
+
+      {/* Tab panel content — FAQ rows */}
+      <div className="space-y-3">
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div
+            key={i}
+            className="card p-4 space-y-2"
+            aria-hidden="true"
+          >
+            <Skeleton height={16} width="70%" />
+            <SkeletonText lines={2} lastLineWidth="45%" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #427
Closes #428
Closes #429
Closes #449

## What changed

### #427 — Release notes process (docs)
- New dated section added to `CHANGELOG.md` documenting this batch; release notes process confirmed as manual Keep-a-Changelog with no Changesets automation required

### #428 — Next.js App Router baseline (docs)
- Added **Folder structure** section to `README.md` with annotated tree of all top-level `src/` directories — the only unmet acceptance criterion (TypeScript strict mode, ESLint, App Router, and `yarn dev` were already configured)

### #429 — Authenticated dashboard shell (feat)
- Added missing `src/app/dashboard/help/loading.tsx` — every other dashboard sub-route had a skeleton loading state; help was the only gap. Skeleton mirrors the page layout: header, tab bar (3 tabs), and FAQ card rows.

### #449 — Error pages 401/403/404/500 (feat)
- Added `src/app/(errors)/server-error/page.tsx` — a navigable `/server-error` route that renders the 500-styled `ErrorPage`, completing the set of explicitly routable error pages (401 `/unauthorized`, 403 `/forbidden`, 404 `not-found.tsx`, 500 `/server-error`)
- Expanded `src/app/dashboard/dev-errors/page.tsx` with a new **Named error pages** section linking to all four error routes for manual QA, alongside the existing error boundary triggers

## How to test
- `yarn dev` then visit:
  - `/unauthorized` → 401 page with "Sign in" primary action
  - `/forbidden` → 403 page with "Back to dashboard" primary action
  - `/not-a-real-route` → 404 not-found page
  - `/server-error` → 500 page with "Back to home" primary action
  - `/dashboard/dev-errors` → see all triggers in one place (dev only)
  - `/dashboard/help` → confirm skeleton renders while the page loads
- `yarn lint` — should pass
- `yarn typecheck` — should pass