### PR TITLE
feat: align dashboard loading skeletons

### DIFF
--- a/src/app/dashboard/history/loading.tsx
+++ b/src/app/dashboard/history/loading.tsx
@@ -1,10 +1,13 @@
-import { TableSkeleton } from "@/components/ui/Skeleton";
+import { Skeleton, TableSkeleton } from "@/components/ui/Skeleton";
 
 export default function HistoryLoading() {
   return (
-    <div className="px-6 pt-8" aria-busy="true" aria-label="Loading history">
-      <div className="mb-4 h-8 w-24 animate-pulse rounded-lg bg-white/5" />
-      <TableSkeleton rows={6} cols={5} />
+    <div className="px-6 pt-8 space-y-6 animate-fade-in" aria-busy="true" aria-label="Loading history">
+      <div className="space-y-2">
+        <Skeleton height={28} width={112} />
+        <Skeleton height={14} width="64%" />
+      </div>
+      <TableSkeleton rows={10} cols={6} />
     </div>
   );
 }

--- a/src/app/dashboard/portfolio/loading.tsx
+++ b/src/app/dashboard/portfolio/loading.tsx
@@ -1,19 +1,28 @@
-import { Skeleton, StatCardSkeleton, AllocationWidgetSkeleton } from "@/components/ui/Skeleton";
+import { Skeleton, StatCardSkeleton, TableSkeleton } from "@/components/ui/Skeleton";
 
 export default function PortfolioLoading() {
   return (
     <div className="space-y-6 animate-fade-in" aria-busy="true" aria-label="Loading portfolio">
-      {/* Stat cards */}
+      <div className="space-y-2">
+        <Skeleton height={28} width={128} />
+        <Skeleton height={14} width="58%" />
+      </div>
+
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        {[1, 2, 3].map((i) => <StatCardSkeleton key={i} />)}
+        {Array.from({ length: 3 }).map((_, i) => (
+          <StatCardSkeleton key={i} />
+        ))}
       </div>
-      {/* Chart placeholder */}
+
       <div className="card">
-        <Skeleton height={14} width="36%" style={{ marginBottom: 20 }} />
-        <Skeleton height={192} width="100%" radius={8} />
+        <Skeleton height={16} width="40%" style={{ marginBottom: 20 }} />
+        <Skeleton height={192} width="100%" radius={12} />
       </div>
-      {/* Allocation */}
-      <AllocationWidgetSkeleton />
+
+      <div className="card">
+        <Skeleton height={16} width="28%" style={{ marginBottom: 20 }} />
+        <TableSkeleton rows={4} cols={5} />
+      </div>
     </div>
   );
 }

--- a/src/app/dashboard/settings/loading.tsx
+++ b/src/app/dashboard/settings/loading.tsx
@@ -1,11 +1,23 @@
-import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
+import { Skeleton, SettingsSectionSkeleton } from "@/components/ui/Skeleton";
 
 export default function SettingsLoading() {
   return (
-    <div className="max-w-2xl space-y-6 animate-fade-in" aria-busy="true" aria-label="Loading settings">
-      {[1, 2, 3].map((section) => (
-        <SettingsSectionSkeleton key={section} rows={2} />
-      ))}
+    <div
+      className="max-w-2xl space-y-6 animate-fade-in"
+      aria-busy="true"
+      aria-label="Loading settings"
+    >
+      <div className="space-y-2">
+        <Skeleton height={28} width={132} />
+        <Skeleton height={14} width="64%" />
+      </div>
+
+      <SettingsSectionSkeleton rows={1} />
+      <SettingsSectionSkeleton rows={2} />
+      <SettingsSectionSkeleton rows={2} />
+      <SettingsSectionSkeleton rows={2} />
+      <SettingsSectionSkeleton rows={2} />
+      <SettingsSectionSkeleton rows={1} />
     </div>
   );
 }


### PR DESCRIPTION
Title: Align dashboard loading states with skeleton design system

Summary:
- Reworked the portfolio, history, and settings loading states to use the shared `Skeleton` vocabulary already in the repo.
- Matched the loading dimensions more closely to the real page layouts: portfolio stats + chart + holdings table, history header + transaction table, and settings header + section groups.
- Removed the unrelated allocation placeholder from portfolio loading and replaced ad hoc shimmer blocks with reusable skeleton primitives.

Verification:
- `git diff --check`
- `yarn typecheck` was not runnable in this workspace because dependencies are not installed locally (`tsc` missing).

Closes #416