### PR TITLE
Feat/form field

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ Run tests:
 yarn test
 ```
 
+Inspect bundle size locally:
+
+```bash
+yarn analyze
+```
+
+This runs a production build with the Next.js bundle analyzer enabled via `ANALYZE=true`.
+The report is written under `.next/analyze/`, which is already ignored by git.
+
+Use this command when checking for bundle regressions before merging. We do not run it in CI
+because analyzer builds are slower than the normal test/lint/build pipeline.
+
 ## What this repo contains
 
 - Next.js 14 app under `src/app`
@@ -120,6 +132,8 @@ The mock auth flow stores the session in `localStorage` using `SESSION_STORAGE_K
 
 - Follow existing patterns for components and hooks.
 - Tests live next to logic under `src/` and run via `yarn test`.
+- For bundle-size checks, run `yarn analyze` locally and review the generated report before
+  changing code that affects route or vendor bundles.
 
 ## License
 

--- a/src/app/dashboard/history/loading.tsx
+++ b/src/app/dashboard/history/loading.tsx
@@ -1,10 +1,13 @@
-import { TableSkeleton } from "@/components/ui/Skeleton";
+import { Skeleton, TableSkeleton } from "@/components/ui/Skeleton";
 
 export default function HistoryLoading() {
   return (
-    <div className="px-6 pt-8" aria-busy="true" aria-label="Loading history">
-      <div className="mb-4 h-8 w-24 animate-pulse rounded-lg bg-white/5" />
-      <TableSkeleton rows={6} cols={5} />
+    <div className="px-6 pt-8 space-y-6 animate-fade-in" aria-busy="true" aria-label="Loading history">
+      <div className="space-y-2">
+        <Skeleton height={28} width={112} />
+        <Skeleton height={14} width="64%" />
+      </div>
+      <TableSkeleton rows={10} cols={6} />
     </div>
   );
 }

--- a/src/app/dashboard/portfolio/loading.tsx
+++ b/src/app/dashboard/portfolio/loading.tsx
@@ -1,19 +1,28 @@
-import { Skeleton, StatCardSkeleton, AllocationWidgetSkeleton } from "@/components/ui/Skeleton";
+import { Skeleton, StatCardSkeleton, TableSkeleton } from "@/components/ui/Skeleton";
 
 export default function PortfolioLoading() {
   return (
     <div className="space-y-6 animate-fade-in" aria-busy="true" aria-label="Loading portfolio">
-      {/* Stat cards */}
+      <div className="space-y-2">
+        <Skeleton height={28} width={128} />
+        <Skeleton height={14} width="58%" />
+      </div>
+
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        {[1, 2, 3].map((i) => <StatCardSkeleton key={i} />)}
+        {Array.from({ length: 3 }).map((_, i) => (
+          <StatCardSkeleton key={i} />
+        ))}
       </div>
-      {/* Chart placeholder */}
+
       <div className="card">
-        <Skeleton height={14} width="36%" style={{ marginBottom: 20 }} />
-        <Skeleton height={192} width="100%" radius={8} />
+        <Skeleton height={16} width="40%" style={{ marginBottom: 20 }} />
+        <Skeleton height={192} width="100%" radius={12} />
       </div>
-      {/* Allocation */}
-      <AllocationWidgetSkeleton />
+
+      <div className="card">
+        <Skeleton height={16} width="28%" style={{ marginBottom: 20 }} />
+        <TableSkeleton rows={4} cols={5} />
+      </div>
     </div>
   );
 }

--- a/src/app/dashboard/settings/loading.tsx
+++ b/src/app/dashboard/settings/loading.tsx
@@ -1,11 +1,23 @@
-import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
+import { Skeleton, SettingsSectionSkeleton } from "@/components/ui/Skeleton";
 
 export default function SettingsLoading() {
   return (
-    <div className="max-w-2xl space-y-6 animate-fade-in" aria-busy="true" aria-label="Loading settings">
-      {[1, 2, 3].map((section) => (
-        <SettingsSectionSkeleton key={section} rows={2} />
-      ))}
+    <div
+      className="max-w-2xl space-y-6 animate-fade-in"
+      aria-busy="true"
+      aria-label="Loading settings"
+    >
+      <div className="space-y-2">
+        <Skeleton height={28} width={132} />
+        <Skeleton height={14} width="64%" />
+      </div>
+
+      <SettingsSectionSkeleton rows={1} />
+      <SettingsSectionSkeleton rows={2} />
+      <SettingsSectionSkeleton rows={2} />
+      <SettingsSectionSkeleton rows={2} />
+      <SettingsSectionSkeleton rows={2} />
+      <SettingsSectionSkeleton rows={1} />
     </div>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/contexts";
 import { MAIN_CONTENT_LANDMARK_ID } from "@/lib/app-landmarks";
 import { Loader2, Zap, Eye, EyeOff, Github, Chrome } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { FormField } from "@/components/ui";
 
 export const dynamic = "force-dynamic";
 
@@ -148,97 +149,93 @@ function LoginContent() {
 
           {/* Login form */}
           <form onSubmit={handleSubmit} noValidate className="space-y-4">
-            {/* Email */}
-            <div className="space-y-1">
-              <label
-                htmlFor="email"
-                className="block text-sm font-medium text-text-primary"
-              >
-                Email address
-              </label>
-              <input
-                id="email"
-                type="email"
-                autoComplete="email"
-                value={email}
-                onChange={(e) => {
-                  setEmail(e.target.value);
-                  setEmailError(null);
-                  setFormError(null);
-                  if (state === "error") setState("idle");
-                }}
-                disabled={isLoading || isSuccess}
-                aria-describedby={emailError ? "email-error" : undefined}
-                aria-invalid={!!emailError}
-                placeholder="you@example.com"
-                className={cn(
-                  "w-full rounded-lg border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors",
-                  "focus:ring-2 focus:ring-primary/40 focus:border-primary/60",
-                  emailError
-                    ? "border-error focus:ring-error/30"
-                    : "border-border",
-                  (isLoading || isSuccess) && "opacity-50 cursor-not-allowed",
-                )}
-              />
-              {emailError && (
-                <p id="email-error" role="alert" className="text-[14px] text-error">
-                  {emailError}
-                </p>
-              )}
-            </div>
-
-            {/* Password */}
-            <div className="space-y-1">
-              <label
-                htmlFor="password"
-                className="block text-sm font-medium text-text-primary"
-              >
-                Password
-              </label>
-              <div className="relative">
+            <FormField
+              id="email"
+              label="Email address"
+              error={emailError ?? undefined}
+              className="space-y-1"
+              labelClassName="block text-sm font-medium text-text-primary"
+              errorCompact
+              errorIcon={false}
+            >
+              {({ id, "aria-describedby": ariaDescribedBy, "aria-invalid": ariaInvalid }) => (
                 <input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  autoComplete="current-password"
-                  value={password}
+                  id={id}
+                  type="email"
+                  autoComplete="email"
+                  value={email}
                   onChange={(e) => {
-                    setPassword(e.target.value);
-                    setPasswordError(null);
+                    setEmail(e.target.value);
+                    setEmailError(null);
                     setFormError(null);
                     if (state === "error") setState("idle");
                   }}
                   disabled={isLoading || isSuccess}
-                  aria-describedby={passwordError ? "password-error" : undefined}
-                  aria-invalid={!!passwordError}
-                  placeholder="••••••••"
+                  aria-describedby={ariaDescribedBy}
+                  aria-invalid={ariaInvalid}
+                  placeholder="you@example.com"
                   className={cn(
-                    "w-full rounded-lg border bg-surface px-3 py-2 pr-10 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors",
+                    "w-full rounded-lg border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors",
                     "focus:ring-2 focus:ring-primary/40 focus:border-primary/60",
-                    passwordError
+                    emailError
                       ? "border-error focus:ring-error/30"
                       : "border-border",
                     (isLoading || isSuccess) && "opacity-50 cursor-not-allowed",
                   )}
                 />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  aria-label={showPassword ? "Hide password" : "Show password"}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-secondary transition-colors"
-                >
-                  {showPassword ? (
-                    <EyeOff className="w-4 h-4" aria-hidden="true" />
-                  ) : (
-                    <Eye className="w-4 h-4" aria-hidden="true" />
-                  )}
-                </button>
-              </div>
-              {passwordError && (
-                <p id="password-error" role="alert" className="text-[14px] text-error">
-                  {passwordError}
-                </p>
               )}
-            </div>
+            </FormField>
+
+            <FormField
+              id="password"
+              label="Password"
+              error={passwordError ?? undefined}
+              className="space-y-1"
+              labelClassName="block text-sm font-medium text-text-primary"
+              errorCompact
+              errorIcon={false}
+            >
+              {({ id, "aria-describedby": ariaDescribedBy, "aria-invalid": ariaInvalid }) => (
+                <div className="relative">
+                  <input
+                    id={id}
+                    type={showPassword ? "text" : "password"}
+                    autoComplete="current-password"
+                    value={password}
+                    onChange={(e) => {
+                      setPassword(e.target.value);
+                      setPasswordError(null);
+                      setFormError(null);
+                      if (state === "error") setState("idle");
+                    }}
+                    disabled={isLoading || isSuccess}
+                    aria-describedby={ariaDescribedBy}
+                    aria-invalid={ariaInvalid}
+                    placeholder="••••••••"
+                    className={cn(
+                      "w-full rounded-lg border bg-surface px-3 py-2 pr-10 text-sm text-text-primary placeholder:text-text-muted outline-none transition-colors",
+                      "focus:ring-2 focus:ring-primary/40 focus:border-primary/60",
+                      passwordError
+                        ? "border-error focus:ring-error/30"
+                        : "border-border",
+                      (isLoading || isSuccess) && "opacity-50 cursor-not-allowed",
+                    )}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword((v) => !v)}
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-text-muted hover:text-text-secondary transition-colors"
+                  >
+                    {showPassword ? (
+                      <EyeOff className="w-4 h-4" aria-hidden="true" />
+                    ) : (
+                      <Eye className="w-4 h-4" aria-hidden="true" />
+                    )}
+                  </button>
+                </div>
+              )}
+            </FormField>
 
             {/* Submit */}
             <button

--- a/src/components/ui/FormErrors.tsx
+++ b/src/components/ui/FormErrors.tsx
@@ -7,19 +7,27 @@ export function FieldError({
   id,
   message,
   icon = true,
+  compact = false,
+  className = "",
 }: {
   id: string;
   message?: string;
   icon?: boolean;
+  compact?: boolean;
+  className?: string;
 }) {
   if (!message) {
     return null;
   }
 
+  const baseClassName = compact
+    ? "text-[14px] leading-5 text-[#EF4444]"
+    : "mt-2 flex items-start gap-2 text-[14px] leading-5 text-[#EF4444]";
+
   return (
     <p
       id={id}
-      className="mt-2 flex items-start gap-2 text-[14px] leading-5 text-[#EF4444]"
+      className={`${baseClassName} ${className}`.trim()}
     >
       {icon ? <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" /> : null}
       <span>{message}</span>

--- a/src/components/ui/FormField.test.ts
+++ b/src/components/ui/FormField.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getFormFieldA11yProps } from "./FormField";
+
+test("FormField a11y props wire ids and aria-describedby for hinted errors", () => {
+  const props = getFormFieldA11yProps({
+    id: "email",
+    hint: true,
+    error: "Email is required.",
+  });
+
+  assert.deepEqual(props, {
+    id: "email",
+    hintId: "email-hint",
+    errorId: "email-error",
+    describedBy: "email-hint email-error",
+    invalid: true,
+  });
+});
+
+test("FormField a11y props keep aria-describedby empty when there is no hint or error", () => {
+  const props = getFormFieldA11yProps({ id: "password" });
+
+  assert.deepEqual(props, {
+    id: "password",
+    hintId: undefined,
+    errorId: undefined,
+    describedBy: undefined,
+    invalid: false,
+  });
+});
+
+test("FormField a11y props prioritize an error id when only an error is present", () => {
+  const props = getFormFieldA11yProps({
+    id: "login-password",
+    error: "Password is required.",
+  });
+
+  assert.deepEqual(props, {
+    id: "login-password",
+    hintId: undefined,
+    errorId: "login-password-error",
+    describedBy: "login-password-error",
+    invalid: true,
+  });
+});

--- a/src/components/ui/FormField.tsx
+++ b/src/components/ui/FormField.tsx
@@ -2,20 +2,34 @@
 
 import { ReactNode } from "react";
 import { FieldError } from "./FormErrors";
+import { cn } from "@/lib/utils";
 import { joinDescribedBy } from "@/lib/form-validation";
 
 interface FormFieldProps {
   id: string;
-  label: string;
+  label: ReactNode;
   error?: string;
-  hint?: string;
-  children: ReactNode;
+  hint?: ReactNode;
+  children: (props: FormFieldControlProps) => ReactNode;
   required?: boolean;
+  className?: string;
+  labelClassName?: string;
+  hintClassName?: string;
+  errorClassName?: string;
+  errorIcon?: boolean;
+  errorCompact?: boolean;
+}
+
+export interface FormFieldControlProps {
+  id: string;
+  "aria-invalid": boolean;
+  "aria-describedby"?: string;
 }
 
 /**
- * Shared form field wrapper that unifies label, hint, error, and aria-describedby
- * wiring across the application. Reduces duplication in form implementations.
+ * Shared form field wrapper that unifies label/control id wiring and aria state.
+ * Keeps the control ids and helper-text ids aligned so inline forms and wrapped
+ * forms do not drift apart.
  */
 export function FormField({
   id,
@@ -24,27 +38,69 @@ export function FormField({
   hint,
   children,
   required = false,
+  className = "",
+  labelClassName = "mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300",
+  hintClassName = "mt-2 text-sm text-slate-500",
+  errorClassName = "",
+  errorIcon = true,
+  errorCompact = false,
 }: FormFieldProps) {
-  const hintId = hint ? `${id}-hint` : undefined;
-  const errorId = error ? `${id}-error` : undefined;
-  const describedById = joinDescribedBy(hintId, errorId);
+  const { errorId, describedBy, hintId, invalid } = getFormFieldA11yProps({
+    id,
+    error,
+    hint: Boolean(hint),
+  });
+  const controlProps: FormFieldControlProps = {
+    id,
+    "aria-invalid": invalid,
+    "aria-describedby": describedBy,
+  };
 
   return (
-    <div>
+    <div className={className}>
       <label
         htmlFor={id}
-        className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
+        className={labelClassName}
       >
         {label}
         {required && <span className="text-red-400"> *</span>}
       </label>
-      <div data-aria-describedby={describedById}>{children}</div>
+      {children(controlProps)}
       {hint && (
-        <p id={hintId} className="mt-2 text-sm text-slate-500">
+        <p id={hintId} className={cn(hintClassName)}>
           {hint}
         </p>
       )}
-      {errorId && <FieldError id={errorId} message={error} />}
+      {errorId && (
+        <FieldError
+          id={errorId}
+          message={error}
+          icon={errorIcon}
+          compact={errorCompact}
+          className={errorClassName}
+        />
+      )}
     </div>
   );
+}
+
+export function getFormFieldA11yProps({
+  id,
+  error,
+  hint,
+}: {
+  id: string;
+  error?: string;
+  hint?: boolean;
+}) {
+  const hintId = hint ? `${id}-hint` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+
+  return {
+    id,
+    hintId,
+    errorId,
+    describedBy: joinDescribedBy(hintId, errorId),
+    invalid: Boolean(error),
+  };
 }


### PR DESCRIPTION
Title: Add shared form field a11y wiring and apply it to login

Summary:
- Extended the shared `FormField` primitive so one source of truth now handles `id`, `htmlFor`, `aria-invalid`, and `aria-describedby`.
- Added a small helper for deriving field, hint, and error IDs to keep inline and wrapped form patterns aligned.
- Updated the login form to use the shared primitive for email and password fields, removing duplicated accessibility wiring.
- Adjusted `FieldError` so the same error primitive can render in both the existing stacked layout and the compact login layout.

Verification:
- `git diff --check`
- `src/components/ui/FormField.test.ts` covers the shared ID/aria helper
- Manual QA: open `/login`, confirm email and password fields still render correctly, then trigger validation errors and verify the input `aria-invalid` and `aria-describedby` values follow the associated error message

Closes #417