### PR TITLE
feat: standardize smoke flow qa selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ The mock auth flow stores the session in `localStorage` using `SESSION_STORAGE_K
 - Tests live next to logic under `src/` and run via `yarn test`.
 - For bundle-size checks, run `yarn analyze` locally and review the generated report before
   changing code that affects route or vendor bundles.
+- Use `data-qa` only for smoke-flow anchors, with kebab-case names that describe the flow and
+  action, for example `landing-primary-cta-button`, `wallet-connect-button`, and
+  `transaction-submit-button`.
 
 ## License
 

--- a/src/components/transactions/TransactionFlow.tsx
+++ b/src/components/transactions/TransactionFlow.tsx
@@ -855,7 +855,7 @@ export function TransactionFlow() {
                         className={`${styles.button} ${styles.buttonPrimary}`}
                         onClick={handleConfirm}
                         type="button"
-                        data-qa="transaction-confirm-button"
+                        data-qa="transaction-submit-button"
                       >
                         {context.confirmActionLabel}
                       </button>

--- a/src/components/transactions/stages/TransactionConfirmStage.tsx
+++ b/src/components/transactions/stages/TransactionConfirmStage.tsx
@@ -91,7 +91,7 @@ export function TransactionConfirmStage({
             onClick={onConfirm}
             disabled={isSubmitting}
             type="button"
-            data-qa="transaction-confirm-button"
+            data-qa="transaction-submit-button"
           >
             {isSubmitting ? "Submitting..." : confirmLabel}
           </button>

--- a/src/features/landing/HeroActions.tsx
+++ b/src/features/landing/HeroActions.tsx
@@ -35,10 +35,17 @@ export function HeroActions() {
       <div className="flex flex-wrap justify-center gap-3">
         {connected ? (
           <Link href="/dashboard">
-            <Button size="lg">{messages.heroActions.openDashboardArrow}</Button>
+            <Button size="lg" data-qa="landing-primary-cta-button">
+              {messages.heroActions.openDashboardArrow}
+            </Button>
           </Link>
         ) : (
-          <Button size="lg" onClick={connectWallet} disabled={loading}>
+          <Button
+            size="lg"
+            onClick={connectWallet}
+            disabled={loading}
+            data-qa="landing-primary-cta-button"
+          >
             {loading ? messages.heroActions.connecting : messages.heroActions.connectWallet}
           </Button>
         )}


### PR DESCRIPTION
Closes #419

Title: Standardize smoke-flow data-qa anchors

Summary:
- Added a consistent `data-qa` anchor for the landing page primary CTA.
- Standardized the final transaction submit action to `data-qa="transaction-submit-button"`.
- Kept the existing wallet connect selector as the canonical wallet anchor.
- Documented the naming convention in README so future smoke tests use `data-qa` only for a small set of flow anchors.

Verification:
- `git diff --check`
- Manual QA:
  - Confirm `landing-primary-cta-button` on the home hero CTA
  - Confirm `wallet-connect-button` on the navbar wallet button
  - Confirm `transaction-submit-button` on the transaction confirm action