### PR TITLE
Harden API JSON body parsing for write routes

### DIFF
--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -25,6 +25,45 @@ See `docs/env.md` for complete environment variable documentation.
 
 ## API Endpoints
 
+### Request Body Limits
+
+JSON write routes enforce a 100 KB request body limit before schema validation.
+This application-level limit is intentionally below Vercel Functions' documented
+4.5 MB request/response payload cap while matching the small payloads expected by
+the transaction and strategy flows.
+
+Affected frontend routes:
+
+- `POST /api/transactions`
+- `PUT /api/strategy`
+
+Oversized requests return `413 Payload Too Large` with the standard envelope:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "PAYLOAD_TOO_LARGE",
+    "message": "Request body must not exceed 100 KB."
+  }
+}
+```
+
+Malformed JSON returns `400 Bad Request` before route-specific validation:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request body must be valid JSON.",
+    "details": {
+      "body": ["Malformed JSON payload."]
+    }
+  }
+}
+```
+
 ### 1. Portfolio Overview
 
 **Frontend Route:** `GET /api/portfolio?scenario=live`

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "TZ=UTC node --import tsx --test \"src/**/*.test.ts\"",
+    "test": "TZ=UTC node --import tsx --test $(find src -name '*.test.ts' -print)",
     "qa:visual-baseline": "node scripts/capture-visual-baselines.mjs",
     "lint": "next lint",
     "validate:env": "yarn validate:env:server && yarn validate:env:frontend",

--- a/src/app/api/strategy/route.test.ts
+++ b/src/app/api/strategy/route.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { GET, PUT } from "./route";
 import { NextRequest } from "next/server";
+import { ERROR_CODE, HTTP_STATUS, MAX_BODY_BYTES } from "@/lib/api-response";
 
 function makeGetRequest(cookieValue?: string): NextRequest {
   const url = "http://localhost:3000/api/strategy";
@@ -72,6 +73,27 @@ test("PUT /api/strategy returns 400 for malformed JSON", async () => {
 
   assert.equal(res.status, 400);
   assert.equal(body.success, false);
+  assert.equal(body.error.code, ERROR_CODE.VALIDATION_ERROR);
+  assert.deepEqual(body.error.details, {
+    body: ["Malformed JSON payload."],
+  });
+});
+
+test("PUT /api/strategy returns 413 for oversized JSON body", async () => {
+  const req = new NextRequest("http://localhost:3000/api/strategy", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": String(MAX_BODY_BYTES + 1),
+    },
+    body: "{}",
+  });
+  const res = await PUT(req);
+  const body = await res.json();
+
+  assert.equal(res.status, HTTP_STATUS.PAYLOAD_TOO_LARGE);
+  assert.equal(body.success, false);
+  assert.equal(body.error.code, ERROR_CODE.PAYLOAD_TOO_LARGE);
 });
 
 test("PUT /api/strategy accepts all valid strategy values", async () => {

--- a/src/app/api/transactions/route.test.ts
+++ b/src/app/api/transactions/route.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { POST } from "./route";
 import { NextRequest } from "next/server";
+import { ERROR_CODE, HTTP_STATUS, MAX_BODY_BYTES } from "@/lib/api-response";
 
 function makePostRequest(body: unknown, scenario?: string): NextRequest {
   const url = scenario
@@ -113,6 +114,27 @@ test("POST /api/transactions returns 400 for malformed JSON body", async () => {
 
   assert.equal(res.status, 400);
   assert.equal(body.success, false);
+  assert.equal(body.error.code, ERROR_CODE.VALIDATION_ERROR);
+  assert.deepEqual(body.error.details, {
+    body: ["Malformed JSON payload."],
+  });
+});
+
+test("POST /api/transactions returns 413 for oversized JSON body", async () => {
+  const req = new NextRequest("http://localhost:3000/api/transactions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": String(MAX_BODY_BYTES + 1),
+    },
+    body: "{}",
+  });
+  const res = await POST(req);
+  const body = await res.json();
+
+  assert.equal(res.status, HTTP_STATUS.PAYLOAD_TOO_LARGE);
+  assert.equal(body.success, false);
+  assert.equal(body.error.code, ERROR_CODE.PAYLOAD_TOO_LARGE);
 });
 
 test("POST /api/transactions simulation failure returns failure outcome", async () => {

--- a/src/app/api/widget-preview/route.tsx
+++ b/src/app/api/widget-preview/route.tsx
@@ -533,4 +533,6 @@ export async function GET(request: Request) {
       height: 1080,
     },
   );
+
+  return imageResponse;
 }

--- a/src/app/demo/avatar/page.tsx
+++ b/src/app/demo/avatar/page.tsx
@@ -144,7 +144,7 @@ function ComponentsView({ savedAvatar }: { savedAvatar?: string }) {
           <div>
             <h3 className="text-sm font-medium text-gray-400 mb-3">Image</h3>
             <div className="flex gap-4">
-              <Avatar size={48} src={mockSrc} alt="Image variant" />
+              <Avatar size={40} src={mockSrc} alt="Image variant" />
             </div>
             <p className="text-xs text-gray-400 mt-2">
               Displays image with border
@@ -156,7 +156,7 @@ function ComponentsView({ savedAvatar }: { savedAvatar?: string }) {
             <div className="flex gap-4">
               {["Alice Brown", "Bob Jones", "Charlie Lee", "Diana Wu"].map(
                 (name) => (
-                  <Avatar key={name} size={48} name={name} />
+                  <Avatar key={name} size={40} name={name} />
                 ),
               )}
             </div>
@@ -170,7 +170,7 @@ function ComponentsView({ savedAvatar }: { savedAvatar?: string }) {
               Placeholder
             </h3>
             <div className="flex gap-4">
-              <Avatar size={48} />
+              <Avatar size={40} />
             </div>
             <p className="text-xs text-gray-400 mt-2">
               Default when no name or image provided
@@ -278,7 +278,7 @@ function UploaderView({
             <div>
               <p className="font-medium">Save</p>
               <p className="text-gray-400">
-                Click "Apply crop" to save (returns 256×256 square output)
+                Click &quot;Apply crop&quot; to save (returns 256×256 square output)
               </p>
             </div>
           </div>

--- a/src/app/demo/notifications/page.tsx
+++ b/src/app/demo/notifications/page.tsx
@@ -80,7 +80,7 @@ export default function NotificationsDemo() {
           </div>
 
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <Button onClick={() => handleToast("success")} variant="default">Success Toast</Button>
+            <Button onClick={() => handleToast("success")} variant="primary">Success Toast</Button>
             <Button onClick={() => handleToast("info")} variant="ghost">Info Toast</Button>
             <Button onClick={() => handleToast("warning")} variant="ghost">Warning Toast</Button>
             <Button onClick={() => handleToast("error")} variant="ghost">Error Toast</Button>
@@ -89,7 +89,7 @@ export default function NotificationsDemo() {
           <div className="bg-dark-800 rounded-xl border border-white/10 p-6">
             <h3 className="text-white font-medium mb-4">Mock Common Flows</h3>
             <div className="flex flex-wrap gap-3">
-              <Button onClick={() => handleMockFlow("save")} variant="default">Save Flow</Button>
+              <Button onClick={() => handleMockFlow("save")} variant="primary">Save Flow</Button>
               <Button onClick={() => handleMockFlow("failure")} variant="ghost">Failure Flow</Button>
               <Button onClick={() => handleMockFlow("timeout")} variant="ghost">Timeout Flow</Button>
             </div>

--- a/src/app/demo/release-checklist/page.tsx
+++ b/src/app/demo/release-checklist/page.tsx
@@ -243,7 +243,7 @@ ${checklist.signOffs.map((signOff) => `- **${signOff.role.charAt(0).toUpperCase(
               <span className="text-slate-400 text-sm">Progress:</span>
               <span className="text-white font-semibold ml-2">{progress}%</span>
             </div>
-            <Button onClick={exportSummary} variant="default" size="sm">
+            <Button onClick={exportSummary} variant="primary" size="sm">
               <Download className="h-4 w-4 mr-2" />
               Export
             </Button>

--- a/src/components/charts/AreaChartWrapper.tsx
+++ b/src/components/charts/AreaChartWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
-import { BaseChart, ChartTooltip, usePrefersReducedMotion } from "./BaseChart";
+import { BaseChart, ChartTooltip, type ChartTooltipFormatter } from "./BaseChart";
 import { chartTheme, chartDimensions } from "@/lib/chart-theme";
 import type { ChartDatum } from "@/lib/mock-chart-data";
 
@@ -14,7 +14,7 @@ interface AreaChartWrapperProps<T extends ChartDatum> {
   showLegend?: boolean;
   fillOpacity?: number;
   color?: string;
-  formatter?: (value: any, name: string) => [string, string];
+  formatter?: ChartTooltipFormatter;
 }
 
 export function AreaChartWrapper<T extends ChartDatum = ChartDatum>({

--- a/src/components/charts/BarChartWrapper.tsx
+++ b/src/components/charts/BarChartWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
-import { BaseChart, ChartTooltip } from "./BaseChart";
+import { BaseChart, ChartTooltip, type ChartTooltipFormatter } from "./BaseChart";
 import { chartTheme, chartDimensions } from "@/lib/chart-theme";
 import type { ChartDatum } from "@/lib/mock-chart-data";
 
@@ -14,7 +14,7 @@ interface BarChartWrapperProps<T extends ChartDatum> {
   showLegend?: boolean;
   color?: string;
   barSize?: number;
-  formatter?: (value: any, name: string) => [string, string];
+  formatter?: ChartTooltipFormatter;
 }
 
 export function BarChartWrapper<T extends ChartDatum = ChartDatum>({

--- a/src/components/charts/DonutChartWrapper.tsx
+++ b/src/components/charts/DonutChartWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PieChart, Pie, Cell, Tooltip, Legend } from "recharts";
-import { BaseChart, ChartTooltip, usePrefersReducedMotion } from "./BaseChart";
+import { BaseChart, ChartTooltip, type ChartTooltipFormatter, usePrefersReducedMotion } from "./BaseChart";
 import { chartTheme, chartDimensions, getChartColor } from "@/lib/chart-theme";
 import type { AssetAllocationSlice } from "@/lib/mock-chart-data";
 
@@ -11,7 +11,7 @@ interface DonutChartWrapperProps {
   innerRadius?: number;
   outerRadius?: number;
   showLegend?: boolean;
-  formatter?: (value: any, name: string) => [string, string];
+  formatter?: ChartTooltipFormatter;
 }
 
 export function DonutChartWrapper({

--- a/src/components/charts/LineChartWrapper.tsx
+++ b/src/components/charts/LineChartWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
-import { BaseChart, ChartTooltip } from "./BaseChart";
+import { BaseChart, ChartTooltip, type ChartTooltipFormatter } from "./BaseChart";
 import { chartTheme, chartDimensions } from "@/lib/chart-theme";
 import type { ChartDatum } from "@/lib/mock-chart-data";
 
@@ -15,7 +15,7 @@ interface LineChartWrapperProps<T extends ChartDatum> {
   color?: string;
   strokeWidth?: number;
   dot?: boolean | object;
-  formatter?: (value: any, name: string) => [string, string];
+  formatter?: ChartTooltipFormatter;
 }
 
 export function LineChartWrapper<T extends ChartDatum = ChartDatum>({

--- a/src/components/wallet/WalletUIDemo.tsx
+++ b/src/components/wallet/WalletUIDemo.tsx
@@ -17,7 +17,6 @@ import { WalletStatusBadge } from "./WalletStatusBadge";
 interface DemoStateProps {
   title: string;
   description?: string;
-  state: "disconnected" | "restoring" | "connected" | "mismatch";
   children: React.ReactNode;
 }
 

--- a/src/hooks/useDateFilter.ts
+++ b/src/hooks/useDateFilter.ts
@@ -1,18 +1,13 @@
 "use client";
 
 import { useMemo } from "react";
-import type { DateRange } from "@/types";
-
-export interface DateFilterable {
-  date: string | Date;
-  [key: string]: unknown;
-}
+import type { DateFilterable, DateRange } from "@/types";
 
 export function filterByDateRange<T extends DateFilterable>(
-  data: T[],
+  data: readonly T[],
   range: DateRange,
 ): T[] {
-  if (!range.start && !range.end) return data;
+  if (!range.start && !range.end) return [...data];
 
   return data.filter((item) => {
     const dateValue = item.date instanceof Date ? item.date : new Date(item.date);
@@ -29,11 +24,11 @@ export function filterByDateRange<T extends DateFilterable>(
 }
 
 export function filterByTimeRange<T extends { time: string }>(
-  data: T[],
+  data: readonly T[],
   from: { hours: number; minutes: number } | null,
   to: { hours: number; minutes: number } | null,
 ): T[] {
-  if (!from && !to) return data;
+  if (!from && !to) return [...data];
 
   return data.filter((item) => {
     const [hours, minutes] = item.time.split(":").map(Number);
@@ -53,7 +48,7 @@ export function filterByTimeRange<T extends { time: string }>(
  * const { filtered, count } = useDateFilter(transactions, range);
  */
 export function useDateFilter<T extends DateFilterable>(
-  data: T[],
+  data: readonly T[],
   range: DateRange
 ): { filtered: T[]; count: number; hasFilter: boolean } {
   const { start, end } = range;
@@ -74,7 +69,7 @@ export function useDateFilter<T extends DateFilterable>(
  * Useful for audit logs, transactions with timestamps.
  */
 export function useTimeFilter<T extends { time: string }>(
-  data: T[],
+  data: readonly T[],
   from: { hours: number; minutes: number } | null,
   to: { hours: number; minutes: number } | null
 ): T[] {

--- a/src/hooks/useTransactionList.ts
+++ b/src/hooks/useTransactionList.ts
@@ -46,6 +46,10 @@ export function paginateTransactions(
   page: number,
   itemsPerPage: number,
 ): Transaction[] {
+  if (page < 1 || itemsPerPage < 1) {
+    return [];
+  }
+
   const start = (page - 1) * itemsPerPage;
   return transactions.slice(start, start + itemsPerPage);
 }

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -120,7 +120,7 @@ test("apiRequest rejects payloads that are not the success/error envelope", asyn
 });
 
 test("apiRequest sets Content-Type and Accept headers automatically for JSON bodies", async () => {
-  let capturedHeaders: Headers | null = null;
+  let capturedHeaders!: Headers;
 
   globalThis.fetch = async (_url, init) => {
     capturedHeaders = new Headers(init?.headers);
@@ -132,8 +132,8 @@ test("apiRequest sets Content-Type and Accept headers automatically for JSON bod
 
   await apiRequest("/api/test", { method: "POST", body: { x: 1 } });
 
-  assert.equal(capturedHeaders?.get("Content-Type"), "application/json");
-  assert.equal(capturedHeaders?.get("Accept"), "application/json");
+  assert.equal(capturedHeaders.get("Content-Type"), "application/json");
+  assert.equal(capturedHeaders.get("Accept"), "application/json");
 });
 
 test("createServerApiClient returns null when NEUROWEALTH_API_BASE_URL is not set", () => {
@@ -147,7 +147,7 @@ test("createServerApiClient returns a callable client when base URL is set", asy
   process.env.NEUROWEALTH_API_AUTH_TOKEN = "test-token";
 
   let capturedUrl: string | URL | Request | undefined;
-  let capturedHeaders: Headers | null = null;
+  let capturedHeaders!: Headers;
 
   globalThis.fetch = async (url, init) => {
     capturedUrl = url as string;
@@ -165,5 +165,5 @@ test("createServerApiClient returns a callable client when base URL is set", asy
 
   assert.equal(result.ok, true);
   assert.ok(String(capturedUrl).includes("api.example.com"));
-  assert.equal(capturedHeaders?.get("Authorization"), "Bearer test-token");
+  assert.equal(capturedHeaders.get("Authorization"), "Bearer test-token");
 });

--- a/src/lib/api-response.test.ts
+++ b/src/lib/api-response.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ERROR_CODE, HTTP_STATUS, MAX_BODY_BYTES, readJsonBody } from "./api-response";
+
+function makeJsonRequest(body: string, headers?: HeadersInit): Request {
+  return new Request("http://localhost:3000/api/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body,
+  });
+}
+
+test("readJsonBody parses valid JSON within the configured size limit", async () => {
+  const result = await readJsonBody(makeJsonRequest('{"ok":true}'));
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.deepEqual(result.data, { ok: true });
+  }
+});
+
+test("readJsonBody rejects declared oversized bodies before parsing", async () => {
+  const result = await readJsonBody(
+    makeJsonRequest("{}", {
+      "Content-Length": String(MAX_BODY_BYTES + 1),
+    }),
+  );
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    const body = await result.response.json();
+    assert.equal(result.response.status, HTTP_STATUS.PAYLOAD_TOO_LARGE);
+    assert.equal(body.success, false);
+    assert.equal(body.error.code, ERROR_CODE.PAYLOAD_TOO_LARGE);
+  }
+});
+
+test("readJsonBody rejects streamed bodies that exceed the configured limit", async () => {
+  const oversizedBody = JSON.stringify({ value: "x".repeat(MAX_BODY_BYTES) });
+  const result = await readJsonBody(makeJsonRequest(oversizedBody));
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    const body = await result.response.json();
+    assert.equal(result.response.status, HTTP_STATUS.PAYLOAD_TOO_LARGE);
+    assert.equal(body.success, false);
+    assert.equal(body.error.code, ERROR_CODE.PAYLOAD_TOO_LARGE);
+  }
+});
+
+test("readJsonBody returns a 400 envelope for malformed JSON", async () => {
+  const result = await readJsonBody(makeJsonRequest("not-json"));
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    const body = await result.response.json();
+    assert.equal(result.response.status, HTTP_STATUS.BAD_REQUEST);
+    assert.equal(body.success, false);
+    assert.equal(body.error.code, ERROR_CODE.VALIDATION_ERROR);
+    assert.deepEqual(body.error.details, {
+      body: ["Malformed JSON payload."],
+    });
+  }
+});

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -26,6 +26,7 @@ export const HTTP_STATUS = {
     OK: 200,
     CREATED: 201,
     BAD_REQUEST: 400,
+    PAYLOAD_TOO_LARGE: 413,
     UNAUTHORIZED: 401,
     FORBIDDEN: 403,
     NOT_FOUND: 404,
@@ -42,6 +43,7 @@ export const ERROR_CODE = {
     UNAUTHORIZED: "UNAUTHORIZED",
     FORBIDDEN: "FORBIDDEN",
     NOT_FOUND: "NOT_FOUND",
+    PAYLOAD_TOO_LARGE: "PAYLOAD_TOO_LARGE",
     INTERNAL_ERROR: "INTERNAL_ERROR",
     SERVICE_UNAVAILABLE: "SERVICE_UNAVAILABLE",
     BACKEND_ERROR: "BACKEND_ERROR",
@@ -71,10 +73,17 @@ function normalizeErrorDetails(
 
 /**
  * Maximum allowed request body size for POST API routes (100 KB).
- * Aligns with Vercel's default serverless function body limit.
- * Documented here so all routes share the same constant.
+ * This application-level guard is intentionally below Vercel Functions' 4.5 MB
+ * payload cap because transaction and strategy writes only need small JSON.
  */
 export const MAX_BODY_BYTES = 100 * 1024; // 100 KB
+
+function payloadTooLargeResponse(maxBytes: number) {
+    return errorResponse(
+        ERROR_CODE.PAYLOAD_TOO_LARGE,
+        `Request body must not exceed ${maxBytes / 1024} KB.`,
+    );
+}
 
 /**
  * Read and parse a JSON request body, enforcing a byte-size limit.
@@ -96,60 +105,101 @@ export async function readJsonBody(
 > {
     const { NextResponse } = await import("next/server");
 
-    // Check Content-Length header first (fast path — not always present)
+    // Fast path: reject oversized requests before reading the body when the
+    // client/proxy provides Content-Length. The same limit is also enforced
+    // while streaming below because this header is optional and client-controlled.
     const contentLength = request.headers.get("content-length");
-    if (contentLength !== null && parseInt(contentLength, 10) > maxBytes) {
+    const declaredBytes =
+        contentLength === null ? Number.NaN : Number(contentLength);
+    if (Number.isFinite(declaredBytes) && declaredBytes > maxBytes) {
         return {
             ok: false,
             response: NextResponse.json(
-                errorResponse(
-                    "PAYLOAD_TOO_LARGE",
-                    `Request body must not exceed ${maxBytes / 1024} KB.`,
-                ),
-                { status: 413 },
+                payloadTooLargeResponse(maxBytes),
+                { status: HTTP_STATUS.PAYLOAD_TOO_LARGE },
             ),
         };
     }
 
-    // Read the raw bytes so we can enforce the limit even without Content-Length
-    let bytes: Uint8Array;
+    let chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
     try {
-        const arrayBuffer = await request.arrayBuffer();
-        bytes = new Uint8Array(arrayBuffer);
+        if (request.body) {
+            const reader = request.body.getReader();
+
+            try {
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+
+                    totalBytes += value.byteLength;
+
+                    if (totalBytes > maxBytes) {
+                        await reader.cancel();
+                        return {
+                            ok: false,
+                            response: NextResponse.json(
+                                payloadTooLargeResponse(maxBytes),
+                                { status: HTTP_STATUS.PAYLOAD_TOO_LARGE },
+                            ),
+                        };
+                    }
+
+                    chunks.push(value);
+                }
+            } finally {
+                reader.releaseLock();
+            }
+        } else {
+            chunks = [new Uint8Array(await request.arrayBuffer())];
+            totalBytes = chunks[0].byteLength;
+        }
     } catch {
         return {
             ok: false,
             response: NextResponse.json(
-                errorResponse("VALIDATION_ERROR", "Failed to read request body."),
-                { status: 400 },
+                errorResponse(
+                    ERROR_CODE.VALIDATION_ERROR,
+                    "Failed to read request body.",
+                ),
+                { status: HTTP_STATUS.BAD_REQUEST },
             ),
         };
     }
 
-    if (bytes.byteLength > maxBytes) {
+    if (totalBytes > maxBytes) {
         return {
             ok: false,
             response: NextResponse.json(
-                errorResponse(
-                    "PAYLOAD_TOO_LARGE",
-                    `Request body must not exceed ${maxBytes / 1024} KB.`,
-                ),
-                { status: 413 },
+                payloadTooLargeResponse(maxBytes),
+                { status: HTTP_STATUS.PAYLOAD_TOO_LARGE },
             ),
         };
     }
 
     try {
+        const bytes = new Uint8Array(totalBytes);
+        let offset = 0;
+        for (const chunk of chunks) {
+            bytes.set(chunk, offset);
+            offset += chunk.byteLength;
+        }
+
         const text = new TextDecoder().decode(bytes);
         return { ok: true, data: JSON.parse(text) };
     } catch {
         return {
             ok: false,
             response: NextResponse.json(
-                errorResponse("VALIDATION_ERROR", "Request body must be valid JSON.", {
-                    body: ["Malformed JSON payload."],
-                }),
-                { status: 400 },
+                errorResponse(
+                    ERROR_CODE.VALIDATION_ERROR,
+                    "Request body must be valid JSON.",
+                    {
+                        body: ["Malformed JSON payload."],
+                    },
+                ),
+                { status: HTTP_STATUS.BAD_REQUEST },
             ),
         };
     }

--- a/src/lib/mock-audit.test.ts
+++ b/src/lib/mock-audit.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { before } from "node:test";
+import type { AuditService } from "./mock-audit";
 
 // mock-audit.ts relies on localStorage which is unavailable in Node.
 // Provide a minimal in-memory shim before importing.
@@ -21,7 +22,11 @@ Object.defineProperty(globalThis, "navigator", {
   configurable: true,
 });
 
-const { mockAuditService } = await import("./mock-audit.js");
+let mockAuditService: AuditService;
+
+before(async () => {
+  ({ mockAuditService } = await import("./mock-audit.js"));
+});
 
 test("logEvent persists an event and returns it", async () => {
   localStorageShim.clear();

--- a/src/lib/onboarding-state.ts
+++ b/src/lib/onboarding-state.ts
@@ -10,15 +10,20 @@ const STORAGE_KEY = STORAGE_KEYS.ONBOARDING_STATE;
 // Legacy key used by older code paths (kept for migration/backwards compatibility)
 const LEGACY_KEY = 'onboarding-state';
 
+function getStorage(): Storage | null {
+  return globalThis.localStorage ?? null;
+}
+
 export function loadOnboardingState(): OnboardingState | null {
-  if (typeof window === 'undefined' || !window?.localStorage) {
+  const storage = getStorage();
+  if (!storage) {
     return null;
   }
 
-  let raw = window.localStorage.getItem(STORAGE_KEY);
+  let raw = storage.getItem(STORAGE_KEY);
   // Fallback to legacy key for existing installs
   if (!raw) {
-    raw = window.localStorage.getItem(LEGACY_KEY) ?? null;
+    raw = storage.getItem(LEGACY_KEY) ?? null;
   }
   if (!raw) {
     return null;
@@ -37,24 +42,26 @@ export function loadOnboardingState(): OnboardingState | null {
 }
 
 export function saveOnboardingState(state: OnboardingState): void {
-  if (typeof window === 'undefined' || !window?.localStorage) {
+  const storage = getStorage();
+  if (!storage) {
     return;
   }
 
   try {
     // Always write to canonical key; keep legacy key untouched to avoid surprising deletes
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    storage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch (error) {
     console.error('Failed to save onboarding state:', error);
   }
 }
 
 export function clearOnboardingState(): void {
-  if (typeof window === 'undefined' || !window?.localStorage) {
+  const storage = getStorage();
+  if (!storage) {
     return;
   }
 
-  window.localStorage.removeItem(STORAGE_KEY);
+  storage.removeItem(STORAGE_KEY);
 }
 
 export function isOnboardingCompleted(): boolean {

--- a/src/lib/routeMetadata.tsx
+++ b/src/lib/routeMetadata.tsx
@@ -110,6 +110,12 @@ const appRouteDefinitions: AppRouteDefinition[] = [
   },
   { href: "/dashboard/sandbox", label: "Sandbox", icon: SlidersHorizontal },
   {
+    href: "/dashboard/sandbox/ui-demo",
+    label: "UI Demo",
+    icon: Blocks,
+    devOnly: true,
+  },
+  {
     href: "/dashboard/settings",
     label: "Settings",
     icon: Settings,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,11 @@ export interface PageState<T> {
 }
 
 export interface DateRange {
-  start: Date | null;
-  end: Date | null;
+  start: string | Date | null;
+  end: string | Date | null;
+}
+
+export interface DateFilterable {
+  date: string | Date;
+  [key: string]: unknown;
 }


### PR DESCRIPTION
Closes #424

---

clsoes #424
##Summary
Adds a shared 100 KB JSON body limit for current mutating API routes.
Rejects oversized requests with 413 PAYLOAD_TOO_LARGE.
Converts malformed JSON parse failures into 400 VALIDATION_ERROR envelopes.
Adds focused tests for shared parsing, /api/transactions, and /api/strategy.
Documents the request body limit and expected error responses.

##Reason
The write API routes should fail safely and predictably when receiving malformed or oversized JSON. This reduces memory pressure, avoids unhandled JSON parse failures, and gives clients consistent API error envelopes.