### PR TITLE
fix: resolve audit issues 

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+yarn lint-staged

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,4 @@
 {
-  "*.{ts,tsx}": ["next lint --fix --file"],
-  "*.{js,mjs,cjs}": ["next lint --fix --file"]
+  "*.{ts,tsx}": ["eslint --fix --max-warnings=0"],
+  "*.{js,mjs,cjs}": ["eslint --fix --max-warnings=0"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,3 @@
-{}
+{
+    "typescript.autoClosingTags": false
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,127 @@
-# Contributing
+# Contributing to NeuroWealth Frontend
 
-## Package manager
+> Goal: onboard a new contributor in under five minutes.
 
-This repo uses **Yarn 1** (`yarn.lock` is canonical). Enable Corepack or install
-Yarn 1.22.x, then:
+## Requirements
+
+| Tool | Version |
+|------|---------|
+| Node.js | **≥ 20** (matches `engines` in `package.json`) |
+| Yarn | **1.22.x** — use Corepack (`corepack enable`) or install directly |
+
+Do not commit `package-lock.json` or `npm-shrinkwrap.json`. `yarn.lock` is the canonical lockfile.
+
+## Getting started
 
 ```bash
-yarn install
-yarn lint
-yarn typecheck
+yarn install   # installs deps and activates Husky pre-commit hook
+yarn dev       # start local dev server at http://localhost:3000
 ```
 
-Do not commit `package-lock.json` or `npm-shrinkwrap.json`.
+Copy `.env.example` to `.env.local` and fill in any values you need.
+The app runs in demo/mock mode with no backend required by default.
 
-## Hook imports (auth + wallet)
+## Commands
 
-Use the `@/contexts` barrel as the single public surface for auth and wallet hooks/providers.
+| Command | What it does |
+|---------|-------------|
+| `yarn dev` | Start dev server |
+| `yarn build` | Production build |
+| `yarn typecheck` | TypeScript — no emit |
+| `yarn lint` | ESLint via `next lint` (CI gate) |
+| `yarn test` | Node test runner — `src/**/*.test.ts` |
+| `yarn validate:env` | Validate env vars against Zod schemas |
+| `yarn analyze` | Bundle analysis (writes to `.next/analyze/`) |
 
-Allowed:
-- `import { useAuth, useWallet, useWalletConfig, AuthProvider, WalletProvider } from "@/contexts";`
+## CI gates
 
-Disallowed:
-- `@/context/AuthContext`
-- `@/contexts/AuthContext`
-- `@/contexts/WalletProvider`
+Every PR runs `frontend-ci.yml` on GitHub Actions:
 
-This is enforced in ESLint via `no-restricted-imports`.
+1. `yarn typecheck`
+2. `yarn test`
+3. `yarn lint`
+4. `yarn build`
 
-## Optional: pre-commit lint with lint-staged + Husky
+All four must pass before merge. If CI is red, fix it before requesting review.
 
-`yarn lint` is the source of truth and runs in CI. Husky and lint-staged are
-committed so hooks install automatically after `yarn install` (via the
-`prepare` script). The hook is **optional** in practice — skip it when needed.
+## Branch rules
 
-Staged-file rules live in `.lintstagedrc` at the repo root (ESLint via
-`next lint --fix --file` on changed sources only).
+- Target branch for PRs: **`main`**
+- Branch from `main`; keep branches short-lived
+- Name pattern: `type/short-description` — e.g. `fix/safe-area-nav`, `feat/onboarding-flow`
+- Do not push directly to `main` or `master`
 
-### Skipping the hook
+## PR checklist
+
+Before opening a PR, confirm:
+
+- [ ] `yarn typecheck` passes locally
+- [ ] `yarn lint` passes locally (or lint-staged ran on your staged files)
+- [ ] `yarn test` passes locally
+- [ ] `yarn build` succeeds (required if you touched routes, layouts, or env vars)
+- [ ] New behaviour is verifiable — attach screenshots, a test, or written QA steps
+- [ ] No new duplicate abstractions introduced without a one-line comment explaining why
+- [ ] `.env.example` updated if you added or renamed an env variable
+
+## Code conventions
+
+**Import paths** — use the `@/` alias, never relative `../../` imports across feature boundaries.
+
+**Auth and wallet hooks** — import only from the `@/contexts` barrel:
+
+```ts
+// ✅ correct
+import { useAuth, useWallet, AuthProvider, WalletProvider } from "@/contexts";
+
+// ❌ wrong — these are enforced by ESLint no-restricted-imports
+import { useAuth } from "@/contexts/AuthContext";
+import { WalletProvider } from "@/contexts/WalletProvider";
+```
+
+**`data-qa` attributes** — kebab-case, describe the flow and action:
+`landing-primary-cta-button`, `wallet-connect-button`, `transaction-submit-button`.
+
+**Design tokens** — add new color/spacing tokens to `src/app/globals.css` (`@theme`),
+not to `tailwind.config.ts`.
+
+## Optional: pre-commit lint (lint-staged + Husky)
+
+`yarn lint` is the CI gate. Husky is already wired up — after `yarn install` the
+pre-commit hook runs `yarn lint-staged`, linting only your staged files.
+
+Skip the hook when needed:
 
 ```bash
 git commit --no-verify -m "wip: skip pre-commit"
 ```
 
-### Why not mandatory?
+See the [Dependency note](#dependency-note) below — no extra install required.
 
-Mandatory hooks slow down contributors on large changesets and can block
-emergency commits. CI (`yarn lint`) is the enforced gate; run `yarn typecheck`
-locally before pushing when you change types.
+<details>
+<summary>Verifying the hook (QA steps)</summary>
+
+1. `yarn install` — the `prepare` script activates Husky automatically.
+2. Stage a `.ts` or `.tsx` file: `git add src/some-file.ts`
+3. `git commit -m "test: lint-staged check"`
+4. Expected: ESLint runs on staged files only. Auto-fixable issues are corrected
+   and re-staged; unfixable violations abort the commit with a clear error.
+5. Confirm CI still passes independently — `yarn lint` runs the full repo.
+
+</details>
+
+### Dependency note
+
+`husky` and `lint-staged` are in `devDependencies` — no separate install. They
+do not run in CI and have zero production bundle impact.
+
+## Issues and backlog
+
+| Resource | Purpose |
+|----------|---------|
+| [Issue templates](/.github/ISSUE_TEMPLATE/) | Bug, Feature, Frontend task, Design proposal |
+| [Backlog](/.github/backlog/) | 50 scoped work items with YAML frontmatter |
+| [Audit queue](/.github/audit-issues/) | 30 engineering/platform issues — auth, CI, perf, docs |
+| [`.github/ISSUES.md`](/.github/ISSUES.md) | Index and label guide |
+
+When filing a new issue, use the closest template. Add labels that match the
+`labels:` frontmatter in backlog and audit files (e.g. `frontend`, `priority-high`).

--- a/docs/env.md
+++ b/docs/env.md
@@ -26,7 +26,7 @@ Set these in `.env.local`:
 | `NEXT_PUBLIC_API_URL` | Yes | Base URL for internal Next.js `/api/*` routes |
 | `NEXT_PUBLIC_STELLAR_NETWORK` | Optional | Network name — `testnet` or `mainnet` (default: `testnet`) |
 | `NEXT_PUBLIC_STELLAR_HORIZON_URL` | Optional | Stellar Horizon endpoint (overrides the SDK default) |
-| `NEXT_PUBLIC_DEMO_SEED` | Optional | Integer seed for deterministic mock data in local dev |
+| `NEXT_PUBLIC_DEMO_SEED` | Optional | String seed for deterministic mock data in demos and visual baselines. Any non-empty string activates the Mulberry32 seeded PRNG; unset or empty uses `Math.random()`. See `docs/qa/demo-seed.md`. |
 
 Example `.env.local`:
 
@@ -35,7 +35,7 @@ NEXT_PUBLIC_WEBHOOK_URL=http://localhost:2000
 NEXT_PUBLIC_API_URL=http://localhost:3001
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
 NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
-NEXT_PUBLIC_DEMO_SEED=42
+NEXT_PUBLIC_DEMO_SEED=demo-seed-2026
 ```
 
 ### Server-only (Node runtime)

--- a/docs/qa/demo-seed.md
+++ b/docs/qa/demo-seed.md
@@ -1,0 +1,151 @@
+# Demo seed — deterministic mock data
+
+**Issue:** #420  
+**Module:** `src/lib/seeded-rng.ts`  
+**Env var:** `NEXT_PUBLIC_DEMO_SEED`
+
+---
+
+## Why this exists
+
+Mock data generated with `Math.random()` changes on every run, making visual
+baseline screenshots and demo recordings flaky. Setting `NEXT_PUBLIC_DEMO_SEED`
+activates a deterministic PRNG (Mulberry32) so every chart value, allocation
+amount, transaction hash, and simulated success/failure outcome is identical
+across runs as long as the seed string is the same.
+
+---
+
+## How it works
+
+`src/lib/seeded-rng.ts` exports three functions used by every mock data module:
+
+| Function | Description |
+|----------|-------------|
+| `random()` | Returns a float in `[0, 1)` |
+| `randomInt(min, max)` | Returns an integer in `[min, max)` |
+| `randomItem(array)` | Returns one element from the array |
+
+When `NEXT_PUBLIC_DEMO_SEED` is set, all three use a Mulberry32 PRNG seeded
+from a DJB2 hash of the string value. When unset or empty, they fall back to
+`Math.random()` so normal dev behaviour is unchanged.
+
+The seed is a `NEXT_PUBLIC_*` variable — it is inlined into the browser bundle
+at build time by Next.js and is also available as `process.env.NEXT_PUBLIC_DEMO_SEED`
+on the server. It contains no secrets.
+
+---
+
+## Enabling the seed
+
+### Local development
+
+Add to `.env.local`:
+
+```bash
+NEXT_PUBLIC_DEMO_SEED=demo-seed-2026
+```
+
+Then restart the dev server:
+
+```bash
+yarn dev
+```
+
+### Visual baseline capture
+
+The server must already be running with the seed set before calling the script:
+
+```bash
+# Terminal 1
+NEXT_PUBLIC_DEMO_SEED=demo-seed-2026 yarn dev
+
+# Terminal 2
+yarn qa:visual-baseline
+```
+
+The captured `manifest.json` records the `demoSeed` field so baselines are
+traceable. If `NEXT_PUBLIC_DEMO_SEED` was unset when the script ran, the
+manifest contains `"demoSeed": null` and a warning is printed.
+
+### Toggling off
+
+Remove the variable or leave it empty to restore random behaviour:
+
+```bash
+NEXT_PUBLIC_DEMO_SEED=
+```
+
+---
+
+## Where randomness is consumed
+
+All of these modules route through `seeded-rng` and become deterministic when
+the seed is set:
+
+| Module | What it randomises |
+|--------|--------------------|
+| `src/lib/mock-chart-data.ts` | Portfolio value noise, yield bars, allocation slices, benchmark comparison |
+| `src/lib/mock-services.ts` | ~15% simulated failure rate, auth token/user IDs |
+| `src/lib/mock-auth.ts` | Session token and user ID suffixes |
+| `src/lib/mock-audit.ts` | Audit event IDs |
+| `src/lib/transactions.ts` | Transaction reference suffix |
+| `src/lib/service-layer/base-adapter.ts` | Request IDs, simulated latency range, failure rate |
+| `src/lib/service-layer/portfolio-service.ts` | Portfolio value history, simulated 24-hour changes |
+| `src/lib/service-layer/strategy-service.ts` | Strategy APY noise |
+| `src/lib/service-layer/transaction-service.ts` | Initial mock tx hashes, 90% success simulation, completed tx hash |
+| `src/lib/service-layer/auth-service.ts` | Auth token generation |
+| `src/lib/logger.ts` | Log entry IDs |
+| `src/lib/analytics.ts` | Analytics event IDs |
+| `src/components/onboarding/steps/WalletConnectStep.tsx` | 90% connection success simulation |
+| `src/components/onboarding/steps/FirstDepositStep.tsx` | 95% deposit success simulation |
+| `src/components/help/SupportForm.tsx` | Support reference ID suffix |
+| `src/components/avatar/FileUpload.tsx` | Upload progress increment steps |
+
+---
+
+## Sandbox toggle
+
+The QA Sandbox at `/dashboard/sandbox` controls UI state scenarios
+(success / empty / loading / partial-failure / timeout) independently of the
+seed. The seed only affects *data values*, not *which scenario is shown*.
+
+To combine both for a fully reproducible demo environment:
+
+1. Set `NEXT_PUBLIC_DEMO_SEED=demo-seed-2026` in `.env.local`
+2. Restart `yarn dev`
+3. Navigate to `/dashboard/sandbox` and select "All Success"
+4. Screenshots will now show identical values across repeated captures
+
+---
+
+## Unit tests
+
+`src/lib/seeded-rng.test.ts` verifies:
+
+- Values stay in `[0, 1)` range
+- Same seed → identical sequence across two separate calls to `reseed()`
+- Different seeds → different sequences
+- `reseed(null)` restores non-deterministic behaviour
+- `randomInt()` always returns integers in the specified range
+- `randomItem()` always returns an element from the input array
+
+Run with:
+
+```bash
+yarn test
+```
+
+---
+
+## QA steps for PR verification
+
+1. Add `NEXT_PUBLIC_DEMO_SEED=demo-seed-2026` to `.env.local` and start `yarn dev`.
+2. Open `/dashboard` — note the portfolio balance and chart values.
+3. Hard-refresh the page (`Cmd+Shift+R` / `Ctrl+Shift+R`). Values must be identical.
+4. Open `/dashboard/strategy` — APY chart values must be identical across reloads.
+5. Open `/dashboard/transactions`, submit a deposit — note the reference ID suffix.
+6. Hard-refresh and repeat step 5 — the suffix must match step 5's value.
+7. Remove `NEXT_PUBLIC_DEMO_SEED` from `.env.local`, restart the server, and reload
+   the dashboard. Values should differ from those in step 2 (unseeded = random).
+8. Run `yarn test` — all `seeded-rng` tests must pass.

--- a/scripts/capture-visual-baselines.mjs
+++ b/scripts/capture-visual-baselines.mjs
@@ -12,6 +12,19 @@ const OUTPUT_DIR = path.resolve(
   DATE_STAMP,
 );
 
+// ─── Demo seed ────────────────────────────────────────────────────────────────
+// NEXT_PUBLIC_DEMO_SEED must be set in the environment of the *server* process
+// that is already running (yarn dev / yarn start) before this script is called.
+// The browser-side RNG is initialised from the inlined env var at build time,
+// so the value baked into the running server is what matters here.
+//
+// Recommended workflow:
+//   NEXT_PUBLIC_DEMO_SEED=demo-seed-2026 yarn dev
+//   yarn qa:visual-baseline
+//
+// The seed value is written into the manifest so baselines are traceable.
+const DEMO_SEED = process.env.NEXT_PUBLIC_DEMO_SEED ?? "";
+
 const DESKTOP_VIEWPORT = {
   name: "desktop-1440x900",
   options: {
@@ -483,6 +496,16 @@ async function captureScenario(browser, viewport, scenario) {
 async function main() {
   await ensureDir(OUTPUT_DIR);
 
+  if (!DEMO_SEED) {
+    console.warn(
+      "⚠  NEXT_PUBLIC_DEMO_SEED is not set. Mock chart data will be random " +
+      "and baselines may differ between runs.\n" +
+      "   Recommended: NEXT_PUBLIC_DEMO_SEED=demo-seed-2026 yarn dev, then re-run this script.",
+    );
+  } else {
+    console.log(`ℹ  Demo seed: "${DEMO_SEED}" — mock data will be deterministic.`);
+  }
+
   const browser = await chromium.launch({
     headless: true,
   });
@@ -518,6 +541,7 @@ async function main() {
       {
         capturedAt: new Date().toISOString(),
         baseUrl: BASE_URL,
+        demoSeed: DEMO_SEED || null,
         namingConvention:
           "<date>__<viewport>__<page>__<state>.png",
         scenarioCount: scenarios.length,

--- a/src/app/dashboard/settings/notifications/page.tsx
+++ b/src/app/dashboard/settings/notifications/page.tsx
@@ -319,6 +319,7 @@ export default function NotificationsSettingsPage() {
       ) : (
         <div
           className="sticky bottom-6 z-40 flex flex-col gap-3 rounded-2xl border border-slate-700/60 bg-slate-950/90 p-4 shadow-[0_8px_32px_rgba(0,0,0,0.45)] backdrop-blur md:flex-row md:items-center md:justify-between"
+          style={{ paddingBottom: "max(1rem, calc(1rem + var(--sai-bottom, 0px)))" }}
           role="group"
           aria-label="Notification settings actions"
         >

--- a/src/app/dashboard/settings/preferences/page.tsx
+++ b/src/app/dashboard/settings/preferences/page.tsx
@@ -475,6 +475,8 @@ export default function PreferencesPage() {
           justify-content: space-between;
           gap: 12px;
           padding: 14px 20px;
+          /* #423: add safe-area-inset-bottom so buttons clear the home indicator */
+          padding-bottom: max(14px, calc(14px + var(--sai-bottom, 0px)));
           background: rgba(2, 6, 23, 0.88);
           backdrop-filter: blur(16px);
           border: 1px solid rgba(148, 163, 184, 0.15);

--- a/src/app/dashboard/settings/security/page.tsx
+++ b/src/app/dashboard/settings/security/page.tsx
@@ -504,6 +504,8 @@ export default function SecurityPage() {
           justify-content: space-between;
           gap: 12px;
           padding: 14px 20px;
+          /* #423: add safe-area-inset-bottom so buttons clear the home indicator */
+          padding-bottom: max(14px, calc(14px + var(--sai-bottom, 0px)));
           background: rgba(2, 6, 23, 0.88);
           backdrop-filter: blur(16px);
           border: 1px solid rgba(148, 163, 184, 0.15);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,14 @@
 :root {
   --font-sans: Inter, "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
   --font-mono: "Roboto Mono", "IBM Plex Mono", "SFMono-Regular", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  /* Safe-area inset tokens — require viewport-fit=cover (set in layout.tsx).
+   * Use var(--sai-bottom) anywhere a fixed/sticky element sits at the bottom
+   * of the screen so it clears the home indicator on notched iOS devices.
+   * Falls back to 0px on devices without a notch. */
+  --sai-top: env(safe-area-inset-top, 0px);
+  --sai-right: env(safe-area-inset-right, 0px);
+  --sai-bottom: env(safe-area-inset-bottom, 0px);
+  --sai-left: env(safe-area-inset-left, 0px);
   --positive: #10b981;
   --negative: #ef4444;
   --neutral: #94a3b8;
@@ -105,3 +113,17 @@ html.theme-transitioning * {
     background-position: -200% 0;
   }
 }
+
+/**
+ * Safe-area utility classes — #423
+ * Apply to any element that must clear the home indicator / notch.
+ * These mirror what Tailwind's safe-area plugin would generate but keep us
+ * plugin-free. The var(--sai-*) tokens are defined in :root above.
+ *
+ * Usage: add class="pb-safe" (or combine: "pb-safe pt-safe") on any
+ * fixed/sticky element sitting at a screen edge.
+ */
+.pb-safe { padding-bottom: var(--sai-bottom); }
+.pt-safe { padding-top: var(--sai-top); }
+.pl-safe { padding-left: var(--sai-left); }
+.pr-safe { padding-right: var(--sai-right); }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -686,6 +686,8 @@ export default function ProfilePage() {
           border: 1px solid rgba(148, 163, 184, 0.15);
           border-radius: 12px;
           padding: 14px 20px;
+          /* #423: add safe-area-inset-bottom so buttons clear the home indicator */
+          padding-bottom: max(14px, calc(14px + var(--sai-bottom, 0px)));
           display: flex;
           align-items: center;
           justify-content: space-between;

--- a/src/components/avatar/FileUpload.tsx
+++ b/src/components/avatar/FileUpload.tsx
@@ -2,6 +2,7 @@
 
 import React, { useRef, useState, useCallback, useId } from "react";
 import Image from "next/image";
+import { random } from "@/lib/seeded-rng";
 
 export interface UploadFile {
   id: string;
@@ -29,7 +30,7 @@ function mockUpload(
   let pct = 0;
   const tick = () => {
     if (signal.aborted) return;
-    pct = Math.min(100, pct + Math.random() * 18 + 4);
+    pct = Math.min(100, pct + random() * 18 + 4);
     onProgress(fileId, Math.round(pct));
     if (pct < 100) setTimeout(tick, 120);
     else onDone(fileId);

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -52,10 +52,14 @@ export default function DashboardShell({ children }: DashboardShellProps) {
           pt-16          /* clear fixed header (64px) */
           sm:pl-14       /* clear collapsed tablet sidebar (56px) */
           lg:pl-64       /* clear full desktop sidebar (256px) */
-          pb-20 sm:pb-0  /* clear mobile bottom nav on xs only */
           min-h-screen
           bg-app-bg
         "
+        style={{
+          // On mobile (<640px): clear fixed bottom nav (80px) plus home indicator.
+          // On sm+: bottom nav is hidden so no extra clearance needed.
+          paddingBottom: "max(5rem, calc(5rem + var(--sai-bottom, 0px)))",
+        }}
         id={MAIN_CONTENT_LANDMARK_ID}
         tabIndex={-1}
         aria-labelledby={DASHBOARD_ROUTE_TITLE_ID}

--- a/src/components/help/SupportForm.tsx
+++ b/src/components/help/SupportForm.tsx
@@ -21,6 +21,7 @@ import {
   type ValidationErrors,
   createDebouncedAsyncCheck,
 } from "@/lib/form-validation";
+import { random } from "@/lib/seeded-rng";
 
 interface FormData {
   name: string;
@@ -112,8 +113,8 @@ export default function SupportForm() {
 
   const generateReferenceId = () => {
     const timestamp = Date.now().toString(36);
-    const random = Math.random().toString(36).slice(2, 7);
-    return `NW-${timestamp}-${random}`.toUpperCase();
+    const rand = random().toString(36).slice(2, 7);
+    return `NW-${timestamp}-${rand}`.toUpperCase();
   };
 
   const validateTransactionIdAsync = async (value: string) => {

--- a/src/components/onboarding/steps/FirstDepositStep.tsx
+++ b/src/components/onboarding/steps/FirstDepositStep.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
+import { random } from '@/lib/seeded-rng';
 
 interface FirstDepositStepProps {
   onNext: () => void;
@@ -69,7 +70,7 @@ export default function FirstDepositStep({ onNext, onSkip, onBack }: FirstDeposi
       await new Promise(resolve => setTimeout(resolve, 3000));
       
       // Simulate random success/failure (95% success rate)
-      if (Math.random() > 0.05) {
+      if (random() > 0.05) {
         // Save deposit record
         const depositRecord = {
           amount: finalAmount,

--- a/src/components/onboarding/steps/WalletConnectStep.tsx
+++ b/src/components/onboarding/steps/WalletConnectStep.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
+import { random } from '@/lib/seeded-rng';
 
 interface WalletConnectStepProps {
   onNext: () => void;
@@ -46,7 +47,7 @@ export default function WalletConnectStep({ onNext, onSkip, onBack }: WalletConn
       await new Promise(resolve => setTimeout(resolve, 2000));
       
       // Simulate random success/failure (90% success rate)
-      if (Math.random() > 0.1) {
+      if (random() > 0.1) {
         // Connection successful
         onNext();
       } else {

--- a/src/components/transactions/transaction-flow.module.css
+++ b/src/components/transactions/transaction-flow.module.css
@@ -499,7 +499,8 @@
   align-items: center;
   position: sticky;
   bottom: 0;
-  padding: 14px 0 0;
+  /* #423: clear home indicator on notched iOS when sticky at bottom of scroll container */
+  padding: 14px 0 var(--sai-bottom, 0px);
   background: linear-gradient(180deg, rgba(255, 255, 255, 0), var(--sticky-bg) 34%);
 }
 
@@ -674,6 +675,6 @@
   }
 
   .actionBar {
-    padding-bottom: 8px;
+    padding-bottom: max(8px, calc(8px + var(--sai-bottom, 0px)));
   }
 }

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -88,9 +88,12 @@ export function Drawer({
           {children}
         </div>
 
-        {/* Footer — 16px padding */}
+        {/* Footer — 16px padding + safe-area-inset-bottom for notched devices (#423) */}
         {footer && (
-      <div className="px-4 py-4 border-t border-zinc-200 dark:border-zinc-700 flex justify-end gap-3">
+      <div
+        className="px-4 pt-4 border-t border-zinc-200 dark:border-zinc-700 flex justify-end gap-3"
+        style={{ paddingBottom: "max(1rem, calc(1rem + var(--sai-bottom, 0px)))" }}
+      >
             {footer}
           </div>
         )}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -90,9 +90,12 @@ export function Modal({
           {children}
         </div>
 
-        {/* Footer — 16px padding */}
+        {/* Footer — 16px padding + safe-area-inset-bottom for notched devices (#423) */}
         {footer && (
-          <div className="px-4 py-4 border-t border-zinc-200 dark:border-zinc-700 flex justify-end gap-3">
+          <div
+            className="px-4 pt-4 border-t border-zinc-200 dark:border-zinc-700 flex justify-end gap-3"
+            style={{ paddingBottom: "max(1rem, calc(1rem + var(--sai-bottom, 0px)))" }}
+          >
         {footer}
           </div>
         )}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,5 @@
 import { logger, scrubPII } from "./logger";
+import { random } from "./seeded-rng";
 
 export interface AnalyticsEvent {
   id: string;
@@ -26,7 +27,7 @@ export const analytics = {
   track: (name: string, params?: Record<string, any>) => {
     const safeParams = params ? scrubPII(params) : undefined;
     const event: AnalyticsEvent = {
-      id: Math.random().toString(36).substring(7),
+      id: random().toString(36).substring(7),
       name,
       timestamp: new Date().toISOString(),
       params: safeParams,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,3 +1,5 @@
+import { random } from "./seeded-rng";
+
 export type LogLevel = "info" | "warn" | "error";
 
 export interface LogEntry {
@@ -46,7 +48,7 @@ export const scrubPII = (data: any): any => {
 };
 
 const createEntry = (level: LogLevel, message: string, context?: any): LogEntry => ({
-  id: Math.random().toString(36).substring(7),
+  id: random().toString(36).substring(7),
   timestamp: new Date().toISOString(),
   level,
   message,

--- a/src/lib/seeded-rng.test.ts
+++ b/src/lib/seeded-rng.test.ts
@@ -1,0 +1,153 @@
+/**
+ * seeded-rng.test.ts
+ *
+ * Verifies that the seeded RNG is deterministic when a seed is provided
+ * and reverts to non-deterministic behaviour when the seed is cleared.
+ *
+ * Run with: yarn test (TZ=UTC node --import tsx --test "src/**\/*.test.ts")
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { random, randomInt, randomItem, reseed } from "./seeded-rng";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function collectSequence(n: number): number[] {
+  return Array.from({ length: n }, () => random());
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("seeded-rng", () => {
+  // Restore whatever seed was active before these tests ran.
+  const originalSeed = process.env.NEXT_PUBLIC_DEMO_SEED ?? null;
+  after(() => reseed(originalSeed));
+
+  describe("random()", () => {
+    it("produces values in [0, 1)", () => {
+      reseed("test");
+      for (let i = 0; i < 200; i++) {
+        const v = random();
+        assert.ok(v >= 0, `value ${v} is below 0`);
+        assert.ok(v < 1, `value ${v} is >= 1`);
+      }
+    });
+
+    it("is deterministic: same seed → same sequence", () => {
+      reseed("demo-seed-2026");
+      const first = collectSequence(50);
+
+      reseed("demo-seed-2026");
+      const second = collectSequence(50);
+
+      assert.deepStrictEqual(first, second, "sequences must be identical for the same seed");
+    });
+
+    it("differs across seeds", () => {
+      reseed("seed-a");
+      const seqA = collectSequence(20);
+
+      reseed("seed-b");
+      const seqB = collectSequence(20);
+
+      assert.notDeepStrictEqual(seqA, seqB, "different seeds must produce different sequences");
+    });
+
+    it("falls back to Math.random when seed is null (non-deterministic)", () => {
+      reseed(null);
+      // Two runs of 20 should almost certainly differ (probability of
+      // collision is negligibly small with floating-point values).
+      const first = collectSequence(20);
+      const second = collectSequence(20);
+      // We can't assert inequality with certainty, but we can check the
+      // values are in range and the call doesn't throw.
+      for (const v of [...first, ...second]) {
+        assert.ok(v >= 0 && v < 1, `unseeded value ${v} out of range`);
+      }
+    });
+  });
+
+  describe("randomInt(min, max)", () => {
+    before(() => reseed("test-int"));
+
+    it("always returns integers in [min, max)", () => {
+      for (let i = 0; i < 500; i++) {
+        const v = randomInt(5, 15);
+        assert.ok(Number.isInteger(v), `${v} is not an integer`);
+        assert.ok(v >= 5, `${v} < min (5)`);
+        assert.ok(v < 15, `${v} >= max (15)`);
+      }
+    });
+
+    it("is deterministic with the same seed", () => {
+      reseed("test-int");
+      const first = Array.from({ length: 30 }, () => randomInt(0, 100));
+
+      reseed("test-int");
+      const second = Array.from({ length: 30 }, () => randomInt(0, 100));
+
+      assert.deepStrictEqual(first, second);
+    });
+
+    it("works when min equals max - 1 (single possible value)", () => {
+      reseed("edge");
+      for (let i = 0; i < 20; i++) {
+        assert.strictEqual(randomInt(7, 8), 7);
+      }
+    });
+  });
+
+  describe("randomItem(array)", () => {
+    before(() => reseed("test-item"));
+
+    it("always returns an element that exists in the array", () => {
+      const arr = ["a", "b", "c", "d", "e"];
+      for (let i = 0; i < 200; i++) {
+        assert.ok(arr.includes(randomItem(arr)), "returned value not in array");
+      }
+    });
+
+    it("is deterministic with the same seed", () => {
+      const arr = [10, 20, 30, 40, 50];
+
+      reseed("test-item");
+      const first = Array.from({ length: 20 }, () => randomItem(arr));
+
+      reseed("test-item");
+      const second = Array.from({ length: 20 }, () => randomItem(arr));
+
+      assert.deepStrictEqual(first, second);
+    });
+  });
+
+  describe("reseed()", () => {
+    it("resets the sequence mid-stream", () => {
+      reseed("mid-stream");
+      // Consume some values to advance the state.
+      collectSequence(10);
+      const mid = random();
+
+      // Reseed to the same value and consume the same number.
+      reseed("mid-stream");
+      collectSequence(10);
+      const midAgain = random();
+
+      assert.strictEqual(mid, midAgain, "reseed must restart the sequence");
+    });
+
+    it("switching seeds produces independent sequences", () => {
+      reseed("alpha");
+      const alpha = collectSequence(5);
+
+      reseed("beta");
+      const beta = collectSequence(5);
+
+      reseed("alpha");
+      const alphaAgain = collectSequence(5);
+
+      assert.deepStrictEqual(alpha, alphaAgain, "alpha sequences must match");
+      assert.notDeepStrictEqual(alpha, beta, "alpha and beta must differ");
+    });
+  });
+});

--- a/src/lib/seeded-rng.ts
+++ b/src/lib/seeded-rng.ts
@@ -1,57 +1,99 @@
 /**
- * Seeded Random Number Generator
- * 
- * Provides deterministic random numbers for demos and testing.
- * Controlled by NEXT_PUBLIC_DEMO_SEED environment variable.
- * When not set, falls back to Math.random() for normal operation.
+ * seeded-rng.ts — Deterministic random number generator
+ *
+ * Controlled by NEXT_PUBLIC_DEMO_SEED (public env var, safe to expose).
+ * When the variable is set, every call to random() / randomInt() /
+ * randomItem() produces the same sequence across server and browser,
+ * making mock data, chart values, and demo screenshots reproducible.
+ *
+ * When NEXT_PUBLIC_DEMO_SEED is unset the module falls back to
+ * Math.random() so normal development behaviour is unchanged.
+ *
+ * Algorithm: Mulberry32 — a fast, high-quality 32-bit PRNG seeded
+ * from a DJB2-style hash of the string seed value.
+ *
+ * Usage
+ * ─────
+ *   import { random, randomInt, randomItem } from "@/lib/seeded-rng";
+ *
+ *   random()              → number in [0, 1)
+ *   randomInt(0, 100)     → integer in [0, 100)
+ *   randomItem(["a","b"]) → one element
+ *
+ * Toggling the seed
+ * ─────────────────
+ *   # .env.local — stable demo/screenshot output
+ *   NEXT_PUBLIC_DEMO_SEED=demo-seed-2026
+ *
+ *   # Unset or empty — normal random behaviour
+ *   NEXT_PUBLIC_DEMO_SEED=
+ *
+ * Resetting mid-test
+ * ──────────────────
+ *   import { reseed } from "@/lib/seeded-rng";
+ *   reseed("my-test-seed");   // deterministic from this point
+ *   reseed(null);             // back to Math.random()
  */
 
+/** Internal PRNG state — null means "use Math.random()". */
 let rng: (() => number) | null = null;
 
-// Simple seeded RNG using the Mulberry32 algorithm
-function mulberry32(a: number): () => number {
-  return function() {
-    let t = a += 0x6D2B79F5;
-    t = Math.imul(t ^ (t >>> 15), t | 1);
+// ─── Mulberry32 algorithm ─────────────────────────────────────────────────────
+
+function mulberry32(seed: number): () => number {
+  let s = seed;
+  return function () {
+    s += 0x6d2b79f5;
+    let t = Math.imul(s ^ (s >>> 15), s | 1);
     t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   };
 }
 
-// Initialize RNG from environment variable if set
-function initializeRNG(): void {
-  const seed = process.env.NEXT_PUBLIC_DEMO_SEED;
+// ─── String → numeric seed (DJB2 hash) ───────────────────────────────────────
+
+function hashSeed(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) {
+    h = Math.imul(31, h) + seed.charCodeAt(i);
+    h |= 0; // keep 32-bit
+  }
+  return Math.abs(h);
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Re-initialize the PRNG with a new seed string, or pass `null` to
+ * revert to Math.random().  Useful in unit tests to get a fresh,
+ * predictable sequence without reloading the module.
+ */
+export function reseed(seed: string | null): void {
   if (seed) {
-    // Convert string seed to numeric hash
-    let hash = 0;
-    for (let i = 0; i < seed.length; i++) {
-      const char = seed.charCodeAt(i);
-      hash = ((hash << 5) - hash) + char;
-      hash = hash & hash; // Convert to 32bit integer
-    }
-    rng = mulberry32(Math.abs(hash));
+    rng = mulberry32(hashSeed(seed));
   } else {
-    rng = null; // Use Math.random()
+    rng = null;
   }
 }
 
-// Get a random number between 0 and 1
+/** Returns a pseudo-random number in [0, 1). */
 export function random(): number {
-  if (rng === null) {
-    return Math.random();
-  }
-  return rng();
+  return rng !== null ? rng() : Math.random();
 }
 
-// Get a random integer between min (inclusive) and max (exclusive)
+/** Returns a pseudo-random integer in [min, max). */
 export function randomInt(min: number, max: number): number {
   return Math.floor(random() * (max - min)) + min;
 }
 
-// Get a random item from an array
+/** Returns a random element from `array`. */
 export function randomItem<T>(array: T[]): T {
   return array[Math.floor(random() * array.length)];
 }
 
-// Initialize on module load
-initializeRNG();
+// ─── Module initialisation ────────────────────────────────────────────────────
+// Runs once when the module is first imported.
+// NEXT_PUBLIC_DEMO_SEED is inlined at build time by Next.js for client
+// bundles and available as process.env.NEXT_PUBLIC_DEMO_SEED on the server.
+
+reseed(process.env.NEXT_PUBLIC_DEMO_SEED || null);

--- a/src/lib/service-layer/auth-service.ts
+++ b/src/lib/service-layer/auth-service.ts
@@ -1,5 +1,6 @@
 import { BaseAdapter } from "./base-adapter";
 import { ServiceResponse } from "./types";
+import { random } from "../seeded-rng";
 
 export interface LoginCredentials {
   email: string;
@@ -159,7 +160,7 @@ export class AuthService extends BaseAdapter {
   }
 
   private generateToken(): string {
-    return `token_${Date.now()}_${Math.random().toString(36).substr(2, 16)}`;
+    return `token_${Date.now()}_${random().toString(36).substr(2, 16)}`;
   }
 }
 

--- a/src/lib/service-layer/base-adapter.ts
+++ b/src/lib/service-layer/base-adapter.ts
@@ -5,6 +5,7 @@ import {
   ServiceConfig,
   ServiceErrorCode,
 } from "./types";
+import { random, randomInt as seededRandomInt } from "../seeded-rng";
 
 const DEFAULT_CONFIG: ServiceConfig = {
   timeout: 10000,
@@ -17,11 +18,11 @@ const DEFAULT_CONFIG: ServiceConfig = {
 };
 
 function generateRequestId(): string {
-  return `req_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  return `req_${Date.now()}_${random().toString(36).substr(2, 9)}`;
 }
 
 function randomInRange(min: number, max: number): number {
-  return Math.floor(Math.random() * (max - min + 1)) + min;
+  return seededRandomInt(min, max + 1);
 }
 
 async function simulateLatency(config: ServiceConfig): Promise<void> {
@@ -34,7 +35,7 @@ async function simulateLatency(config: ServiceConfig): Promise<void> {
 function shouldSimulateFailure(config: ServiceConfig): boolean {
   if (!config.simulateFailure) return false;
   const failureRate = config.failureRate || DEFAULT_CONFIG.failureRate!;
-  return Math.random() < failureRate;
+  return random() < failureRate;
 }
 
 function createServiceError(

--- a/src/lib/service-layer/portfolio-service.ts
+++ b/src/lib/service-layer/portfolio-service.ts
@@ -1,5 +1,6 @@
 import { BaseAdapter } from "./base-adapter";
 import { ServiceResponse, PaginatedResponse, PaginationParams } from "./types";
+import { random } from "../seeded-rng";
 
 export interface Portfolio {
   id: string;
@@ -73,7 +74,7 @@ export class PortfolioService extends BaseAdapter {
     const history: PortfolioHistory[] = [];
     for (let i = 30; i >= 0; i--) {
       const date = new Date(Date.now() - i * 24 * 60 * 60 * 1000);
-      const value = 10000 + Math.random() * 5000;
+      const value = 10000 + random() * 5000;
       history.push({
         date: date.toISOString(),
         value,
@@ -128,16 +129,16 @@ export class PortfolioService extends BaseAdapter {
       }
 
       // Simulate value changes
-      portfolio.totalValue = portfolio.totalValue * (1 + (Math.random() - 0.5) * 0.02);
-      portfolio.totalValueChange24h = portfolio.totalValue * (Math.random() - 0.5) * 0.05;
+      portfolio.totalValue = portfolio.totalValue * (1 + (random() - 0.5) * 0.02);
+      portfolio.totalValueChange24h = portfolio.totalValue * (random() - 0.5) * 0.05;
       portfolio.totalValueChange24hPercent = (portfolio.totalValueChange24h / portfolio.totalValue) * 100;
       portfolio.updatedAt = new Date().toISOString();
 
       // Update asset values
       portfolio.assets = portfolio.assets.map((asset) => ({
         ...asset,
-        value: asset.value * (1 + (Math.random() - 0.5) * 0.03),
-        valueChange24h: asset.value * (Math.random() - 0.5) * 0.05,
+        value: asset.value * (1 + (random() - 0.5) * 0.03),
+        valueChange24h: asset.value * (random() - 0.5) * 0.05,
         valueChange24hPercent: (asset.valueChange24h / asset.value) * 100,
       }));
 

--- a/src/lib/service-layer/strategy-service.ts
+++ b/src/lib/service-layer/strategy-service.ts
@@ -1,5 +1,6 @@
 import { BaseAdapter } from "./base-adapter";
 import { ServiceResponse, PaginatedResponse, PaginationParams } from "./types";
+import { random } from "../seeded-rng";
 
 export interface Strategy {
   id: string;
@@ -107,7 +108,7 @@ export class StrategyService extends BaseAdapter {
       const performance: StrategyPerformance[] = [];
       for (let i = 30; i >= 0; i--) {
         const date = new Date(Date.now() - i * 24 * 60 * 60 * 1000);
-        const apy = strategy.expectedApy * (1 + (Math.random() - 0.5) * 0.2);
+        const apy = strategy.expectedApy * (1 + (random() - 0.5) * 0.2);
         const totalValue = 10000 * (1 + apy / 100 * (30 - i) / 365);
         performance.push({
           strategyId: strategy.id,

--- a/src/lib/service-layer/transaction-service.ts
+++ b/src/lib/service-layer/transaction-service.ts
@@ -1,5 +1,6 @@
 import { BaseAdapter } from "./base-adapter";
 import { ServiceResponse, PaginatedResponse, PaginationParams } from "./types";
+import { random } from "../seeded-rng";
 
 export interface Transaction {
   id: string;
@@ -53,7 +54,7 @@ export class TransactionService extends BaseAdapter {
         status: "completed",
         fromAddress: "GD...1234",
         toAddress: "GA...5678",
-        txHash: "0x" + Math.random().toString(16).substr(2, 64),
+        txHash: "0x" + random().toString(16).substr(2, 64),
         fee: 0.01,
         createdAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(),
         completedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000 + 5000).toISOString(),
@@ -66,7 +67,7 @@ export class TransactionService extends BaseAdapter {
         asset: "USDC",
         status: "completed",
         toAddress: "GA...9012",
-        txHash: "0x" + Math.random().toString(16).substr(2, 64),
+        txHash: "0x" + random().toString(16).substr(2, 64),
         fee: 0.02,
         createdAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
         completedAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000 + 10000).toISOString(),
@@ -249,7 +250,7 @@ export class TransactionService extends BaseAdapter {
     }
 
     // Simulate 90% success rate
-    const isSuccess = Math.random() < 0.9;
+    const isSuccess = random() < 0.9;
 
     transaction.status = isSuccess ? "processing" : "failed";
     this.mockTransactions.set(userId, transactions);
@@ -264,7 +265,7 @@ export class TransactionService extends BaseAdapter {
       if (updatedTransaction) {
         updatedTransaction.status = "completed";
         updatedTransaction.completedAt = new Date().toISOString();
-        updatedTransaction.txHash = "0x" + Math.random().toString(16).substr(2, 64);
+        updatedTransaction.txHash = "0x" + random().toString(16).substr(2, 64);
         this.mockTransactions.set(userId, updatedTransactions);
       }
     }


### PR DESCRIPTION
closes #425  - lint-staged + Husky pre-commit (optional)
- Fix .lintstagedrc: replace broken next lint --fix --file with eslint --fix --max-warnings=0 (lint-staged passes files as positional args, not as --file flag values)
- Switch .husky/pre-commit from npx lint-staged to yarn lint-staged (consistent with yarn-only policy, uses local bin)
- Expand CONTRIBUTING.md with QA verification steps for the hook

closes #421  - Add CONTRIBUTING.md (Yarn, lint, build, PR checklist)
- Full rewrite: Node >=20 requirement, commands table, CI gates (typecheck/test/lint/build from frontend-ci.yml), branch rules, PR checklist, code conventions, issue/backlog links

closes #423  - Mobile safe-area env for bottom nav and fixed CTAs
- Add --sai-top/right/bottom/left CSS custom properties to :root in globals.css wrapping env(safe-area-inset-*) with 0px fallbacks
- Add .pb-safe / .pt-safe / .pl-safe / .pr-safe utility classes
- DashboardShell: replace pb-20 sm:pb-0 with calc(5rem + var(--sai-bottom))
- MobileBottomNav already correct (paddingBottom: env(safe-area-inset-bottom))
- Drawer footer: add max(1rem, calc(1rem + var(--sai-bottom))) padding
- Modal footer: same safe-area treatment
- transaction-flow.module.css .actionBar: pad bottom with var(--sai-bottom)
- profile/page.tsx .profile-action-row: safe-area bottom padding
- settings/security + preferences .settings-action-bar: safe-area padding
- settings/notifications sticky bar: inline style safe-area padding

closes #420  - Deterministic mock data for demo and visual baseline stability
- Rewrite seeded-rng.ts: add reseed() export, improve hashSeed to use Math.imul for correct 32-bit arithmetic, full JSDoc
- Route all remaining bare Math.random() calls through seeded-rng: service-layer/base-adapter (requestId, latency, failure rate) service-layer/portfolio-service (history values, live updates) service-layer/strategy-service (APY noise) service-layer/transaction-service (txHashes, success rate) service-layer/auth-service (token generation) logger.ts (log entry IDs) analytics.ts (event IDs) WalletConnectStep (90% connection success) FirstDepositStep (95% deposit success) SupportForm (reference ID suffix) FileUpload (upload progress increments)
- Add seeded-rng.test.ts: determinism, range, reseed, cross-seed isolation
- Update scripts/capture-visual-baselines.mjs: warn when seed unset, record demoSeed in manifest.json
- Fix docs/env.md: correct NEXT_PUBLIC_DEMO_SEED description (string not integer) and update example value
- Add docs/qa/demo-seed.md: full QA doc with coverage table, workflow instructions, and written QA steps