### PR TITLE
Verify chart colors for CVD contrast and redundancy

### DIFF
--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -327,4 +327,4 @@ curl -X POST http://localhost:3000/api/transactions \
 
 - #167: Document NEUROWEALTH_API contract (paths, auth, error JSON) for integration
 - #131: Align cookie consent storage keys and settings page labels
-- #163: Data viz: verify chart colors against design tokens and contrast for CVD
+- #422: Data viz: verify chart colors against design tokens and contrast for CVD

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -25,6 +25,45 @@ See `docs/env.md` for complete environment variable documentation.
 
 ## API Endpoints
 
+### Request Body Limits
+
+JSON write routes enforce a 100 KB request body limit before schema validation.
+This application-level limit is intentionally below Vercel Functions' documented
+4.5 MB request/response payload cap while matching the small payloads expected by
+the transaction and strategy flows.
+
+Affected frontend routes:
+
+- `POST /api/transactions`
+- `PUT /api/strategy`
+
+Oversized requests return `413 Payload Too Large` with the standard envelope:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "PAYLOAD_TOO_LARGE",
+    "message": "Request body must not exceed 100 KB."
+  }
+}
+```
+
+Malformed JSON returns `400 Bad Request` before route-specific validation:
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "VALIDATION_ERROR",
+    "message": "Request body must be valid JSON.",
+    "details": {
+      "body": ["Malformed JSON payload."]
+    }
+  }
+}
+```
+
 ### 1. Portfolio Overview
 
 **Frontend Route:** `GET /api/portfolio?scenario=live`

--- a/docs/qa/chart-colors-cvd.md
+++ b/docs/qa/chart-colors-cvd.md
@@ -1,101 +1,70 @@
-# Chart Colors & CVD Accessibility (Issue #163)
+# Chart Colors & CVD Accessibility (Issue #422)
 
-## Overview
+## Scope
 
-This document verifies that chart colors are distinguishable for common color-vision deficiency (CVD) cases and meet WCAG AA contrast standards.
+Owner: frontend data visualization.
 
-## Color Palette
+This check covers the shared chart tokens in `src/lib/chart-theme.ts`, the CVD
+utilities in `src/lib/chart-colors-cvd.ts`, the Recharts wrappers in
+`src/components/charts/*`, and the visible chart reference page at
+`/docs/charts`.
 
-### Primary Palette (CVD-Safe)
+## Approved Palette
 
-All colors tested for deuteranopia, protanopia, and tritanopia:
+The active chart tones are token-backed and must be used instead of ad hoc hex
+values.
 
-| Color  | Hex       | Use Case          | CVD Safe    |
-| ------ | --------- | ----------------- | ----------- |
-| Blue   | `#0369a1` | Primary series    | ✓ All types |
-| Orange | `#ea580c` | Secondary series  | ✓ All types |
-| Teal   | `#0d9488` | Tertiary series   | ✓ All types |
-| Purple | `#7c3aed` | Quaternary series | ✓ All types |
-| Green  | `#059669` | Quinary series    | ✓ All types |
+| Tone             | Hex       | Redundant pattern | Use case                         |
+| ---------------- | --------- | ----------------- | -------------------------------- |
+| `primary`        | `#0284c7` | Solid             | Main series and portfolio trend  |
+| `accent`         | `#d55e00` | Dash              | Secondary series and yield bars  |
+| `warning`        | `#cc79a7` | Dot               | Third series and comparisons     |
+| `neutral-strong` | `#64748b` | Long dash         | Other/inactive/supporting slices |
 
-### Contrast Ratios (vs. Dark Background #020617)
+Supporting `neutral-soft` remains available for low-emphasis UI chrome and
+labels, but it is not part of the active multi-series palette.
 
-| Color  | Contrast Ratio | WCAG AA (Text) | WCAG AA (Graphics) |
-| ------ | -------------- | -------------- | ------------------ |
-| Blue   | 8.2:1          | ✓ Pass         | ✓ Pass             |
-| Orange | 7.5:1          | ✓ Pass         | ✓ Pass             |
-| Teal   | 6.8:1          | ✓ Pass         | ✓ Pass             |
-| Purple | 7.1:1          | ✓ Pass         | ✓ Pass             |
-| Green  | 6.2:1          | ✓ Pass         | ✓ Pass             |
+## Automated Verification
 
-## Implementation
+Run:
 
-### Chart Theme Configuration
-
-Located in `src/lib/chart-theme.ts`:
-
-```typescript
-import { CVD_PALETTES } from "@/lib/chart-colors-cvd";
-
-export const chartTheme = {
-  colors: {
-    primary: CVD_PALETTES.primary.blue, // #0369a1
-    accent: CVD_PALETTES.primary.orange, // #ea580c
-    warning: CVD_PALETTES.primary.teal, // #0d9488
-    // ...
-  },
-};
+```bash
+npx tsx scripts/verify-chart-contrast.ts
 ```
 
-### CVD Color Utilities
+The script verifies:
 
-Located in `src/lib/chart-colors-cvd.ts`:
+- WCAG AA graphics contrast (`3:1`) against the dark chart surface `#111827`.
+- WCAG AA graphics contrast (`3:1`) against light chart backgrounds `#ffffff`.
+- Simulated pairwise RGB distance for protanopia, deuteranopia, and tritanopia.
+- Minimum simulated CVD pair distance of `35` for every active palette pair.
 
-- `getCVDSafeColor(index)` - Get color by index (cycles through palette)
-- `getContrastRatio(color1, color2)` - Calculate WCAG contrast ratio
-- `meetsWCAGAA(color1, color2, isText)` - Verify WCAG AA compliance
+Unit coverage lives in `src/lib/chart-colors-cvd.test.ts` and checks the same
+critical requirements during `yarn test`.
 
-## Testing Checklist
+## Manual QA
 
-### Visual QA
+1. Open `/docs/charts`.
+2. Confirm the palette swatches show sky, orange, magenta, and slate.
+3. Confirm bar examples use dashed/dotted outlines where configured.
+4. Confirm donut slices show both color and stroke-pattern differences.
+5. Verify tooltips and legends provide labels so color is not the only carrier
+   of meaning.
+6. Optional: capture the chart page and inspect it in a CVD simulator for
+   protanopia, deuteranopia, and tritanopia.
 
-- [ ] Portfolio chart displays with blue/orange/teal series
-- [ ] Activity chart uses CVD-safe colors
-- [ ] Strategy chart distinguishable in all series
-- [ ] Donut chart segments clearly differentiated
-- [ ] Line chart series easily distinguished
+## Design Notes
 
-### Accessibility Testing
-
-- [ ] Test with Coblis CVD simulator (https://www.color-blindness.com/coblis-color-blindness-simulator/)
-- [ ] Verify colors remain distinguishable in deuteranopia mode
-- [ ] Verify colors remain distinguishable in protanopia mode
-- [ ] Verify colors remain distinguishable in tritanopia mode
-
-### Browser Testing
-
-- [ ] Chrome DevTools color contrast checker
-- [ ] Firefox accessibility inspector
-- [ ] Safari accessibility features
-
-## Pattern Redundancy (Future Enhancement)
-
-For multi-series charts with >5 series, consider adding pattern/texture redundancy:
-
-- Solid fill for series 1
-- Diagonal stripes for series 2
-- Dots for series 3
-- Dashes for series 4
-- Etc.
-
-This provides additional visual distinction beyond color alone.
+- The previous palette had a blue value that missed the `3:1` graphics threshold
+  on the actual dark chart surface by a small margin.
+- Teal/green-adjacent colors can collapse under tritanopia and some red-green
+  simulations, so the third active tone uses magenta instead of teal.
+- Pattern redundancy is applied through shared stroke-dasharray tokens. This is
+  intentionally lightweight because the current wrappers mostly render
+  single-series line/bar charts and tone-based donut slices.
 
 ## References
 
-- WCAG 2.1 Color Contrast: https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
-- CVD Simulator: https://www.color-blindness.com/coblis-color-blindness-simulator/
-- Accessible Colors: https://accessible-colors.com/
-
-## Related Issues
-
-- #163: Data viz: verify chart colors against design tokens and contrast for CVD
+- WCAG 2.1 Non-text Contrast: https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html
+- WCAG 2.1 Contrast Minimum: https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html
+- CVD simulator for optional manual review: https://www.color-blindness.com/coblis-color-blindness-simulator/

--- a/docs/qa/cookie-consent-checklist.md
+++ b/docs/qa/cookie-consent-checklist.md
@@ -317,5 +317,5 @@ test("Cookie consent: accept all", () => {
 ## Related Issues
 
 - #131: Align cookie consent storage keys and settings page labels
-- #163: Data viz: verify chart colors against design tokens and contrast for CVD
+- #422: Data viz: verify chart colors against design tokens and contrast for CVD
 - #167: Document NEUROWEALTH_API contract (paths, auth, error JSON) for integration

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "next build",
     "start": "next start",
     "typecheck": "tsc --noEmit",
-    "test": "TZ=UTC node --import tsx --test \"src/**/*.test.ts\"",
+    "test": "TZ=UTC node --import tsx --test $(find src -name '*.test.ts' -print)",
     "qa:visual-baseline": "node scripts/capture-visual-baselines.mjs",
     "lint": "next lint",
     "validate:env": "yarn validate:env:server && yarn validate:env:frontend",

--- a/scripts/verify-chart-contrast.ts
+++ b/scripts/verify-chart-contrast.ts
@@ -2,14 +2,16 @@
 /**
  * Chart Color Contrast Verification Script
  *
- * Programmatically verifies that all chart colors meet WCAG AA standards
- * for the actual backgrounds used in the application.
+ * Programmatically verifies chart colors for WCAG AA graphics contrast and
+ * simulated CVD distinguishability on the actual application backgrounds.
  *
  * Usage: npx tsx scripts/verify-chart-contrast.ts
  */
 
 import {
   CVD_PALETTES,
+  type CvdMode,
+  getCvdPairDistance,
   getContrastRatio,
   meetsWCAGAA,
 } from "../src/lib/chart-colors-cvd";
@@ -26,6 +28,8 @@ const BACKGROUNDS = {
 const WCAG_AA_TEXT = 4.5;
 const WCAG_AA_GRAPHICS = 3.0;
 const WCAG_AAA_TEXT = 7.0;
+const MIN_CVD_PAIR_DISTANCE = 35;
+const CVD_MODES: CvdMode[] = ["protanopia", "deuteranopia", "tritanopia"];
 
 interface ContrastResult {
   color: string;
@@ -62,6 +66,10 @@ function formatResult(result: ContrastResult): string {
   const aaaStatus = result.passesAAAText ? "(AAA)" : "";
 
   return `${graphicsStatus} ${textStatus} ${result.color.padEnd(18)} ${result.hex} → ${result.ratio.toFixed(2)}:1 ${aaaStatus}`;
+}
+
+function formatDistance(value: number): string {
+  return Math.round(value * 10) / 10 + "";
 }
 
 function main() {
@@ -163,25 +171,35 @@ function main() {
   );
 
   // Color differentiation test
-  console.log("\n\n🔍 COLOR DIFFERENTIATION TEST\n");
+  console.log("\n\n🔍 CVD DIFFERENTIATION TEST\n");
   console.log(
-    "Testing contrast between palette colors (should be distinguishable):\n",
+    `Testing simulated RGB distance between palette colors (minimum ${MIN_CVD_PAIR_DISTANCE}):\n`,
   );
 
   const paletteColors = Object.entries(CVD_PALETTES.primary);
+  let allCvdPairsPass = true;
 
-  for (let i = 0; i < paletteColors.length; i++) {
-    for (let j = i + 1; j < paletteColors.length; j++) {
-      const [name1, hex1] = paletteColors[i];
-      const [name2, hex2] = paletteColors[j];
-      const ratio = getContrastRatio(hex1, hex2);
-      const status = ratio >= 1.5 ? "✅" : "⚠️";
+  CVD_MODES.forEach((mode) => {
+    console.log(`\n${mode.toUpperCase()}\n`);
 
-      console.log(
-        `${status} ${name1.padEnd(10)} vs ${name2.padEnd(10)}: ${ratio.toFixed(2)}:1`,
-      );
+    for (let i = 0; i < paletteColors.length; i++) {
+      for (let j = i + 1; j < paletteColors.length; j++) {
+        const [name1, hex1] = paletteColors[i];
+        const [name2, hex2] = paletteColors[j];
+        const distance = getCvdPairDistance(hex1, hex2, mode);
+        const passes = distance >= MIN_CVD_PAIR_DISTANCE;
+        const status = passes ? "✅" : "❌";
+
+        if (!passes) {
+          allCvdPairsPass = false;
+        }
+
+        console.log(
+          `${status} ${name1.padEnd(10)} vs ${name2.padEnd(10)}: ${formatDistance(distance)}`,
+        );
+      }
     }
-  }
+  });
 
   console.log("\n" + "=".repeat(80));
   console.log("\n✨ Verification complete!\n");
@@ -191,6 +209,20 @@ function main() {
   if (!allSurfaceGraphicsPass) {
     console.error(
       "❌ CRITICAL: Some colors fail WCAG AA graphics contrast (3:1) on surface backgrounds\n",
+    );
+    process.exit(1);
+  }
+
+  if (!allLightGraphicsPass) {
+    console.error(
+      "❌ CRITICAL: Some colors fail WCAG AA graphics contrast (3:1) on light backgrounds\n",
+    );
+    process.exit(1);
+  }
+
+  if (!allCvdPairsPass) {
+    console.error(
+      `❌ CRITICAL: Some chart colors are too close under simulated CVD modes (minimum ${MIN_CVD_PAIR_DISTANCE})\n`,
     );
     process.exit(1);
   }
@@ -208,7 +240,7 @@ function main() {
   }
 
   console.log(
-    "✅ All critical accessibility requirements met for chart graphics!\n",
+    "✅ All critical accessibility requirements met for chart graphics and CVD differentiation!\n",
   );
 }
 

--- a/src/app/api/strategy/route.test.ts
+++ b/src/app/api/strategy/route.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { GET, PUT } from "./route";
 import { NextRequest } from "next/server";
+import { ERROR_CODE, HTTP_STATUS, MAX_BODY_BYTES } from "@/lib/api-response";
 
 function makeGetRequest(cookieValue?: string): NextRequest {
   const url = "http://localhost:3000/api/strategy";
@@ -72,6 +73,27 @@ test("PUT /api/strategy returns 400 for malformed JSON", async () => {
 
   assert.equal(res.status, 400);
   assert.equal(body.success, false);
+  assert.equal(body.error.code, ERROR_CODE.VALIDATION_ERROR);
+  assert.deepEqual(body.error.details, {
+    body: ["Malformed JSON payload."],
+  });
+});
+
+test("PUT /api/strategy returns 413 for oversized JSON body", async () => {
+  const req = new NextRequest("http://localhost:3000/api/strategy", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": String(MAX_BODY_BYTES + 1),
+    },
+    body: "{}",
+  });
+  const res = await PUT(req);
+  const body = await res.json();
+
+  assert.equal(res.status, HTTP_STATUS.PAYLOAD_TOO_LARGE);
+  assert.equal(body.success, false);
+  assert.equal(body.error.code, ERROR_CODE.PAYLOAD_TOO_LARGE);
 });
 
 test("PUT /api/strategy accepts all valid strategy values", async () => {

--- a/src/app/api/transactions/route.test.ts
+++ b/src/app/api/transactions/route.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import { POST } from "./route";
 import { NextRequest } from "next/server";
+import { ERROR_CODE, HTTP_STATUS, MAX_BODY_BYTES } from "@/lib/api-response";
 
 function makePostRequest(body: unknown, scenario?: string): NextRequest {
   const url = scenario
@@ -113,6 +114,27 @@ test("POST /api/transactions returns 400 for malformed JSON body", async () => {
 
   assert.equal(res.status, 400);
   assert.equal(body.success, false);
+  assert.equal(body.error.code, ERROR_CODE.VALIDATION_ERROR);
+  assert.deepEqual(body.error.details, {
+    body: ["Malformed JSON payload."],
+  });
+});
+
+test("POST /api/transactions returns 413 for oversized JSON body", async () => {
+  const req = new NextRequest("http://localhost:3000/api/transactions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": String(MAX_BODY_BYTES + 1),
+    },
+    body: "{}",
+  });
+  const res = await POST(req);
+  const body = await res.json();
+
+  assert.equal(res.status, HTTP_STATUS.PAYLOAD_TOO_LARGE);
+  assert.equal(body.success, false);
+  assert.equal(body.error.code, ERROR_CODE.PAYLOAD_TOO_LARGE);
 });
 
 test("POST /api/transactions simulation failure returns failure outcome", async () => {

--- a/src/app/api/widget-preview/route.tsx
+++ b/src/app/api/widget-preview/route.tsx
@@ -533,4 +533,6 @@ export async function GET(request: Request) {
       height: 1080,
     },
   );
+
+  return imageResponse;
 }

--- a/src/app/demo/avatar/page.tsx
+++ b/src/app/demo/avatar/page.tsx
@@ -144,7 +144,7 @@ function ComponentsView({ savedAvatar }: { savedAvatar?: string }) {
           <div>
             <h3 className="text-sm font-medium text-gray-400 mb-3">Image</h3>
             <div className="flex gap-4">
-              <Avatar size={48} src={mockSrc} alt="Image variant" />
+              <Avatar size={40} src={mockSrc} alt="Image variant" />
             </div>
             <p className="text-xs text-gray-400 mt-2">
               Displays image with border
@@ -156,7 +156,7 @@ function ComponentsView({ savedAvatar }: { savedAvatar?: string }) {
             <div className="flex gap-4">
               {["Alice Brown", "Bob Jones", "Charlie Lee", "Diana Wu"].map(
                 (name) => (
-                  <Avatar key={name} size={48} name={name} />
+                  <Avatar key={name} size={40} name={name} />
                 ),
               )}
             </div>
@@ -170,7 +170,7 @@ function ComponentsView({ savedAvatar }: { savedAvatar?: string }) {
               Placeholder
             </h3>
             <div className="flex gap-4">
-              <Avatar size={48} />
+              <Avatar size={40} />
             </div>
             <p className="text-xs text-gray-400 mt-2">
               Default when no name or image provided
@@ -278,7 +278,7 @@ function UploaderView({
             <div>
               <p className="font-medium">Save</p>
               <p className="text-gray-400">
-                Click "Apply crop" to save (returns 256×256 square output)
+                Click &quot;Apply crop&quot; to save (returns 256×256 square output)
               </p>
             </div>
           </div>

--- a/src/app/demo/notifications/page.tsx
+++ b/src/app/demo/notifications/page.tsx
@@ -80,7 +80,7 @@ export default function NotificationsDemo() {
           </div>
 
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-            <Button onClick={() => handleToast("success")} variant="default">Success Toast</Button>
+            <Button onClick={() => handleToast("success")} variant="primary">Success Toast</Button>
             <Button onClick={() => handleToast("info")} variant="ghost">Info Toast</Button>
             <Button onClick={() => handleToast("warning")} variant="ghost">Warning Toast</Button>
             <Button onClick={() => handleToast("error")} variant="ghost">Error Toast</Button>
@@ -89,7 +89,7 @@ export default function NotificationsDemo() {
           <div className="bg-dark-800 rounded-xl border border-white/10 p-6">
             <h3 className="text-white font-medium mb-4">Mock Common Flows</h3>
             <div className="flex flex-wrap gap-3">
-              <Button onClick={() => handleMockFlow("save")} variant="default">Save Flow</Button>
+              <Button onClick={() => handleMockFlow("save")} variant="primary">Save Flow</Button>
               <Button onClick={() => handleMockFlow("failure")} variant="ghost">Failure Flow</Button>
               <Button onClick={() => handleMockFlow("timeout")} variant="ghost">Timeout Flow</Button>
             </div>

--- a/src/app/demo/release-checklist/page.tsx
+++ b/src/app/demo/release-checklist/page.tsx
@@ -243,7 +243,7 @@ ${checklist.signOffs.map((signOff) => `- **${signOff.role.charAt(0).toUpperCase(
               <span className="text-slate-400 text-sm">Progress:</span>
               <span className="text-white font-semibold ml-2">{progress}%</span>
             </div>
-            <Button onClick={exportSummary} variant="default" size="sm">
+            <Button onClick={exportSummary} variant="primary" size="sm">
               <Download className="h-4 w-4 mr-2" />
               Export
             </Button>

--- a/src/app/docs/charts/page.tsx
+++ b/src/app/docs/charts/page.tsx
@@ -114,24 +114,24 @@ function DoDont({
 
 const chartPalette = [
   {
-    name: "Primary (Blue)",
+    name: "Primary (Sky)",
     value: chartTheme.colors.primary,
-    usage: "Main data series, portfolio growth, primary KPI lines",
+    usage: "Main data series, portfolio growth, primary KPI lines; solid stroke",
   },
   {
     name: "Accent (Orange)",
     value: chartTheme.colors.accent,
-    usage: "Secondary series, yield/return bars, comparison lines",
+    usage: "Secondary series, yield/return bars, comparison lines; dashed stroke",
   },
   {
-    name: "Warning (Teal)",
+    name: "Warning (Magenta)",
     value: chartTheme.colors.warning,
-    usage: "Third data series, benchmark overlays, neutral metrics",
+    usage: "Third data series, benchmark overlays, neutral metrics; dotted stroke",
   },
   {
     name: "Neutral Strong",
     value: chartTheme.colors["neutral-strong"],
-    usage: "Suppressed data, inactive slices, low-emphasis fills",
+    usage: "Suppressed data, inactive slices, low-emphasis fills; long dash",
   },
 ];
 
@@ -187,7 +187,7 @@ export default function ChartStyleGuidePage() {
         <Section
           id="palette"
           title="Approved Chart Palette"
-          description="All charts must use tokens from this palette. The set is CVD-safe (tested for deuteranopia, protanopia, and tritanopia) and meets WCAG AA contrast on dark backgrounds."
+          description="All charts must use tokens from this palette. The set is CVD-tested for deuteranopia, protanopia, and tritanopia, and meets WCAG AA graphics contrast on dark and light chart backgrounds."
         >
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {chartPalette.map((swatch) => (
@@ -296,6 +296,7 @@ import { chartTheme } from "@/lib/chart-theme";
                 xAxisKey="name"
                 height={220}
                 color={chartTheme.colors.accent}
+                strokeDasharray={chartTheme.patterns.accent}
                 formatter={(v) => [`$${Number(v).toLocaleString()}`, "Yield"]}
               />
             </div>
@@ -309,6 +310,7 @@ import { chartTheme } from "@/lib/chart-theme";
                 xAxisKey="name"
                 height={220}
                 color={chartTheme.colors.warning}
+                strokeDasharray={chartTheme.patterns.warning}
                 formatter={(v) => [`$${Number(v).toLocaleString()}`, "Amount"]}
               />
             </div>
@@ -324,6 +326,7 @@ import { chartTheme } from "@/lib/chart-theme";
   xAxisKey="name"
   height={220}
   color={chartTheme.colors.accent}
+  strokeDasharray={chartTheme.patterns.accent}
   formatter={(v) => [\`$\${Number(v).toLocaleString()}\`, "Yield"]}
 />`}
           />
@@ -359,8 +362,9 @@ import { assetAllocationData } from "@/lib/mock-chart-data";
           />
           <div className="mt-3 rounded-lg border border-slate-700/40 bg-slate-900/40 p-3 text-xs text-slate-400">
             Each donut slice maps a <code className="text-sky-300">tone</code>{" "}
-            field to an approved palette colour. The legend renders below the
-            chart on mobile and to the right on desktop automatically.
+            field to an approved palette colour and a redundant stroke pattern.
+            The legend renders below the chart on mobile and to the right on
+            desktop automatically.
           </div>
         </Section>
 
@@ -372,12 +376,12 @@ import { assetAllocationData } from "@/lib/mock-chart-data";
         >
           <div className="space-y-4">
             <DoDont
-              doText="Use approved palette tokens (primary, accent, warning, neutral-strong). Colours are pre-tested for CVD safety."
-              dontText="Introduce custom hex colours outside the chart palette — this breaks CVD safety guarantees and visual consistency."
+              doText="Use approved palette tokens (primary, accent, warning, neutral-strong). Colours are tested for CVD distance and chart contrast."
+              dontText="Introduce custom hex colours outside the chart palette — this breaks CVD guarantees and visual consistency."
             />
             <DoDont
-              doText="Pair colour with a text label or legend entry. Screen readers and colour-blind users rely on labels, not colour."
-              dontText="Use colour as the only differentiator between series. A user with monochromacy would see identical lines."
+              doText="Pair colour with a text label, legend entry, and stroke pattern where the wrapper supports it."
+              dontText="Use colour as the only differentiator between series. Simulated CVD checks can still miss unlabeled intent."
             />
             <DoDont
               doText="Keep axis labels at least 12 px and use the axis.fill token (#64748b) so labels are readable on dark backgrounds."

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,9 +19,9 @@
   --positive: #10b981;
   --negative: #ef4444;
   --neutral: #94a3b8;
-  --chart-primary: #0f766e;
-  --chart-accent: #38bdf8;
-  --chart-warning: #f59e0b;
+  --chart-primary: #0284c7;
+  --chart-accent: #d55e00;
+  --chart-warning: #cc79a7;
   --chart-neutral-strong: #64748b;
   --chart-neutral-soft: #94a3b8;
   /* Motion tokens */

--- a/src/components/charts/AreaChartWrapper.tsx
+++ b/src/components/charts/AreaChartWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
-import { BaseChart, ChartTooltip, usePrefersReducedMotion } from "./BaseChart";
+import { BaseChart, ChartTooltip, type ChartTooltipFormatter } from "./BaseChart";
 import { chartTheme, chartDimensions } from "@/lib/chart-theme";
 import type { ChartDatum } from "@/lib/mock-chart-data";
 
@@ -14,7 +14,7 @@ interface AreaChartWrapperProps<T extends ChartDatum> {
   showLegend?: boolean;
   fillOpacity?: number;
   color?: string;
-  formatter?: (value: any, name: string) => [string, string];
+  formatter?: ChartTooltipFormatter;
 }
 
 export function AreaChartWrapper<T extends ChartDatum = ChartDatum>({

--- a/src/components/charts/BarChartWrapper.tsx
+++ b/src/components/charts/BarChartWrapper.tsx
@@ -13,6 +13,7 @@ interface BarChartWrapperProps<T extends ChartDatum> {
   showGrid?: boolean;
   showLegend?: boolean;
   color?: string;
+  strokeDasharray?: string;
   barSize?: number;
   formatter?: ChartTooltipFormatter;
 }
@@ -25,6 +26,7 @@ export function BarChartWrapper<T extends ChartDatum = ChartDatum>({
   showGrid = true,
   showLegend = false,
   color = chartTheme.colors.primary,
+  strokeDasharray = chartTheme.patterns.primary,
   barSize,
   formatter,
 }: BarChartWrapperProps<T>) {
@@ -54,6 +56,8 @@ export function BarChartWrapper<T extends ChartDatum = ChartDatum>({
         <Bar
           dataKey={dataKey}
           fill={color}
+          stroke={color}
+          strokeDasharray={strokeDasharray}
           radius={[4, 4, 0, 0]}
           barSize={barSize}
         />

--- a/src/components/charts/BarChartWrapper.tsx
+++ b/src/components/charts/BarChartWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
-import { BaseChart, ChartTooltip } from "./BaseChart";
+import { BaseChart, ChartTooltip, type ChartTooltipFormatter } from "./BaseChart";
 import { chartTheme, chartDimensions } from "@/lib/chart-theme";
 import type { ChartDatum } from "@/lib/mock-chart-data";
 
@@ -14,7 +14,7 @@ interface BarChartWrapperProps<T extends ChartDatum> {
   showLegend?: boolean;
   color?: string;
   barSize?: number;
-  formatter?: (value: any, name: string) => [string, string];
+  formatter?: ChartTooltipFormatter;
 }
 
 export function BarChartWrapper<T extends ChartDatum = ChartDatum>({

--- a/src/components/charts/DonutChartWrapper.tsx
+++ b/src/components/charts/DonutChartWrapper.tsx
@@ -2,7 +2,7 @@
 
 import { PieChart, Pie, Cell, Tooltip, Legend } from "recharts";
 import { BaseChart, ChartTooltip, type ChartTooltipFormatter, usePrefersReducedMotion } from "./BaseChart";
-import { chartTheme, chartDimensions, getChartColor } from "@/lib/chart-theme";
+import { chartTheme, getChartColor, getChartStrokeDasharray } from "@/lib/chart-theme";
 import type { AssetAllocationSlice } from "@/lib/mock-chart-data";
 
 interface DonutChartWrapperProps {
@@ -41,6 +41,9 @@ export function DonutChartWrapper({
             <Cell
               key={`cell-${index}`}
               fill={entry.tone ? getChartColor(entry.tone) : chartTheme.colors.primary}
+              stroke={chartTheme.tooltip.contentStyle.backgroundColor}
+              strokeDasharray={entry.tone ? getChartStrokeDasharray(entry.tone) : chartTheme.patterns.primary}
+              strokeWidth={2}
             />
           ))}
         </Pie>

--- a/src/components/charts/DonutChartWrapper.tsx
+++ b/src/components/charts/DonutChartWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { PieChart, Pie, Cell, Tooltip, Legend } from "recharts";
-import { BaseChart, ChartTooltip, usePrefersReducedMotion } from "./BaseChart";
+import { BaseChart, ChartTooltip, type ChartTooltipFormatter, usePrefersReducedMotion } from "./BaseChart";
 import { chartTheme, chartDimensions, getChartColor } from "@/lib/chart-theme";
 import type { AssetAllocationSlice } from "@/lib/mock-chart-data";
 
@@ -11,7 +11,7 @@ interface DonutChartWrapperProps {
   innerRadius?: number;
   outerRadius?: number;
   showLegend?: boolean;
-  formatter?: (value: any, name: string) => [string, string];
+  formatter?: ChartTooltipFormatter;
 }
 
 export function DonutChartWrapper({

--- a/src/components/charts/LineChartWrapper.tsx
+++ b/src/components/charts/LineChartWrapper.tsx
@@ -14,6 +14,7 @@ interface LineChartWrapperProps<T extends ChartDatum> {
   showLegend?: boolean;
   color?: string;
   strokeWidth?: number;
+  strokeDasharray?: string;
   dot?: boolean | object;
   formatter?: ChartTooltipFormatter;
 }
@@ -27,6 +28,7 @@ export function LineChartWrapper<T extends ChartDatum = ChartDatum>({
   showLegend = false,
   color = chartTheme.colors.primary,
   strokeWidth = 2,
+  strokeDasharray = chartTheme.patterns.primary,
   dot = false,
   formatter,
 }: LineChartWrapperProps<T>) {
@@ -58,6 +60,7 @@ export function LineChartWrapper<T extends ChartDatum = ChartDatum>({
           dataKey={dataKey}
           stroke={color}
           strokeWidth={strokeWidth}
+          strokeDasharray={strokeDasharray}
           dot={dot}
           activeDot={{ r: 4, stroke: color, strokeWidth: 2, fill: "#fff" }}
         />

--- a/src/components/charts/LineChartWrapper.tsx
+++ b/src/components/charts/LineChartWrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from "recharts";
-import { BaseChart, ChartTooltip } from "./BaseChart";
+import { BaseChart, ChartTooltip, type ChartTooltipFormatter } from "./BaseChart";
 import { chartTheme, chartDimensions } from "@/lib/chart-theme";
 import type { ChartDatum } from "@/lib/mock-chart-data";
 
@@ -15,7 +15,7 @@ interface LineChartWrapperProps<T extends ChartDatum> {
   color?: string;
   strokeWidth?: number;
   dot?: boolean | object;
-  formatter?: (value: any, name: string) => [string, string];
+  formatter?: ChartTooltipFormatter;
 }
 
 export function LineChartWrapper<T extends ChartDatum = ChartDatum>({

--- a/src/components/wallet/WalletUIDemo.tsx
+++ b/src/components/wallet/WalletUIDemo.tsx
@@ -17,7 +17,6 @@ import { WalletStatusBadge } from "./WalletStatusBadge";
 interface DemoStateProps {
   title: string;
   description?: string;
-  state: "disconnected" | "restoring" | "connected" | "mismatch";
   children: React.ReactNode;
 }
 

--- a/src/hooks/useDateFilter.ts
+++ b/src/hooks/useDateFilter.ts
@@ -1,18 +1,13 @@
 "use client";
 
 import { useMemo } from "react";
-import type { DateRange } from "@/types";
-
-export interface DateFilterable {
-  date: string | Date;
-  [key: string]: unknown;
-}
+import type { DateFilterable, DateRange } from "@/types";
 
 export function filterByDateRange<T extends DateFilterable>(
-  data: T[],
+  data: readonly T[],
   range: DateRange,
 ): T[] {
-  if (!range.start && !range.end) return data;
+  if (!range.start && !range.end) return [...data];
 
   return data.filter((item) => {
     const dateValue = item.date instanceof Date ? item.date : new Date(item.date);
@@ -29,11 +24,11 @@ export function filterByDateRange<T extends DateFilterable>(
 }
 
 export function filterByTimeRange<T extends { time: string }>(
-  data: T[],
+  data: readonly T[],
   from: { hours: number; minutes: number } | null,
   to: { hours: number; minutes: number } | null,
 ): T[] {
-  if (!from && !to) return data;
+  if (!from && !to) return [...data];
 
   return data.filter((item) => {
     const [hours, minutes] = item.time.split(":").map(Number);
@@ -53,7 +48,7 @@ export function filterByTimeRange<T extends { time: string }>(
  * const { filtered, count } = useDateFilter(transactions, range);
  */
 export function useDateFilter<T extends DateFilterable>(
-  data: T[],
+  data: readonly T[],
   range: DateRange
 ): { filtered: T[]; count: number; hasFilter: boolean } {
   const { start, end } = range;
@@ -74,7 +69,7 @@ export function useDateFilter<T extends DateFilterable>(
  * Useful for audit logs, transactions with timestamps.
  */
 export function useTimeFilter<T extends { time: string }>(
-  data: T[],
+  data: readonly T[],
   from: { hours: number; minutes: number } | null,
   to: { hours: number; minutes: number } | null
 ): T[] {

--- a/src/hooks/useTransactionList.ts
+++ b/src/hooks/useTransactionList.ts
@@ -46,6 +46,10 @@ export function paginateTransactions(
   page: number,
   itemsPerPage: number,
 ): Transaction[] {
+  if (page < 1 || itemsPerPage < 1) {
+    return [];
+  }
+
   const start = (page - 1) * itemsPerPage;
   return transactions.slice(start, start + itemsPerPage);
 }

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -120,7 +120,7 @@ test("apiRequest rejects payloads that are not the success/error envelope", asyn
 });
 
 test("apiRequest sets Content-Type and Accept headers automatically for JSON bodies", async () => {
-  let capturedHeaders: Headers | null = null;
+  let capturedHeaders!: Headers;
 
   globalThis.fetch = async (_url, init) => {
     capturedHeaders = new Headers(init?.headers);
@@ -132,8 +132,8 @@ test("apiRequest sets Content-Type and Accept headers automatically for JSON bod
 
   await apiRequest("/api/test", { method: "POST", body: { x: 1 } });
 
-  assert.equal(capturedHeaders?.get("Content-Type"), "application/json");
-  assert.equal(capturedHeaders?.get("Accept"), "application/json");
+  assert.equal(capturedHeaders.get("Content-Type"), "application/json");
+  assert.equal(capturedHeaders.get("Accept"), "application/json");
 });
 
 test("createServerApiClient returns null when NEUROWEALTH_API_BASE_URL is not set", () => {
@@ -147,7 +147,7 @@ test("createServerApiClient returns a callable client when base URL is set", asy
   process.env.NEUROWEALTH_API_AUTH_TOKEN = "test-token";
 
   let capturedUrl: string | URL | Request | undefined;
-  let capturedHeaders: Headers | null = null;
+  let capturedHeaders!: Headers;
 
   globalThis.fetch = async (url, init) => {
     capturedUrl = url as string;
@@ -165,5 +165,5 @@ test("createServerApiClient returns a callable client when base URL is set", asy
 
   assert.equal(result.ok, true);
   assert.ok(String(capturedUrl).includes("api.example.com"));
-  assert.equal(capturedHeaders?.get("Authorization"), "Bearer test-token");
+  assert.equal(capturedHeaders.get("Authorization"), "Bearer test-token");
 });

--- a/src/lib/api-response.test.ts
+++ b/src/lib/api-response.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ERROR_CODE, HTTP_STATUS, MAX_BODY_BYTES, readJsonBody } from "./api-response";
+
+function makeJsonRequest(body: string, headers?: HeadersInit): Request {
+  return new Request("http://localhost:3000/api/test", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...headers,
+    },
+    body,
+  });
+}
+
+test("readJsonBody parses valid JSON within the configured size limit", async () => {
+  const result = await readJsonBody(makeJsonRequest('{"ok":true}'));
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.deepEqual(result.data, { ok: true });
+  }
+});
+
+test("readJsonBody rejects declared oversized bodies before parsing", async () => {
+  const result = await readJsonBody(
+    makeJsonRequest("{}", {
+      "Content-Length": String(MAX_BODY_BYTES + 1),
+    }),
+  );
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    const body = await result.response.json();
+    assert.equal(result.response.status, HTTP_STATUS.PAYLOAD_TOO_LARGE);
+    assert.equal(body.success, false);
+    assert.equal(body.error.code, ERROR_CODE.PAYLOAD_TOO_LARGE);
+  }
+});
+
+test("readJsonBody rejects streamed bodies that exceed the configured limit", async () => {
+  const oversizedBody = JSON.stringify({ value: "x".repeat(MAX_BODY_BYTES) });
+  const result = await readJsonBody(makeJsonRequest(oversizedBody));
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    const body = await result.response.json();
+    assert.equal(result.response.status, HTTP_STATUS.PAYLOAD_TOO_LARGE);
+    assert.equal(body.success, false);
+    assert.equal(body.error.code, ERROR_CODE.PAYLOAD_TOO_LARGE);
+  }
+});
+
+test("readJsonBody returns a 400 envelope for malformed JSON", async () => {
+  const result = await readJsonBody(makeJsonRequest("not-json"));
+
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    const body = await result.response.json();
+    assert.equal(result.response.status, HTTP_STATUS.BAD_REQUEST);
+    assert.equal(body.success, false);
+    assert.equal(body.error.code, ERROR_CODE.VALIDATION_ERROR);
+    assert.deepEqual(body.error.details, {
+      body: ["Malformed JSON payload."],
+    });
+  }
+});

--- a/src/lib/api-response.ts
+++ b/src/lib/api-response.ts
@@ -26,6 +26,7 @@ export const HTTP_STATUS = {
     OK: 200,
     CREATED: 201,
     BAD_REQUEST: 400,
+    PAYLOAD_TOO_LARGE: 413,
     UNAUTHORIZED: 401,
     FORBIDDEN: 403,
     NOT_FOUND: 404,
@@ -42,6 +43,7 @@ export const ERROR_CODE = {
     UNAUTHORIZED: "UNAUTHORIZED",
     FORBIDDEN: "FORBIDDEN",
     NOT_FOUND: "NOT_FOUND",
+    PAYLOAD_TOO_LARGE: "PAYLOAD_TOO_LARGE",
     INTERNAL_ERROR: "INTERNAL_ERROR",
     SERVICE_UNAVAILABLE: "SERVICE_UNAVAILABLE",
     BACKEND_ERROR: "BACKEND_ERROR",
@@ -71,10 +73,17 @@ function normalizeErrorDetails(
 
 /**
  * Maximum allowed request body size for POST API routes (100 KB).
- * Aligns with Vercel's default serverless function body limit.
- * Documented here so all routes share the same constant.
+ * This application-level guard is intentionally below Vercel Functions' 4.5 MB
+ * payload cap because transaction and strategy writes only need small JSON.
  */
 export const MAX_BODY_BYTES = 100 * 1024; // 100 KB
+
+function payloadTooLargeResponse(maxBytes: number) {
+    return errorResponse(
+        ERROR_CODE.PAYLOAD_TOO_LARGE,
+        `Request body must not exceed ${maxBytes / 1024} KB.`,
+    );
+}
 
 /**
  * Read and parse a JSON request body, enforcing a byte-size limit.
@@ -96,60 +105,101 @@ export async function readJsonBody(
 > {
     const { NextResponse } = await import("next/server");
 
-    // Check Content-Length header first (fast path — not always present)
+    // Fast path: reject oversized requests before reading the body when the
+    // client/proxy provides Content-Length. The same limit is also enforced
+    // while streaming below because this header is optional and client-controlled.
     const contentLength = request.headers.get("content-length");
-    if (contentLength !== null && parseInt(contentLength, 10) > maxBytes) {
+    const declaredBytes =
+        contentLength === null ? Number.NaN : Number(contentLength);
+    if (Number.isFinite(declaredBytes) && declaredBytes > maxBytes) {
         return {
             ok: false,
             response: NextResponse.json(
-                errorResponse(
-                    "PAYLOAD_TOO_LARGE",
-                    `Request body must not exceed ${maxBytes / 1024} KB.`,
-                ),
-                { status: 413 },
+                payloadTooLargeResponse(maxBytes),
+                { status: HTTP_STATUS.PAYLOAD_TOO_LARGE },
             ),
         };
     }
 
-    // Read the raw bytes so we can enforce the limit even without Content-Length
-    let bytes: Uint8Array;
+    let chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+
     try {
-        const arrayBuffer = await request.arrayBuffer();
-        bytes = new Uint8Array(arrayBuffer);
+        if (request.body) {
+            const reader = request.body.getReader();
+
+            try {
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+
+                    totalBytes += value.byteLength;
+
+                    if (totalBytes > maxBytes) {
+                        await reader.cancel();
+                        return {
+                            ok: false,
+                            response: NextResponse.json(
+                                payloadTooLargeResponse(maxBytes),
+                                { status: HTTP_STATUS.PAYLOAD_TOO_LARGE },
+                            ),
+                        };
+                    }
+
+                    chunks.push(value);
+                }
+            } finally {
+                reader.releaseLock();
+            }
+        } else {
+            chunks = [new Uint8Array(await request.arrayBuffer())];
+            totalBytes = chunks[0].byteLength;
+        }
     } catch {
         return {
             ok: false,
             response: NextResponse.json(
-                errorResponse("VALIDATION_ERROR", "Failed to read request body."),
-                { status: 400 },
+                errorResponse(
+                    ERROR_CODE.VALIDATION_ERROR,
+                    "Failed to read request body.",
+                ),
+                { status: HTTP_STATUS.BAD_REQUEST },
             ),
         };
     }
 
-    if (bytes.byteLength > maxBytes) {
+    if (totalBytes > maxBytes) {
         return {
             ok: false,
             response: NextResponse.json(
-                errorResponse(
-                    "PAYLOAD_TOO_LARGE",
-                    `Request body must not exceed ${maxBytes / 1024} KB.`,
-                ),
-                { status: 413 },
+                payloadTooLargeResponse(maxBytes),
+                { status: HTTP_STATUS.PAYLOAD_TOO_LARGE },
             ),
         };
     }
 
     try {
+        const bytes = new Uint8Array(totalBytes);
+        let offset = 0;
+        for (const chunk of chunks) {
+            bytes.set(chunk, offset);
+            offset += chunk.byteLength;
+        }
+
         const text = new TextDecoder().decode(bytes);
         return { ok: true, data: JSON.parse(text) };
     } catch {
         return {
             ok: false,
             response: NextResponse.json(
-                errorResponse("VALIDATION_ERROR", "Request body must be valid JSON.", {
-                    body: ["Malformed JSON payload."],
-                }),
-                { status: 400 },
+                errorResponse(
+                    ERROR_CODE.VALIDATION_ERROR,
+                    "Request body must be valid JSON.",
+                    {
+                        body: ["Malformed JSON payload."],
+                    },
+                ),
+                { status: HTTP_STATUS.BAD_REQUEST },
             ),
         };
     }

--- a/src/lib/chart-colors-cvd.test.ts
+++ b/src/lib/chart-colors-cvd.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { chartTheme } from "./chart-theme";
+import {
+  type CvdMode,
+  getCvdPairDistance,
+  meetsWCAGAA,
+} from "./chart-colors-cvd";
+
+const CHART_BACKGROUNDS = ["#111827", "#ffffff"];
+const CVD_MODES: CvdMode[] = ["protanopia", "deuteranopia", "tritanopia"];
+const MIN_CVD_PAIR_DISTANCE = 35;
+
+const activeChartColors = [
+  chartTheme.colors.primary,
+  chartTheme.colors.accent,
+  chartTheme.colors.warning,
+  chartTheme.colors["neutral-strong"],
+];
+
+test("active chart colors meet WCAG AA graphics contrast on dark and light chart backgrounds", () => {
+  for (const color of activeChartColors) {
+    for (const background of CHART_BACKGROUNDS) {
+      assert.equal(
+        meetsWCAGAA(color, background, false),
+        true,
+        `${color} should meet 3:1 graphics contrast on ${background}`,
+      );
+    }
+  }
+});
+
+test("active chart colors remain distinguishable under simulated CVD modes", () => {
+  for (const mode of CVD_MODES) {
+    for (let i = 0; i < activeChartColors.length; i++) {
+      for (let j = i + 1; j < activeChartColors.length; j++) {
+        const distance = getCvdPairDistance(
+          activeChartColors[i],
+          activeChartColors[j],
+          mode,
+        );
+
+        assert.ok(
+          distance >= MIN_CVD_PAIR_DISTANCE,
+          `${activeChartColors[i]} and ${activeChartColors[j]} are too close in ${mode}: ${distance.toFixed(1)}`,
+        );
+      }
+    }
+  }
+});
+
+test("chart tones expose non-color stroke patterns for redundant series encoding", () => {
+  assert.equal(chartTheme.patterns.primary, "0");
+  assert.notEqual(chartTheme.patterns.accent, chartTheme.patterns.primary);
+  assert.notEqual(chartTheme.patterns.warning, chartTheme.patterns.primary);
+  assert.notEqual(
+    chartTheme.patterns["neutral-strong"],
+    chartTheme.patterns.primary,
+  );
+});

--- a/src/lib/chart-colors-cvd.ts
+++ b/src/lib/chart-colors-cvd.ts
@@ -1,35 +1,37 @@
 /**
  * CVD-safe color palettes for charts
- * Issue #163: Ensure chart colors are distinguishable for common color-vision deficiency cases
+ * Issue #422: Ensure chart colors are distinguishable for common color-vision deficiency cases
  * 
  * References:
  * - Deuteranopia (red-green, ~1% of males): Difficulty distinguishing red/green
  * - Protanopia (red-green, ~0.5% of males): Similar to deuteranopia
  * - Tritanopia (blue-yellow, ~0.001%): Difficulty distinguishing blue/yellow
  * 
- * Strategy: Use blue/orange/teal palette with pattern redundancy where possible
+ * Strategy: Use sky/orange/magenta/neutral palette with pattern redundancy where possible
  * All colors tested against WCAG AA contrast requirements (4.5:1 for text, 3:1 for graphics)
  */
 
+export type CvdMode = "protanopia" | "deuteranopia" | "tritanopia";
+export type ChartPatternKey = "solid" | "dash" | "dot" | "longDash";
+
 export const CVD_PALETTES = {
-    // Primary palette: Blue/Orange/Teal (safe for all CVD types)
-    // Uses pattern + color redundancy
+    // Primary palette: Sky/Orange/Magenta/Neutral.
+    // Each color passes WCAG AA graphics contrast on dark chart surfaces and
+    // light backgrounds, then gets checked for CVD simulated distance.
     primary: {
-        blue: "#0369a1",      // Sky blue (safe for all CVD)
-        orange: "#ea580c",    // Vibrant orange (safe for all CVD)
-        teal: "#0d9488",      // Teal (safe for all CVD)
-        purple: "#7c3aed",    // Purple (safe for all CVD)
-        green: "#059669",     // Emerald green (safe for all CVD)
+        sky: "#0284c7",       // Sky 600
+        orange: "#d55e00",    // CVD-safe orange
+        magenta: "#cc79a7",   // CVD-safe reddish purple
+        neutral: "#64748b",   // Slate 500
     },
 
     // Accessible palette: High contrast, CVD-safe
     accessible: {
-        color1: "#0369a1",    // Blue
-        color2: "#ea580c",    // Orange
-        color3: "#0d9488",    // Teal
-        color4: "#7c3aed",    // Purple
-        color5: "#059669",    // Green
-        color6: "#dc2626",    // Red (use with caution, pair with pattern)
+        color1: "#0284c7",    // Sky
+        color2: "#d55e00",    // Orange
+        color3: "#cc79a7",    // Magenta
+        color4: "#64748b",    // Neutral
+        color5: "#dc2626",    // Red (status/emphasis only, pair with pattern)
     },
 
     // Neutral/supporting colors
@@ -38,6 +40,21 @@ export const CVD_PALETTES = {
         soft: "#94a3b8",      // Slate-400
         lighter: "#cbd5e1",   // Slate-300
     },
+} as const;
+
+export const CVD_PATTERNS: Record<ChartPatternKey, string> = {
+    solid: "0",
+    dash: "6 4",
+    dot: "1 5",
+    longDash: "10 4",
+} as const;
+
+export const CHART_TONE_PATTERNS = {
+    primary: CVD_PATTERNS.solid,
+    accent: CVD_PATTERNS.dash,
+    warning: CVD_PATTERNS.dot,
+    "neutral-strong": CVD_PATTERNS.longDash,
+    "neutral-soft": CVD_PATTERNS.longDash,
 } as const;
 
 /**
@@ -49,16 +66,23 @@ export function getCVDSafeColor(index: number): string {
     return colors[index % colors.length];
 }
 
+export function hexToRgb(hex: string): [number, number, number] {
+    const normalized = hex.replace("#", "");
+    if (!/^[0-9a-fA-F]{6}$/.test(normalized)) {
+        throw new Error(`Invalid hex color: ${hex}`);
+    }
+
+    const rgb = parseInt(normalized, 16);
+    return [(rgb >> 16) & 0xff, (rgb >> 8) & 0xff, rgb & 0xff];
+}
+
 /**
  * Verify color contrast ratio (WCAG)
  * Returns true if contrast >= 4.5:1 (AA standard for text)
  */
 export function getContrastRatio(color1: string, color2: string): number {
     const getLuminance = (hex: string): number => {
-        const rgb = parseInt(hex.slice(1), 16);
-        const r = (rgb >> 16) & 0xff;
-        const g = (rgb >> 8) & 0xff;
-        const b = (rgb >> 0) & 0xff;
+        const [r, g, b] = hexToRgb(hex);
         const [rs, gs, bs] = [r, g, b].map((c) => {
             c = c / 255;
             return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
@@ -81,14 +105,83 @@ export function meetsWCAGAA(color1: string, color2: string, isText = true): bool
     return ratio >= (isText ? 4.5 : 3);
 }
 
+const CVD_SIMULATION_MATRICES: Record<CvdMode, [number, number, number][]> = {
+    protanopia: [
+        [0.152286, 1.052583, -0.204868],
+        [0.114503, 0.786281, 0.099216],
+        [-0.003882, -0.048116, 1.051998],
+    ],
+    deuteranopia: [
+        [0.367322, 0.860646, -0.227968],
+        [0.280085, 0.672501, 0.047413],
+        [-0.01182, 0.04294, 0.968881],
+    ],
+    tritanopia: [
+        [1.255528, -0.076749, -0.178779],
+        [-0.078411, 0.930809, 0.147602],
+        [0.004733, 0.691367, 0.3039],
+    ],
+};
+
+function clampRgbChannel(value: number): number {
+    return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+/**
+ * Simulate a color under a common full-severity CVD mode.
+ * The output is RGB so tests can compare pairwise visual distance.
+ */
+export function simulateColorVisionDeficiency(
+    hex: string,
+    mode: CvdMode,
+): [number, number, number] {
+    const [r, g, b] = hexToRgb(hex).map((channel) => channel / 255);
+    const matrix = CVD_SIMULATION_MATRICES[mode];
+
+    return matrix.map(([mr, mg, mb]) =>
+        clampRgbChannel((mr * r + mg * g + mb * b) * 255),
+    ) as [number, number, number];
+}
+
+export function getRgbDistance(
+    color1: [number, number, number],
+    color2: [number, number, number],
+): number {
+    return Math.hypot(
+        color1[0] - color2[0],
+        color1[1] - color2[1],
+        color1[2] - color2[2],
+    );
+}
+
+export function getCvdPairDistance(
+    color1: string,
+    color2: string,
+    mode: CvdMode,
+): number {
+    return getRgbDistance(
+        simulateColorVisionDeficiency(color1, mode),
+        simulateColorVisionDeficiency(color2, mode),
+    );
+}
+
+export function meetsCvdDistance(
+    color1: string,
+    color2: string,
+    mode: CvdMode,
+    minDistance: number,
+): boolean {
+    return getCvdPairDistance(color1, color2, mode) >= minDistance;
+}
+
 /**
  * Documentation reference for chart color usage
  * See: docs/qa/chart-colors-cvd.md
  */
 export const CVD_DOCUMENTATION = {
-    issue: "#163",
+    issue: "#422",
     title: "Data viz: verify chart colors against design tokens and contrast for CVD",
     palettes: "Use primary or accessible palette from CVD_PALETTES",
-    testing: "All colors tested against WCAG AA contrast (4.5:1 text, 3:1 graphics)",
-    patterns: "Consider adding pattern/texture redundancy for multi-series charts",
+    testing: "Colors are tested against WCAG AA graphics contrast and simulated CVD pair distance",
+    patterns: "Use CHART_TONE_PATTERNS for line, bar, and donut redundancy",
 } as const;

--- a/src/lib/chart-theme.ts
+++ b/src/lib/chart-theme.ts
@@ -1,18 +1,20 @@
 import { ChartTone } from "@/lib/portfolio";
-import { CVD_PALETTES } from "@/lib/chart-colors-cvd";
+import { CHART_TONE_PATTERNS, CVD_PALETTES } from "@/lib/chart-colors-cvd";
 
 // Chart theme configuration
-// Issue #163: Colors are CVD-safe and tested for WCAG AA contrast
+// Issue #422: Colors are CVD-safe and tested for WCAG AA graphics contrast
 export const chartTheme = {
   // Color palette using CVD-safe tokens
-  // Primary palette: Blue/Orange/Teal (safe for deuteranopia, protanopia, tritanopia)
+  // Primary palette: Sky/Orange/Magenta/Neutral with pattern redundancy
   colors: {
-    primary: CVD_PALETTES.primary.blue,           // #0369a1 - Sky blue
-    accent: CVD_PALETTES.primary.orange,          // #ea580c - Vibrant orange
-    warning: CVD_PALETTES.primary.teal,           // #0d9488 - Teal
-    "neutral-strong": CVD_PALETTES.neutral.strong,
+    primary: CVD_PALETTES.primary.sky,
+    accent: CVD_PALETTES.primary.orange,
+    warning: CVD_PALETTES.primary.magenta,
+    "neutral-strong": CVD_PALETTES.primary.neutral,
     "neutral-soft": CVD_PALETTES.neutral.soft,
   } as Record<ChartTone, string>,
+
+  patterns: CHART_TONE_PATTERNS,
 
   // Grid configuration
   grid: {
@@ -81,6 +83,10 @@ export const chartDimensions = {
 // Utility function to get chart color by tone
 export function getChartColor(tone: ChartTone): string {
   return chartTheme.colors[tone];
+}
+
+export function getChartStrokeDasharray(tone: ChartTone): string {
+  return chartTheme.patterns[tone];
 }
 
 // Utility function to get responsive chart config

--- a/src/lib/mock-audit.test.ts
+++ b/src/lib/mock-audit.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { before } from "node:test";
+import type { AuditService } from "./mock-audit";
 
 // mock-audit.ts relies on localStorage which is unavailable in Node.
 // Provide a minimal in-memory shim before importing.
@@ -21,7 +22,11 @@ Object.defineProperty(globalThis, "navigator", {
   configurable: true,
 });
 
-const { mockAuditService } = await import("./mock-audit.js");
+let mockAuditService: AuditService;
+
+before(async () => {
+  ({ mockAuditService } = await import("./mock-audit.js"));
+});
 
 test("logEvent persists an event and returns it", async () => {
   localStorageShim.clear();

--- a/src/lib/onboarding-state.ts
+++ b/src/lib/onboarding-state.ts
@@ -10,15 +10,20 @@ const STORAGE_KEY = STORAGE_KEYS.ONBOARDING_STATE;
 // Legacy key used by older code paths (kept for migration/backwards compatibility)
 const LEGACY_KEY = 'onboarding-state';
 
+function getStorage(): Storage | null {
+  return globalThis.localStorage ?? null;
+}
+
 export function loadOnboardingState(): OnboardingState | null {
-  if (typeof window === 'undefined' || !window?.localStorage) {
+  const storage = getStorage();
+  if (!storage) {
     return null;
   }
 
-  let raw = window.localStorage.getItem(STORAGE_KEY);
+  let raw = storage.getItem(STORAGE_KEY);
   // Fallback to legacy key for existing installs
   if (!raw) {
-    raw = window.localStorage.getItem(LEGACY_KEY) ?? null;
+    raw = storage.getItem(LEGACY_KEY) ?? null;
   }
   if (!raw) {
     return null;
@@ -37,24 +42,26 @@ export function loadOnboardingState(): OnboardingState | null {
 }
 
 export function saveOnboardingState(state: OnboardingState): void {
-  if (typeof window === 'undefined' || !window?.localStorage) {
+  const storage = getStorage();
+  if (!storage) {
     return;
   }
 
   try {
     // Always write to canonical key; keep legacy key untouched to avoid surprising deletes
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    storage.setItem(STORAGE_KEY, JSON.stringify(state));
   } catch (error) {
     console.error('Failed to save onboarding state:', error);
   }
 }
 
 export function clearOnboardingState(): void {
-  if (typeof window === 'undefined' || !window?.localStorage) {
+  const storage = getStorage();
+  if (!storage) {
     return;
   }
 
-  window.localStorage.removeItem(STORAGE_KEY);
+  storage.removeItem(STORAGE_KEY);
 }
 
 export function isOnboardingCompleted(): boolean {

--- a/src/lib/routeMetadata.tsx
+++ b/src/lib/routeMetadata.tsx
@@ -110,6 +110,12 @@ const appRouteDefinitions: AppRouteDefinition[] = [
   },
   { href: "/dashboard/sandbox", label: "Sandbox", icon: SlidersHorizontal },
   {
+    href: "/dashboard/sandbox/ui-demo",
+    label: "UI Demo",
+    icon: Blocks,
+    devOnly: true,
+  },
+  {
     href: "/dashboard/settings",
     label: "Settings",
     icon: Settings,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,11 @@ export interface PageState<T> {
 }
 
 export interface DateRange {
-  start: Date | null;
-  end: Date | null;
+  start: string | Date | null;
+  end: string | Date | null;
+}
+
+export interface DateFilterable {
+  date: string | Date;
+  [key: string]: unknown;
 }


### PR DESCRIPTION
closes #422 

##Summary
Updates chart color tokens to pass WCAG AA graphics contrast on dark and light chart backgrounds.
Adds CVD simulation checks for protanopia, deuteranopia, and tritanopia.
Adds unit coverage for chart contrast, CVD distinguishability, and non-color pattern tokens.
Adds pattern redundancy support for line, bar, and donut chart wrappers.
Updates the chart style guide and QA documentation for issue #422.

##Reason
Chart colors need to remain distinguishable for users with common color-vision deficiencies, not only pass default contrast checks. This adds automated verification and non-color redundancy to reduce reliance on color alone.