### PR TITLE
docs: link SECURITY.md from README footer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ The mock auth flow stores the session in `localStorage` using `SESSION_STORAGE_K
   action, for example `landing-primary-cta-button`, `wallet-connect-button`, and
   `transaction-submit-button`.
 
+## Security
+
+To report a vulnerability or for our handling and response expectations, see [SECURITY.md](SECURITY.md). Please do not file public issues for security reports.
+
 ## License
 
 Internal/demo project — see repository owner for license details.


### PR DESCRIPTION
## Summary
closes #408 
closes #411 
closes #414


Closes the audit-queue items #408, #411, and #414. While addressing these I found that **#408 and #411 were already fully implemented and merged in `main`**, and **#414 was only partially done** (the policy file existed but was undiscoverable). This PR closes the discoverability gap and documents the verified state of all three.

## Issue status

### #414 — Add SECURITY.md with contact and handling expectations ✅ (changed here)
- `SECURITY.md` already defined scope/ownership, private reporting channels (GitHub advisories + `[SECURITY]` email), and response SLAs.
- **Gap:** it was not linked anywhere. This PR adds a **Security** section to the README footer pointing to `SECURITY.md`, satisfying the "link from README footer" acceptance criterion.

### #408 — Runtime validation (Zod) for `/api/*` request bodies ✅ (already in main)
- `src/lib/validation/api.ts` holds colocated Zod schemas.
- Validation is wired into `transactions`, `portfolio`, `strategy`, and `transaction-history` routes.
- Invalid input returns `400` with the existing `VALIDATION_ERROR` envelope via `errorResponse` + `zodErrorToDetails`.

### #411 — Single public surface for auth + wallet hooks ✅ (already in main)
- `@/contexts` barrel is the single public surface.
- `eslint.config.mjs` enforces it with `no-restricted-imports`.
- Allowed import path documented in `CONTRIBUTING.md`.
- No scattered `@/context/...` imports remain in `src/`.

## Changes in this PR
- `README.md`: add Security section in the footer linking to `SECURITY.md`.

## QA / verification
- Docs-only change; no code paths touched.
- `#408`: send a malformed body to `/api/transactions` → `400` with `VALIDATION_ERROR` details.
- `#411`: `import { useAuth } from "@/contexts/AuthContext"` triggers the ESLint `no-restricted-imports` error.
- `#414`: README footer now renders a clickable link to `SECURITY.md`