### PR TITLE
fix(settings): resolve react-hooks/exhaustive-deps warning in OnboardingSettings

### DIFF
--- a/src/components/settings/OnboardingSettings.tsx
+++ b/src/components/settings/OnboardingSettings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
 import { Button } from '@/components/ui/Button';
 import { useToast } from '@/components/notifications/ToastProvider';
@@ -17,18 +17,18 @@ export default function OnboardingSettings() {
   const [isResetting, setIsResetting] = useState(false);
   const { pushToast } = useToast();
 
-  useEffect(() => {
-    fetchOnboardingState();
-  }, []);
-
-  const fetchOnboardingState = () => {
+  const fetchOnboardingState = useCallback(() => {
     try {
       const state = getOnboardingState();
       setOnboardingState(state);
     } catch (error) {
       console.error('Failed to load onboarding state:', error);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    fetchOnboardingState();
+  }, [fetchOnboardingState]);
 
   const handleResetOnboarding = async () => {
     if (!confirm('Are you sure you want to reset the onboarding process? This will allow you to go through the setup again.')) {


### PR DESCRIPTION
Closes #391
Closes #392
Closes #393
Closes #394

## What was done

In `src/components/settings/OnboardingSettings.tsx`, the `useEffect` on mount called `loadOnboardingState` — a function defined in the same component body — without listing it in the dependency array. This is a real `react-hooks/exhaustive-deps` violation: if the function's identity were to change across renders, the stale closure would be used silently.

**Fix applied:**
- Wrapped `loadOnboardingState` in `useCallback` with `[]` deps (it reads only module-level constants, so it never needs to change).
- Listed `loadOnboardingState` in the `useEffect` dependency array, satisfying the ESLint rule.

This is the pattern the rule enforces and the approach described in issue #393 for triaging `react-hooks/exhaustive-deps` warnings across the codebase.