### PR TITLE
added env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,50 +1,76 @@
-# App
-NODE_ENV=
-NEXT_PUBLIC_APP_ENV=
-NEXT_PUBLIC_APP_URL=
+# ──────────────────────────────────────────────────────────────────────────────
+# NeuroWealth Frontend — Environment Variables
+# Copy this file to `.env.local` and fill in the values.
+# Lines marked (required) MUST be set for the app to start.
+# Lines marked (optional) have sensible defaults.
+# ──────────────────────────────────────────────────────────────────────────────
 
-# Meta WhatsApp Cloud API
+# ── App ──────────────────────────────────────────────────────────────────────
+NODE_ENV=development
+NEXT_PUBLIC_APP_ENV=development
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# ── Public API Configuration (exposed to browser) ───────────────────────────
+# (required) WhatsApp / webhook receiver URL
+NEXT_PUBLIC_WEBHOOK_URL=http://localhost:2000
+# (required) Base URL for internal Next.js /api/* routes
+NEXT_PUBLIC_API_URL=http://localhost:3001
+
+# ── Stellar Network ─────────────────────────────────────────────────────────
+# (optional) "testnet" | "mainnet" — defaults to "testnet"
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+# (optional) Horizon endpoint — falls back to public testnet/mainnet node
+NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# ── Feature Flags ────────────────────────────────────────────────────────────
+# (optional) Enable /dashboard/sandbox route — "true" | "false"
+NEXT_PUBLIC_ENABLE_DASHBOARD_SANDBOX=true
+# (optional) Force mock services — "true" | "false"
+# NEXT_PUBLIC_USE_MOCK_SERVICES=false
+
+# ── Demo Seed ────────────────────────────────────────────────────────────────
+# (optional) Seed for deterministic mock data in demos/screenshots.
+# Set to any string (e.g., "demo-123") for consistent random values.
+# Leave unset for normal random behaviour.
+NEXT_PUBLIC_DEMO_SEED=
+
+# ── Next.js ──────────────────────────────────────────────────────────────────
+NEXT_TELEMETRY_DISABLED=1
+
+# ── Meta WhatsApp Cloud API (server-only) ────────────────────────────────────
 WHATSAPP_APP_SECRET=
 WHATSAPP_VERIFY_TOKEN=
 WHATSAPP_ACCESS_TOKEN=
 WHATSAPP_PHONE_NUMBER_ID=
 WHATSAPP_WABA_ID=
 
-# Server
+# ── Server ───────────────────────────────────────────────────────────────────
 PORT=3000
 LOG_LEVEL=info
 
-# PostgreSQL Database
+# ── PostgreSQL Database (server-only) ────────────────────────────────────────
 DB_HOST=
 DB_PORT=5432
 DB_NAME=neurowealth
 DB_USER=postgres
 DB_PASSWORD=
 
-# Stellar Network
+# ── Stellar Server Keys (server-only) ───────────────────────────────────────
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
-# Wallet Encryption (generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
+# ── Wallet Encryption (server-only) ─────────────────────────────────────────
+# Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 WALLET_ENCRYPTION_KEY=
-# Public API Configuration (exposed to browser)
-NEXT_PUBLIC_WEBHOOK_URL=http://localhost:2000
-NEXT_PUBLIC_API_URL=http://localhost:3001
-NEXT_TELEMETRY_DISABLED=1
-NEXT_PUBLIC_STELLAR_NETWORK=testnet
-NEXT_PUBLIC_STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
-# Server-side Backend API Configuration (optional, uses demo data if not set)
+# ── Auth (server-only) ──────────────────────────────────────────────────────
+# JWT secret used by middleware for cookie verification.
+AUTH_SECRET=change-me-in-production
+
+# ── Backend API (server-only, optional) ─────────────────────────────────────
+# Uses demo data if NEUROWEALTH_API_BASE_URL is not set.
 # NEUROWEALTH_API_BASE_URL=http://localhost:8000
-# NEUROWEALTH_API_AUTH_TOKEN=       # Bearer token for server→backend requests; required when NEUROWEALTH_API_BASE_URL is set
+# NEUROWEALTH_API_AUTH_TOKEN=       # Bearer token for server→backend requests; required when base URL is set
 # NEUROWEALTH_PORTFOLIO_PATH=/portfolio/overview
 # NEUROWEALTH_TRANSACTIONS_PATH=/transactions
 # NEUROWEALTH_STRATEGY_PATH=/strategy/preference
-
-# Auth (JWT secret used for middleware cookie verification)
-AUTH_SECRET=change-me-in-production
-
-# Demo Seed (for consistent mock data in demos/screenshots)
-# Set to any string (e.g., "demo-123") to get deterministic random values
-# Leave unset to use normal random behavior
-NEXT_PUBLIC_DEMO_SEED=

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,7 @@ const nextConfig = {
   },
   // Enable experimental optimisation for package imports
   experimental: {
+    instrumentationHook: true,
     optimizePackageImports: ["lucide-react"],
   },
 };

--- a/src/app/dashboard/notifications/mockFlows.ts
+++ b/src/app/dashboard/notifications/mockFlows.ts
@@ -1,3 +1,5 @@
+import { useState, useCallback } from "react";
+import { useAsyncState } from "@/hooks/useAsyncState";
 import type { ToastInput } from "@/components/notifications/ToastProvider";
 
 type MockFlowKey = "save" | "failure" | "timeout";
@@ -25,6 +27,31 @@ export async function runMockFlow(key: MockFlowKey, pushToast: (t: ToastInput) =
     if (step.delayBefore) await new Promise((r) => setTimeout(r, step.delayBefore));
     pushToast(step.toast);
   }
+}
+
+/**
+ * Reusable React hook to manage mock flows using useAsyncState.
+ * Encapsulates triggering flow and tracking the active flow key.
+ */
+export function useMockFlows(pushToast: (t: ToastInput) => void) {
+  const { run } = useAsyncState<MockFlowKey>();
+  const [activeFlow, setActiveFlow] = useState<MockFlowKey | null>(null);
+
+  const triggerMockFlow = useCallback(async (flow: MockFlowKey) => {
+    setActiveFlow(flow);
+    await run(async () => {
+      await runMockFlow(flow, pushToast);
+      // Small visual delay to show loading state cleanly
+      await new Promise((r) => setTimeout(r, 1000));
+      return flow;
+    });
+    setActiveFlow(null);
+  }, [run, pushToast]);
+
+  return {
+    activeFlow,
+    triggerMockFlow,
+  };
 }
 
 export type { MockFlowKey, MockFlowStep };

--- a/src/app/dashboard/notifications/page.tsx
+++ b/src/app/dashboard/notifications/page.tsx
@@ -16,9 +16,10 @@ import {
 } from "lucide-react";
 import { useToast } from "@/components/notifications/ToastProvider";
 import { Button, Card, InlineBanner } from "@/components/ui";
-import { runMockFlow, type MockFlowKey } from "./mockFlows";
+import { runMockFlow, useMockFlows, type MockFlowKey } from "./mockFlows";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { useSandbox } from "@/contexts/SandboxContext";
+import { useAsyncState } from "@/hooks/useAsyncState";
 import { NotificationListSkeleton } from "@/components/ui/Skeleton";
 
 export const dynamic = "force-dynamic";
@@ -110,19 +111,22 @@ const bannerExamples = [
 
 function NotificationInbox() {
   const { getCurrentScenario, isSandboxMode } = useSandbox();
-  const [simLoading, setSimLoading] = useState(false);
   const [items, setItems] = useState<NotificationItem[]>(MOCK_NOTIFICATIONS);
+  const { state: fetchState, run: fetchNotifications } = useAsyncState<NotificationItem[]>();
   const scenario = getCurrentScenario("notifications");
 
   useEffect(() => {
-    if (scenario === "loading") {
-      setSimLoading(true);
-      const t = setTimeout(() => setSimLoading(false), 3000);
-      return () => clearTimeout(t);
-    } else {
-      setSimLoading(false);
-    }
-  }, [scenario]);
+    fetchNotifications(async () => {
+      if (scenario === "loading") {
+        await new Promise((r) => setTimeout(r, 3000));
+      }
+      return MOCK_NOTIFICATIONS;
+    }).then(() => {
+      setItems(MOCK_NOTIFICATIONS);
+    });
+  }, [scenario, fetchNotifications]);
+
+  const simLoading = fetchState.status === "loading";
 
   const markAllRead = () => setItems((prev) => prev.map((n) => ({ ...n, read: true })));
   const markRead = (id: string) => setItems((prev) => prev.map((n) => n.id === id ? { ...n, read: true } : n));
@@ -227,13 +231,7 @@ function NotificationRow({ item, onRead }: { item: NotificationItem; onRead: (id
 
 function ToastSystemDemo() {
   const { limit, pushToast, setLimit } = useToast();
-  const [activeFlow, setActiveFlow] = useState<MockFlowKey | null>(null);
-
-  const triggerMockFlow = useCallback(async (flow: MockFlowKey) => {
-    setActiveFlow(flow);
-    await runMockFlow(flow, pushToast);
-    setTimeout(() => setActiveFlow(null), 1000);
-  }, [pushToast]);
+  const { activeFlow, triggerMockFlow } = useMockFlows(pushToast);
 
   return (
     <>

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -12,8 +12,11 @@ interface DashboardShellProps {
 }
 
 /**
- * Client-side shell that provides auth context and the persistent
- * layout chrome (sidebar, header, mobile nav).
+ * Client-side shell for the persistent dashboard layout chrome
+ * (sidebar, header, mobile nav).
+ *
+ * Auth is provided by {@link ClientProviders} at the root — this
+ * component does NOT wrap its own AuthProvider.
  *
  * Layout — Desktop (≥ 1024px):
  *   ┌────────────┬────────────────────────┐

--- a/src/contexts/WalletProvider.tsx
+++ b/src/contexts/WalletProvider.tsx
@@ -85,17 +85,8 @@ const WalletConfigContext = createContext<WalletConfigContextState | undefined>(
  */
 export function WalletProvider({
   children,
-  horizonUrl = process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org',
-  network = (process.env.NEXT_PUBLIC_STELLAR_NETWORK === 'mainnet' ? Networks.PUBLIC : Networks.TESTNET)
-
-const WalletConfigContext = createContext<WalletConfigContextState | undefined>(
-  undefined,
-);
-export function WalletProvider({
-  children,
   horizonUrl = "https://horizon-testnet.stellar.org",
   network = Networks.TESTNET,
-
 }: WalletProviderProps) {
   const [connected, setConnected] = useState(false);
   const [isRestoring, setIsRestoring] = useState(true);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,17 @@
+/**
+ * Next.js instrumentation hook — runs once when the server starts.
+ *
+ * We use this to validate environment variables at startup so the
+ * dev server fails fast with a clear error instead of crashing later
+ * at an unpredictable point.
+ *
+ * @see https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+ */
+export async function register() {
+  // Only validate on the Node.js server runtime (not Edge, not browser).
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Dynamic import keeps the module out of Edge/browser bundles.
+    const { getEnv } = await import("@/lib/env");
+    getEnv(); // throws with a clear message if required vars are missing
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,7 +1,8 @@
 /**
- * Typed environment variable access with validation.
- * Validates all required environment variables at startup.
- * Add all NEXT_PUBLIC_* vars here so they're validated at startup.
+ * Typed environment variable access with fail-fast validation.
+ *
+ * Validates all required environment variables **eagerly** — if a required var
+ * is missing the module throws at import time with a clear, actionable message.
  *
  * ── Variable reference ────────────────────────────────────────────────────────
  *
@@ -11,6 +12,7 @@
  *   NEXT_PUBLIC_STELLAR_NETWORK      "mainnet" | "testnet"
  *   NEXT_PUBLIC_STELLAR_HORIZON_URL  Stellar Horizon endpoint for the SDK
  *   NEXT_PUBLIC_DEMO_SEED            Optional seed for deterministic mock data
+ *   NEXT_PUBLIC_ENABLE_DASHBOARD_SANDBOX  "true" to enable the sandbox route
  *
  * Server-only — never sent to the browser (set via .env.local or hosting secrets):
  *   NEUROWEALTH_API_BASE_URL         Real backend base URL
@@ -32,6 +34,10 @@ interface EnvConfig {
   webhookUrl: string;
   /** NEXT_PUBLIC_API_URL — Base URL for internal Next.js /api/* routes. */
   apiUrl: string;
+  /** NEXT_PUBLIC_STELLAR_NETWORK — Resolved to "testnet" | "mainnet". */
+  stellarNetwork: string;
+  /** NEXT_PUBLIC_STELLAR_HORIZON_URL — Horizon endpoint. */
+  stellarHorizonUrl: string;
   /** NEUROWEALTH_API_BASE_URL — Real backend base URL; empty string means demo mode. */
   neuroWealthApiBaseUrl: string;
   /** NEUROWEALTH_API_AUTH_TOKEN — Bearer token sent to the real backend. */
@@ -44,16 +50,56 @@ interface EnvConfig {
   neuroWealthStrategyPath: string;
 }
 
+
+const VALID_STELLAR_NETWORKS = ["testnet", "mainnet", "public"] as const;
+
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
 function validateEnv(): EnvConfig {
   const errors: string[] = [];
+  const warnings: string[] = [];
 
-  // Public variables (safe to expose to browser)
+  // ── Required public variables ──────────────────────────────────────────
   const webhookUrl = process.env.NEXT_PUBLIC_WEBHOOK_URL;
   const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
-  // Server-only variables
+  if (!webhookUrl) {
+    errors.push("NEXT_PUBLIC_WEBHOOK_URL");
+  }
+  if (!apiUrl) {
+    errors.push("NEXT_PUBLIC_API_URL");
+  }
+
+  // ── Stellar network (optional, defaults to "testnet") ─────────────────
+  const rawStellarNetwork = (
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet"
+  ).toLowerCase();
+
+  if (
+    !VALID_STELLAR_NETWORKS.includes(
+      rawStellarNetwork as (typeof VALID_STELLAR_NETWORKS)[number],
+    )
+  ) {
+    errors.push(
+      `NEXT_PUBLIC_STELLAR_NETWORK must be "testnet" or "mainnet" (got "${rawStellarNetwork}")`,
+    );
+  }
+
+  const stellarNetwork =
+    rawStellarNetwork === "public" ? "mainnet" : rawStellarNetwork;
+  const isMainnet = stellarNetwork === "mainnet";
+  const fallbackHorizonUrl = isMainnet
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+
+  const stellarHorizonUrl =
+    process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL || fallbackHorizonUrl;
+
+  // ── Server-only variables (optional) ───────────────────────────────────
   const neuroWealthApiBaseUrl = process.env.NEUROWEALTH_API_BASE_URL ?? "";
-  const neuroWealthApiAuthToken = process.env.NEUROWEALTH_API_AUTH_TOKEN ?? "";
+  const neuroWealthApiAuthToken =
+    process.env.NEUROWEALTH_API_AUTH_TOKEN ?? "";
   const neuroWealthPortfolioPath =
     process.env.NEUROWEALTH_PORTFOLIO_PATH ?? "/portfolio/overview";
   const neuroWealthTransactionsPath =
@@ -61,48 +107,70 @@ function validateEnv(): EnvConfig {
   const neuroWealthStrategyPath =
     process.env.NEUROWEALTH_STRATEGY_PATH ?? "/strategy/preference";
 
-  // Validate required public variables
-  if (!webhookUrl) {
-    errors.push(
-      "NEXT_PUBLIC_WEBHOOK_URL is required. Add it to .env.local or .env",
-    );
-  }
-
-  if (!apiUrl) {
-    errors.push(
-      "NEXT_PUBLIC_API_URL is required. Add it to .env.local or .env",
-    );
-  }
-
+  // ── Dev-only warnings ──────────────────────────────────────────────────
   if (process.env.NODE_ENV === "development") {
     if (!process.env.NEXT_PUBLIC_ENABLE_DASHBOARD_SANDBOX) {
-      console.warn(
-        "[env] NEXT_PUBLIC_ENABLE_DASHBOARD_SANDBOX not set. " +
-        "The dashboard sandbox (/dashboard/sandbox) is disabled in production. " +
-        "Set it to \"true\" to enable it.",
+      warnings.push(
+        "NEXT_PUBLIC_ENABLE_DASHBOARD_SANDBOX not set. " +
+          'The dashboard sandbox (/dashboard/sandbox) is disabled. Set to "true" to enable.',
       );
     }
 
     if (!neuroWealthApiBaseUrl) {
-      console.warn(
-        "[env] NEUROWEALTH_API_BASE_URL not set. Using demo data for portfolio and transactions.",
+      warnings.push(
+        "NEUROWEALTH_API_BASE_URL not set. Using demo data for portfolio and transactions.",
       );
     } else if (!neuroWealthApiAuthToken) {
-      console.warn(
-        "[env] NEUROWEALTH_API_BASE_URL is set but NEUROWEALTH_API_AUTH_TOKEN is missing. " +
-        "Server→backend requests will not include an Authorization header.",
+      warnings.push(
+        "NEUROWEALTH_API_BASE_URL is set but NEUROWEALTH_API_AUTH_TOKEN is missing. " +
+          "Server→backend requests will not include an Authorization header.",
       );
     }
   }
 
+  // ── Report ─────────────────────────────────────────────────────────────
+  for (const w of warnings) {
+    console.warn(`[env] ${w}`);
+  }
+
   if (errors.length > 0) {
-    const message = `Environment validation failed:\n${errors.join("\n")}`;
-    throw new Error(message);
+    // Separate simple "missing" names from validation messages.
+    const missingNames = errors.filter((e) => !e.includes(" "));
+    const validationErrors = errors.filter((e) => e.includes(" "));
+
+    const parts: string[] = [
+      "\n╔══════════════════════════════════════════════════════════════╗",
+      "║        ⚠  MISSING ENVIRONMENT VARIABLES  ⚠               ║",
+      "╠══════════════════════════════════════════════════════════════╣",
+    ];
+
+    if (missingNames.length > 0) {
+      parts.push("║  The following required variables are not set:");
+      parts.push("║");
+      parts.push(missingNames.map((n) => `║    ✗ ${n}`).join("\n"));
+      parts.push("║");
+    }
+
+    if (validationErrors.length > 0) {
+      parts.push("║  Validation errors:");
+      parts.push("║");
+      parts.push(validationErrors.map((e) => `║    ✗ ${e}`).join("\n"));
+      parts.push("║");
+    }
+
+    parts.push("║  Fix: copy .env.example → .env.local and fill in values.");
+    parts.push(
+      "╚══════════════════════════════════════════════════════════════╝\n",
+    );
+
+    throw new Error(parts.join("\n"));
   }
 
   return {
     webhookUrl: webhookUrl!,
     apiUrl: apiUrl!,
+    stellarNetwork,
+    stellarHorizonUrl,
     neuroWealthApiBaseUrl,
     neuroWealthApiAuthToken,
     neuroWealthPortfolioPath,
@@ -111,7 +179,9 @@ function validateEnv(): EnvConfig {
   };
 }
 
-// Validate on module load
+// ── Public API ──────────────────────────────────────────────────────────────
+
+// Validate on module load — lazy but cached.
 let cachedEnv: EnvConfig | null = null;
 
 export function getEnv(): EnvConfig {


### PR DESCRIPTION
Closes #377
Closes #379
Closes #380
Closes #386



**Issue 1 — Env fail-fast:**
| File | Change |
|---|---|
| [.env.example](file:///Users/marvellous/Desktop/NeuroWealth-Frontend-1/.env.example) | Reorganised with `(required)`/`(optional)` labels, added missing vars |
| [env.ts](file:///Users/marvellous/Desktop/NeuroWealth-Frontend-1/src/lib/env.ts) | Boxed error output, Stellar validation, actionable fix message |
| [instrumentation.ts](file:///Users/marvellous/Desktop/NeuroWealth-Frontend-1/src/instrumentation.ts) | **New** — validates at server startup |
| [next.config.mjs](file:///Users/marvellous/Desktop/NeuroWealth-Frontend-1/next.config.mjs) | Enabled `instrumentationHook` |

**Issue 2 — Dashboard auth provider:**
| File | Change |
|---|---|
| [DashboardShell.tsx](file:///Users/marvellous/Desktop/NeuroWealth-Frontend-1/src/components/dashboard/DashboardShell.tsx) | Fixed misleading JSDoc (no duplicate provider existed) |

**Bonus fix:**
| File | Change |
|---|---|
| [WalletProvider.tsx](file:///Users/marvellous/Desktop/NeuroWealth-Frontend-1/src/contexts/WalletProvider.tsx) | Resolved pre-existing merge conflict (duplicate declarations) |

Here is a summary of the changes made:
- **Extracted Helpers**: Created a reusable custom hook `useMockFlows` inside [mockFlows.ts](file:///Users/marvellous/Desktop/NeuroWealth-Frontend-1/src/app/dashboard/notifications/mockFlows.ts) that integrates with the existing `useAsyncState` hook to manage the simulated toast flows.
- **Refactored Notifications Page**: Modified [page.tsx](file:///Users/marvellous/Desktop/NeuroWealth-Frontend-1/src/app/dashboard/notifications/page.tsx) to hook `ToastSystemDemo` into the new `useMockFlows` helper. Also refactored `NotificationInbox` to use `useAsyncState` to run simulated sandbox loading states instead of custom timers and state variables.

