### PR TITLE
fix: harden portfolio and transaction recovery ux

### DIFF
--- a/src/components/dashboard/PortfolioDashboard.tsx
+++ b/src/components/dashboard/PortfolioDashboard.tsx
@@ -23,6 +23,7 @@ import {
 import { ApiRequestError, apiRequest } from "@/lib/api-client";
 import { useSandbox, ScenarioType } from "@/contexts/SandboxContext";
 import { AllocationChart } from "./AllocationChart";
+import { ErrorBlock } from "@/components/ui/ErrorBlock";
 
 type ThemeMode = "light" | "dark";
 
@@ -194,6 +195,7 @@ export function PortfolioDashboard() {
   const [portfolio, setPortfolio] = useState<PortfolioPayload | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retryNonce, setRetryNonce] = useState(0);
 
   const theme = getTheme(searchParams);
   const scenario = getScenario(searchParams, mapScenarioTypeToPortfolio(getCurrentScenario("portfolio")));
@@ -238,7 +240,7 @@ export function PortfolioDashboard() {
     void loadPortfolio();
 
     return () => controller.abort();
-  }, [scenario]);
+  }, [scenario, retryNonce]);
 
   function updateParam(key: "scenario" | "theme", value: string) {
     const nextParams = new URLSearchParams(searchParams.toString());
@@ -251,6 +253,10 @@ export function PortfolioDashboard() {
 
   function resetToLivePreview() {
     updateParam("scenario", "live");
+  }
+
+  function retryPortfolio() {
+    setRetryNonce((value) => value + 1);
   }
 
   const summaryCards = portfolio
@@ -379,22 +385,13 @@ export function PortfolioDashboard() {
           </div>
 
           {error && !portfolio ? (
-            <div className={`${styles.card} ${styles.errorState}`}>
-              <h2 className={styles.errorTitle}>
-                Portfolio widgets unavailable
-              </h2>
-              <p className={styles.errorCopy}>
-                {error} The dashboard can retry once connectivity to the
-                portfolio API is restored.
-              </p>
-              <button
-                className={styles.emptyButton}
-                onClick={resetToLivePreview}
-                type="button"
-              >
-                Retry widgets
-              </button>
-            </div>
+            <ErrorBlock
+              className={styles.card}
+              title="Portfolio widgets unavailable"
+              description={`${error} Retry once connectivity to the portfolio API is restored.`}
+              actionLabel="Retry widgets"
+              onAction={retryPortfolio}
+            />
           ) : (
             <>
               <div className={styles.summaryGrid}>

--- a/src/components/transactions/TransactionFlow.tsx
+++ b/src/components/transactions/TransactionFlow.tsx
@@ -22,7 +22,6 @@ import {
   TransactionReceipt,
   validateTransactionValues,
   getTransactionRecoveryUI,
-  mapErrorCodeToErrorMode,
   type RecoveryAction,
   type TransactionRecoveryUI,
 } from "@/lib/transactions";
@@ -99,6 +98,7 @@ export function TransactionFlow() {
   const searchParams = useSearchParams();
   const { getCurrentScenario, isSandboxMode } = useSandbox();
   const timeoutRef = useRef<number | null>(null);
+  const requestControllerRef = useRef<AbortController | null>(null);
 
   const [theme, setTheme] = useState<ThemeMode>(() => getTheme(searchParams));
   const [kind, setKind] = useState<TransactionKind>(() =>
@@ -121,6 +121,7 @@ export function TransactionFlow() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [recovery, setRecovery] = useState<TransactionRecoveryUI | null>(null);
   const [lastErrorReference, setLastErrorReference] = useState<string | null>(null);
+  const [lastFailedAction, setLastFailedAction] = useState<"review" | "confirm" | null>(null);
 
   const context = getTransactionContext(kind);
   const statusChips = buildStatusChips(kind, formValues);
@@ -145,6 +146,7 @@ export function TransactionFlow() {
       setIsSubmitting(false);
       setRecovery(null);
       setLastErrorReference(null);
+      setLastFailedAction(null);
       return;
     }
 
@@ -158,6 +160,7 @@ export function TransactionFlow() {
     setIsSubmitting(false);
     setRecovery(null);
     setLastErrorReference(null);
+    setLastFailedAction(null);
   }, [kind, preview]);
 
   // Handle sandbox scenarios
@@ -200,10 +203,27 @@ export function TransactionFlow() {
         window.clearTimeout(timeoutRef.current);
         timeoutRef.current = null;
       }
+      if (requestControllerRef.current) {
+        requestControllerRef.current.abort();
+        requestControllerRef.current = null;
+      }
       // Clean up all state on unmount to prevent memory leaks
       // This ensures pending states and timers are cleared when component is destroyed
     };
   }, []);
+
+  function beginApiRequest() {
+    requestControllerRef.current?.abort();
+    const controller = new AbortController();
+    requestControllerRef.current = controller;
+    return controller;
+  }
+
+  function endApiRequest(controller: AbortController) {
+    if (requestControllerRef.current === controller) {
+      requestControllerRef.current = null;
+    }
+  }
 
   function syncRoute(
     nextTheme: ThemeMode,
@@ -262,9 +282,7 @@ export function TransactionFlow() {
     updateField("amount", context.availableAmount.toFixed(2));
   }
 
-  async function handleReview(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-
+  async function submitReview() {
     if (preview !== "interactive") {
       return;
     }
@@ -279,6 +297,9 @@ export function TransactionFlow() {
     setIsSubmitting(true);
     setRequestMessage(null);
     setRecovery(null);
+    setLastFailedAction(null);
+
+    const controller = beginApiRequest();
 
     try {
       const payload = await apiRequest<{ quote: TransactionQuote }>(
@@ -291,6 +312,7 @@ export function TransactionFlow() {
             values: formValues,
           },
           timeoutMs: 12000,
+          signal: controller.signal,
         },
       );
 
@@ -298,7 +320,14 @@ export function TransactionFlow() {
       setQuote(payload.quote);
       setStage("confirm");
       setRecovery(null);
+      setLastFailedAction(null);
     } catch (error) {
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      setLastFailedAction("review");
+
       if (error instanceof ApiRequestError) {
         // Map API error code to recovery UI with actionable copy
         const recoveryUI = getTransactionRecoveryUI(error.code, quote?.reference);
@@ -314,8 +343,16 @@ export function TransactionFlow() {
       setRecovery(recoveryUI);
       setStage("error");
     } finally {
-      setIsSubmitting(false);
+      endApiRequest(controller);
+      if (!controller.signal.aborted) {
+        setIsSubmitting(false);
+      }
     }
+  }
+
+  async function handleReview(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await submitReview();
   }
 
   async function handleConfirm() {
@@ -326,6 +363,9 @@ export function TransactionFlow() {
     setIsSubmitting(true);
     setRequestMessage(null);
     setRecovery(null);
+    setLastFailedAction(null);
+
+    const controller = beginApiRequest();
 
     try {
       const payload = await apiRequest<{ pending: PendingTransaction }>(
@@ -338,6 +378,7 @@ export function TransactionFlow() {
             values: formValues,
           },
           timeoutMs: 12000,
+          signal: controller.signal,
         },
       );
 
@@ -345,6 +386,7 @@ export function TransactionFlow() {
       setQuote(payload.pending.quote);
       setStage("pending");
       setLastErrorReference(payload.pending.reference);
+      setLastFailedAction(null);
 
       timeoutRef.current = window.setTimeout(() => {
         const nextReceipt = buildTransactionReceipt(
@@ -359,6 +401,12 @@ export function TransactionFlow() {
         setIsSubmitting(false);
       }, payload.pending.completionDelayMs);
     } catch (error) {
+      if (controller.signal.aborted) {
+        return;
+      }
+
+      setLastFailedAction("confirm");
+
       if (error instanceof ApiRequestError) {
         // Map API error code to recovery UI with actionable copy and transaction reference
         const recoveryUI = getTransactionRecoveryUI(
@@ -377,7 +425,10 @@ export function TransactionFlow() {
         setStage("error");
       }
     } finally {
-      setIsSubmitting(false);
+      endApiRequest(controller);
+      if (!controller.signal.aborted) {
+        setIsSubmitting(false);
+      }
     }
   }
 
@@ -392,10 +443,14 @@ export function TransactionFlow() {
   function handleRecoveryAction(action: RecoveryAction) {
     switch (action) {
       case "retry": {
-        // Clear error state and retry the last operation
-        setStage("form");
+        // Clear error state and retry the failed operation with the saved values.
         setRecovery(null);
-        setIsSubmitting(false);
+        setRequestMessage("Retrying request...");
+        if (lastFailedAction === "confirm" && quote) {
+          void handleConfirm();
+        } else {
+          void submitReview();
+        }
         break;
       }
       case "edit": {
@@ -403,6 +458,7 @@ export function TransactionFlow() {
         setStage("form");
         setRecovery(null);
         setIsSubmitting(false);
+        setLastFailedAction(null);
         break;
       }
       case "support": {


### PR DESCRIPTION
## Summary

- Add a real retry path for failed portfolio dashboard fetches.
- Replace the custom portfolio failure panel with the existing ErrorBlock pattern.
- Track the failed transaction action so recovery retry replays quote or submit.
- Abort in-flight transaction API requests on unmount or replacement requests.

Closes #389
Closes #390
Closes #387
Closes #388
