### PR TITLE
test(search): race-safety tests for global search + close chart/search cleanup batch (#363, #364, #365, #367)

### DIFF
--- a/src/components/search/GlobalSearch.test.ts
+++ b/src/components/search/GlobalSearch.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { computeNextIndex } from "@/components/search/GlobalSearch";
+import {
+  computeNextIndex,
+  createLatestRequestTracker,
+} from "@/components/search/GlobalSearch";
 import {
   GroupedSearchResults,
   hasAnySearchResults,
@@ -40,6 +43,66 @@ test("computeNextIndex returns -1 when total is 0", () => {
 
 test("computeNextIndex clamps out-of-range current to 0", () => {
   assert.equal(computeNextIndex(99, 1, 5), 0);
+});
+
+// ── createLatestRequestTracker (race safety, #365) ───────────────────────────
+
+test("tracker: a response for the latest request is applied", () => {
+  const tracker = createLatestRequestTracker();
+  const id = tracker.start();
+  assert.equal(tracker.isStale(id), false);
+});
+
+test("tracker: rapid typing supersedes the earlier in-flight request", () => {
+  const tracker = createLatestRequestTracker();
+  // User types, fires a search, then types again before the first resolves.
+  const first = tracker.start();
+  const second = tracker.start();
+
+  // Slow first response arrives after the second query started → dropped.
+  assert.equal(tracker.isStale(first), true);
+  // Newer query's response is still applied.
+  assert.equal(tracker.isStale(second), false);
+});
+
+test("tracker: out-of-order resolution never lets a stale result win", () => {
+  const tracker = createLatestRequestTracker();
+  const first = tracker.start();
+  const second = tracker.start();
+
+  // Even if the second resolves first and the first resolves last,
+  // the first remains stale and cannot overwrite the newer results.
+  assert.equal(tracker.isStale(second), false);
+  assert.equal(tracker.isStale(first), true);
+});
+
+test("tracker: invalidate() drops the in-flight request (clear / navigate / unmount)", () => {
+  const tracker = createLatestRequestTracker();
+  const id = tracker.start();
+  tracker.invalidate();
+
+  // A late response after clearing the query can no longer repopulate.
+  assert.equal(tracker.isStale(id), true);
+});
+
+test("tracker: a fresh request after invalidate is honoured again", () => {
+  const tracker = createLatestRequestTracker();
+  tracker.start();
+  tracker.invalidate();
+
+  const next = tracker.start();
+  assert.equal(tracker.isStale(next), false);
+});
+
+test("tracker: ids are strictly increasing across starts and invalidations", () => {
+  const tracker = createLatestRequestTracker();
+  const a = tracker.start();
+  const b = tracker.start();
+  tracker.invalidate();
+  const c = tracker.start();
+
+  assert.ok(b > a);
+  assert.ok(c > b);
 });
 
 // ── hasAnySearchResults ──────────────────────────────────────────────────────

--- a/src/components/search/GlobalSearch.tsx
+++ b/src/components/search/GlobalSearch.tsx
@@ -45,6 +45,31 @@ export function computeNextIndex(
   return next;
 }
 
+/**
+ * Tracks the latest in-flight async search so stale responses can be dropped.
+ * Extracted as a pure helper (rather than inlined ref arithmetic) so the
+ * latest-wins / supersede behaviour can be unit-tested directly — see #365.
+ */
+export interface LatestRequestTracker {
+  /** Begin a new request; supersedes all earlier ones and returns its id. */
+  start(): number;
+  /** True once `id` is no longer the latest (a newer request or invalidate ran). */
+  isStale(id: number): boolean;
+  /** Supersede any in-flight request without starting a new one (clear/navigate/unmount). */
+  invalidate(): void;
+}
+
+export function createLatestRequestTracker(): LatestRequestTracker {
+  let latest = 0;
+  return {
+    start: () => ++latest,
+    isStale: (id: number) => id !== latest,
+    invalidate: () => {
+      latest += 1;
+    },
+  };
+}
+
 export function GlobalSearch({
   placeholder = "Search pages, actions, or records",
   onRequestClose,
@@ -66,10 +91,10 @@ export function GlobalSearch({
 
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  // Monotonic id for the latest in-flight search. A response is applied only
-  // when its id still matches, so a slow search can never overwrite a newer
-  // one (or results that were cleared / navigated away from).
-  const requestIdRef = useRef(0);
+  // Tracks the latest in-flight search. A response is applied only when its id
+  // is still the latest, so a slow search can never overwrite a newer one (or
+  // results that were cleared / navigated away from).
+  const requestTrackerRef = useRef<LatestRequestTracker>(createLatestRequestTracker());
 
   useOnClickOutside(rootRef, () => {
     setIsOpen(false);
@@ -86,9 +111,11 @@ export function GlobalSearch({
   }, [autoFocus]);
 
   useEffect(() => {
+    const tracker = requestTrackerRef.current;
+
     if (!debouncedQuery) {
       // Invalidate any in-flight search so a late response can't repopulate.
-      requestIdRef.current += 1;
+      tracker.invalidate();
       setResults(EMPTY_RESULTS);
       setErrorMessage(null);
       setIsLoading(false);
@@ -96,33 +123,33 @@ export function GlobalSearch({
       return;
     }
 
-    const requestId = ++requestIdRef.current;
+    const requestId = tracker.start();
     setIsLoading(true);
     setErrorMessage(null);
 
     getSearchDataProvider()
       .search(debouncedQuery)
       .then((grouped) => {
-        if (requestId !== requestIdRef.current) return;
+        if (tracker.isStale(requestId)) return;
         setResults(grouped);
         const nextFlat = flattenResults(grouped);
         setActiveIndex(nextFlat.length > 0 ? 0 : -1);
       })
       .catch(() => {
-        if (requestId !== requestIdRef.current) return;
+        if (tracker.isStale(requestId)) return;
         setResults(EMPTY_RESULTS);
         setActiveIndex(-1);
         setErrorMessage("Search is temporarily unavailable. Please try again.");
       })
       .finally(() => {
-        if (requestId === requestIdRef.current) {
+        if (!tracker.isStale(requestId)) {
           setIsLoading(false);
         }
       });
 
     return () => {
       // A newer query (or unmount) supersedes this run; ignore its result.
-      requestIdRef.current += 1;
+      tracker.invalidate();
     };
   }, [debouncedQuery, retryKey]);
 
@@ -142,7 +169,7 @@ export function GlobalSearch({
   };
 
   const clearQuery = () => {
-    requestIdRef.current += 1; // drop any in-flight search so it can't repopulate
+    requestTrackerRef.current.invalidate(); // drop any in-flight search so it can't repopulate
     setQuery("");
     setResults(EMPTY_RESULTS);
     setErrorMessage(null);
@@ -152,7 +179,7 @@ export function GlobalSearch({
   };
 
   const navigateToResult = (item: SearchResultItem) => {
-    requestIdRef.current += 1; // drop any in-flight search before navigating away
+    requestTrackerRef.current.invalidate(); // drop any in-flight search before navigating away
     router.push(item.href);
     setIsOpen(false);
     setQuery("");


### PR DESCRIPTION
## Summary

This PR closes a batch of four related chart/search cleanup issues from `CLEANUP_ISSUES_2026-05.md`. Three of them (#363, #364, #367) were **already delivered** by previously merged work; the one remaining gap was the missing race-condition **test** for global search (#365), which this PR adds. The code diff is therefore scoped to `GlobalSearch.tsx` and its test, with each already-resolved issue documented below for traceability.

## What this PR changes (#365 — Make global search cancellable and race-safe)

The supersede *behaviour* already shipped (`requestIdRef` guard, merged in `2b34964`), but its third task — **"Add tests for rapid typing and query changes"** — had no coverage. To make the latest-wins guard testable in the repo's `node:test` (no-DOM) setup, the inlined ref arithmetic is extracted into a small pure helper, `createLatestRequestTracker`, mirroring the existing exported-`computeNextIndex` pattern.

- `createLatestRequestTracker()` — `start()` / `isStale(id)` / `invalidate()`. One-line rationale in the code: extracted purely so the supersede logic is unit-testable (no new abstraction beyond that).
- `GlobalSearch` now drives the guard through that helper. **Behaviour is unchanged** — identical monotonic-id semantics; all existing call sites (effect start/cleanup, clear, navigate) map 1:1.
- New tests cover: latest request applied, **rapid typing** supersedes the earlier in-flight request, **out-of-order resolution** never lets a stale result win, `invalidate()` drops in-flight on clear/navigate/unmount, fresh request after invalidate is honoured, and strictly-increasing ids.

## Already-resolved issues closed for traceability

| Issue | Status | Where it landed |
|------|--------|-----------------|
| **#363** Align chart data types with domain models | ✅ Already done | `2b34964` — typed `ChartDatum` / `PortfolioValuePoint` / `AssetAllocationSlice` / `BenchmarkComparisonPoint` in `mock-chart-data.ts`; chart wrappers made generic over them. |
| **#364** Trim command palette / search bundle cost | ✅ Already done | `2b34964` — `CommandPalette` is a tiny launcher that lazy-loads `CommandPaletteDialog` via `next/dynamic`; `GlobalSearch` intentionally stays eager (renders in the navbar). |
| **#365** Make global search race-safe | ✅ Completed here | Behaviour in `2b34964`; **tests added in this PR**. |
| **#367** Verify chart color contrast & CVD palette | ✅ Already done | `2573ad1` + `7604bac` — CVD palette, WCAG/CVD-simulation tests (`chart-colors-cvd.test.ts`), and `CHART_CVD_AUDIT_REPORT.md`. |

No code changes are made for #363/#364/#367 — re-adding their abstractions would violate the "no new duplicate abstractions" criterion. They are closed here because this PR completes the batch's last outstanding artifact.

## Verification

- `node --test src/components/search/GlobalSearch.test.ts` → **28/28 pass** (22 existing + 6 new race tests).
- `node --test src/lib/chart-colors-cvd.test.ts` → **3/3 pass** (confirms #367 still green).
- `yarn lint` (`next lint`) → **no warnings/errors in changed files**.

> Note: a pre-existing, unrelated corruption in `src/lib/i18n/messages.ts` (literal `\n` escape sequences committed to `main`) breaks repo-wide `yarn typecheck`/`yarn lint`/`yarn build`. It is outside the scope of these issues and left untouched.

## Acceptance criteria

- [x] Scope limited to the listed files (`GlobalSearch.tsx` + its test; other issues already merged).
- [x] Verifiable — new unit tests for the race behaviour.
- [x] No behavior regressions — guard semantics unchanged.
- [x] No new duplicate abstractions — single small helper, with a one-line rationale.

Closes #363
Closes #364
Closes #365
Closes #367
