### PR TITLE
fix: enforce ESLint in production builds and complete reduced-motion consistency

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,10 @@
 /** @type {import('next').NextConfig} */
 // Fixes issue 443: Implement frontend performance optimization pass
 const nextConfig = {
+  eslint: {
+    // Lint errors must be resolved before a production build succeeds.
+    ignoreDuringBuilds: false,
+  },
   reactStrictMode: true,
   staticPageGenerationTimeout: 0,
   // Compress responses with gzip for smaller transfer sizes

--- a/src/components/CommandPaletteDialog.tsx
+++ b/src/components/CommandPaletteDialog.tsx
@@ -124,7 +124,7 @@ export function CommandPaletteDialog({ onClose }: CommandPaletteDialogProps) {
   return (
     <div className="fixed inset-0 z-[9999] flex items-start justify-center px-0 pt-[10vh] sm:px-4 sm:pt-[20vh]">
       <div
-        className="fixed inset-0 bg-black/60 backdrop-blur-sm"
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm transition-opacity motion-reduce:transition-none"
         onClick={onClose}
         aria-hidden="true"
       />


### PR DESCRIPTION
Closes #353
Closes #354
Closes #355
Closes #356

## What was done

### `next.config.mjs` — issue #356

Added an explicit `eslint: { ignoreDuringBuilds: false }` block. Previously the key was absent (Next.js defaults to `false`), which left the intent ambiguous. The explicit declaration makes it clear that lint errors block production builds and prevents any future accidental re-introduction of `ignoreDuringBuilds: true`.

### `src/components/CommandPaletteDialog.tsx` — issue #353

Added `transition-opacity motion-reduce:transition-none` to the backdrop overlay, matching the pattern already used in `Modal.tsx` and `Drawer.tsx`. The dialog panel itself already carried `animate-in fade-in zoom-in-95 duration-200 motion-reduce:animate-none motion-reduce:duration-0 motion-reduce:transform-none`, and list items already had `motion-reduce:transition-none` — the backdrop was the only remaining element without the suppression class.

### issue #354 — already implemented

All API route handlers (`/api/transactions`, `/api/portfolio`, `/api/transaction-history`, `/api/strategy`) already validate request bodies and query params using Zod schemas from `src/lib/validation/api.ts` and return consistent `400` / `422` error envelopes via `errorResponse()`. No further changes needed.

### issue #355 — already implemented

Dashboard pages are Next.js Server Components that do not issue client-side `fetch()` calls. Where data fetching does occur client-side (e.g. strategy preferences), it already goes through `apiRequest()` from `src/lib/api-client.ts`. No stray ad-hoc fetch calls were found in `src/app/dashboard/**`.