### PR TITLE
fix: API timeouts, logger hardening, PII audit, and backend docs (#357–#360)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,53 @@ Lint runs via `yarn lint` (ESLint + `eslint-config-next`).
 ## Environment variables
 
 See `docs/env.md` for the full variable reference, including the public/server-only split,
-Edge middleware constraints, and runtime validation notes.
+Edge middleware constraints, and runtime validation notes. Typed accessors and validation
+live in `src/lib/env.ts` — each field is documented with its corresponding env var name.
+
+## Backend integration (mock vs real API)
+
+The frontend supports two runtime modes controlled by **server-only** env vars (see
+`src/lib/env.ts` and [NEUROWEALTH_API.md](NEUROWEALTH_API.md)):
+
+| Mode | Condition | Behaviour |
+| --- | --- | --- |
+| **Demo / mock** | `NEUROWEALTH_API_BASE_URL` unset | All `/api/*` route handlers return in-process mock data (`source: "demo"`). No backend required — default for local dev and PR previews. |
+| **Real API** | `NEUROWEALTH_API_BASE_URL` set | Route handlers proxy to the backend via `createServerApiClient()` with `Authorization: Bearer <NEUROWEALTH_API_AUTH_TOKEN>`. |
+
+### Request paths
+
+| Browser calls | Next.js route | Backend path (when configured) |
+| --- | --- | --- |
+| Portfolio data | `GET /api/portfolio` | `GET {NEUROWEALTH_PORTFOLIO_PATH}` (default `/portfolio/overview`) |
+| Transactions | `POST /api/transactions` | `POST {NEUROWEALTH_TRANSACTIONS_PATH}` (default `/transactions`) |
+| Strategy | `GET/PUT /api/strategy` | `GET/PUT {NEUROWEALTH_STRATEGY_PATH}` (default `/strategy/preference`) |
+
+Browser → Next.js requests authenticate via the httpOnly session cookie (`nw_session`).
+Next.js → backend requests require the Bearer token — never expose it to the client bundle.
+
+### Headers
+
+| Hop | Required headers |
+| --- | --- |
+| Browser → `/api/*` | `Accept: application/json`; `Content-Type: application/json` on writes; session cookie |
+| Server → backend | `Accept: application/json`; `Authorization: Bearer <NEUROWEALTH_API_AUTH_TOKEN>` |
+
+### Response envelope & errors
+
+All `/api/*` responses use the unified envelope defined in `src/lib/api-response.ts`:
+
+```json
+{ "success": true, "data": { } }
+{ "success": false, "error": { "code": "ERROR_CODE", "message": "…", "details": { } } }
+```
+
+The typed client in `src/lib/api-client.ts` unwraps success payloads and throws `ApiRequestError`
+on failure. Built-in client error codes include `REQUEST_TIMEOUT` (408), `NETWORK_ERROR` (503),
+`INVALID_JSON`, and `INVALID_ENVELOPE`. Backend codes are forwarded verbatim.
+
+Use `useAsyncData((signal) => apiRequest("/api/…", { signal }))` so in-flight requests abort on
+unmount. See [NEUROWEALTH_API.md](NEUROWEALTH_API.md) and [docs/api-integration.md](docs/api-integration.md)
+for full endpoint schemas and integration checklists.
 
 ## Provider tree & data flow
 

--- a/src/hooks/useAsyncData.test.ts
+++ b/src/hooks/useAsyncData.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ApiRequestError } from "@/lib/api-client";
+import { formatAsyncErrorMessage } from "@/hooks/useAsyncData";
+
+test("formatAsyncErrorMessage returns actionable copy for REQUEST_TIMEOUT", () => {
+  const error = new ApiRequestError("Request timed out. Please try again.", {
+    code: "REQUEST_TIMEOUT",
+    status: 408,
+  });
+
+  const message = formatAsyncErrorMessage(error);
+  assert.match(message ?? "", /took too long/i);
+});
+
+test("formatAsyncErrorMessage returns actionable copy for NETWORK_ERROR", () => {
+  const error = new ApiRequestError("Unable to reach the service right now.", {
+    code: "NETWORK_ERROR",
+    status: 503,
+  });
+
+  const message = formatAsyncErrorMessage(error);
+  assert.match(message ?? "", /unable to reach/i);
+});
+
+test("formatAsyncErrorMessage returns null for AbortError", () => {
+  const error = new DOMException("The operation was aborted.", "AbortError");
+  assert.equal(formatAsyncErrorMessage(error), null);
+});

--- a/src/hooks/useAsyncData.ts
+++ b/src/hooks/useAsyncData.ts
@@ -5,8 +5,14 @@
  * Prevents the "infinite skeleton" bug by always transitioning out of loading —
  * whether the fetch succeeds or fails.
  *
+ * Passes an AbortSignal to the fetcher so in-flight requests are cancelled on
+ * unmount or when dependencies change. Wire the signal into apiRequest({ signal }).
+ *
  * Usage:
- *   const { data, loading, error, retry } = useAsyncData(fetchPortfolio, [userId]);
+ *   const { data, loading, error, errorMessage, retry } = useAsyncData(
+ *     (signal) => apiRequest<Portfolio>("/api/portfolio", { signal }),
+ *     [userId],
+ *   );
  */
 
 import {
@@ -16,6 +22,7 @@ import {
   useRef,
   DependencyList,
 } from "react";
+import { ApiRequestError } from "@/lib/api-client";
 
 export type AsyncStatus = "idle" | "loading" | "success" | "error";
 
@@ -24,53 +31,90 @@ export interface AsyncState<T> {
   status: AsyncStatus;
   loading: boolean;
   error: Error | null;
+  /** User-facing message derived from error (null for aborted requests). */
+  errorMessage: string | null;
   /** Re-run the fetch manually (e.g. from a Retry button) */
   retry: () => void;
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError";
+}
+
 /**
- * @param fetcher  An async function that returns the data. Wrap in useCallback
- *                 if it closes over variables that change.
+ * Maps fetch errors to actionable UI copy. Returns null for aborted requests
+ * so callers can skip rendering an error banner.
+ */
+export function formatAsyncErrorMessage(error: Error | null): string | null {
+  if (!error) return null;
+
+  if (error instanceof ApiRequestError) {
+    switch (error.code) {
+      case "REQUEST_TIMEOUT":
+        return "The request took too long. Check your connection and try again.";
+      case "NETWORK_ERROR":
+        return "Unable to reach the service right now. Please try again shortly.";
+      default:
+        return error.message;
+    }
+  }
+
+  if (isAbortError(error)) {
+    return null;
+  }
+
+  return error.message;
+}
+
+/**
+ * @param fetcher  Async function receiving an AbortSignal. Pass the signal to
+ *                 apiRequest or fetch so requests cancel on unmount/deps change.
  * @param deps     Re-fetch whenever these values change (like useEffect deps).
  */
 export function useAsyncData<T>(
-  fetcher: () => Promise<T>,
+  fetcher: (signal: AbortSignal) => Promise<T>,
   deps: DependencyList = [],
 ): AsyncState<T> {
-  const [state, setState] = useState<Omit<AsyncState<T>, "retry">>({
+  const [state, setState] = useState<Omit<AsyncState<T>, "retry" | "errorMessage">>({
     data: null,
     status: "idle",
     loading: false,
     error: null,
   });
 
-  // Use a ref to track whether the component is still mounted
   const mountedRef = useRef(true);
+  const abortRef = useRef<AbortController | null>(null);
+
   useEffect(() => {
     mountedRef.current = true;
     return () => {
       mountedRef.current = false;
+      abortRef.current?.abort();
     };
   }, []);
 
-  // Increment this to force a re-fetch via retry()
   const [attempt, setAttempt] = useState(0);
 
   const run = useCallback(async () => {
+    abortRef.current?.abort();
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     setState((prev) => ({
       ...prev,
       status: "loading",
       loading: true,
       error: null,
     }));
+
     try {
-      const data = await fetcher();
-      if (!mountedRef.current) return;
+      const data = await fetcher(controller.signal);
+      if (controller.signal.aborted || !mountedRef.current) return;
       setState({ data, status: "success", loading: false, error: null });
     } catch (err) {
-      if (!mountedRef.current) return;
+      if (controller.signal.aborted || !mountedRef.current) return;
       const error = err instanceof Error ? err : new Error(String(err));
-      // KEY FIX: always set loading: false so skeletons never stay forever
       setState((prev) => ({
         ...prev,
         data: prev.data,
@@ -84,9 +128,16 @@ export function useAsyncData<T>(
 
   useEffect(() => {
     run();
+    return () => {
+      abortRef.current?.abort();
+    };
   }, [run]);
 
   const retry = useCallback(() => setAttempt((n) => n + 1), []);
 
-  return { ...state, retry };
+  return {
+    ...state,
+    errorMessage: formatAsyncErrorMessage(state.error),
+    retry,
+  };
 }

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sanitizeAnalyticsParams } from "@/lib/analytics";
+
+test("sanitizeAnalyticsParams strips userId from auth events", () => {
+  const result = sanitizeAnalyticsParams("auth_sign_in", {
+    userId: "u1",
+    method: "password",
+  });
+
+  assert.deepEqual(result, { method: "password" });
+});
+
+test("sanitizeAnalyticsParams returns undefined for auth events with only PII params", () => {
+  const result = sanitizeAnalyticsParams("auth_sign_up_failed");
+  assert.equal(result, undefined);
+});
+
+test("sanitizeAnalyticsParams scrubs PII from non-auth events", () => {
+  const result = sanitizeAnalyticsParams("notification_read", {
+    id: "n1",
+    email: "user@example.com",
+  }) as Record<string, unknown>;
+
+  assert.equal(result.id, "n1");
+  assert.equal(result.email, "***REDACTED***");
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,3 +1,24 @@
+/**
+ * Lightweight analytics facade. All event params pass through scrubPII before
+ * logging or fan-out to listeners.
+ *
+ * ── Safe analytics guidelines (contributors) ──────────────────────────────────
+ *
+ * DO track:
+ *   - Event names describing user actions ("auth_sign_in", "notification_read")
+ *   - Non-identifying metadata (feature flags, UI section, boolean toggles)
+ *
+ * DO NOT track:
+ *   - Emails, names, wallet addresses, auth tokens, support message bodies
+ *   - Full error messages that may contain user-entered text
+ *
+ * Auth events should use coarse names only; omit userId unless required — scrubPII
+ * redacts keys containing "userid" but prefer event names like "auth_sign_in_failed"
+ * with no params for failure cases.
+ *
+ * See also: src/lib/logger.ts for diagnostic logging guidelines.
+ */
+
 import { logger, scrubPII } from "./logger";
 import { random } from "./seeded-rng";
 
@@ -5,7 +26,7 @@ export interface AnalyticsEvent {
   id: string;
   name: string;
   timestamp: string;
-  params?: Record<string, any>;
+  params?: Record<string, unknown>;
 }
 
 type EventListener = (event: AnalyticsEvent) => void;
@@ -23,9 +44,33 @@ const notifyListeners = (event: AnalyticsEvent) => {
   listeners.forEach((l) => l(event));
 };
 
+/** Allowed analytics param keys for auth flows (non-PII identifiers only). */
+const AUTH_SAFE_PARAM_KEYS = new Set(["method", "provider", "step"]);
+
+export function sanitizeAnalyticsParams(
+  name: string,
+  params?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!params) return undefined;
+
+  const scrubbed = scrubPII(params) as Record<string, unknown>;
+
+  if (name.startsWith("auth_")) {
+    const filtered: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(scrubbed)) {
+      if (AUTH_SAFE_PARAM_KEYS.has(key)) {
+        filtered[key] = value;
+      }
+    }
+    return Object.keys(filtered).length > 0 ? filtered : undefined;
+  }
+
+  return scrubbed;
+}
+
 export const analytics = {
-  track: (name: string, params?: Record<string, any>) => {
-    const safeParams = params ? scrubPII(params) : undefined;
+  track: (name: string, params?: Record<string, unknown>) => {
+    const safeParams = sanitizeAnalyticsParams(name, params);
     const event: AnalyticsEvent = {
       id: random().toString(36).substring(7),
       name,
@@ -34,12 +79,10 @@ export const analytics = {
     };
 
     logger.info(`Analytics [${name}]`, safeParams);
-
     notifyListeners(event);
 
-    // In a real app, this would send to Segment, Mixpanel, etc.
     if (process.env.NODE_ENV === "production") {
-      // Send to real endpoint
+      // Send to real endpoint (Segment, Mixpanel, etc.)
     }
   },
 };

--- a/src/lib/api-client.test.ts
+++ b/src/lib/api-client.test.ts
@@ -142,6 +142,50 @@ test("createServerApiClient returns null when NEUROWEALTH_API_BASE_URL is not se
   assert.equal(client, null);
 });
 
+test("apiRequest rejects timed-out requests with REQUEST_TIMEOUT", async () => {
+  globalThis.fetch = async (_url, init) => {
+    return new Promise((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) return;
+
+      signal.addEventListener(
+        "abort",
+        () => reject(new DOMException("The operation was aborted.", "AbortError")),
+        { once: true },
+      );
+    });
+  };
+
+  await assert.rejects(
+    () => apiRequest("/api/test", { timeoutMs: 50 }),
+    (error: unknown) => {
+      assert.ok(error instanceof ApiRequestError);
+      assert.equal(error.code, "REQUEST_TIMEOUT");
+      assert.equal(error.status, 408);
+      assert.match(error.message, /timed out/i);
+      return true;
+    },
+  );
+});
+
+test("apiRequest forwards external AbortSignal and rejects with NETWORK_ERROR when aborted early", async () => {
+  const controller = new AbortController();
+
+  globalThis.fetch = async () => {
+    controller.abort();
+    throw new DOMException("The operation was aborted.", "AbortError");
+  };
+
+  await assert.rejects(
+    () => apiRequest("/api/test", { signal: controller.signal }),
+    (error: unknown) => {
+      assert.ok(error instanceof ApiRequestError);
+      assert.equal(error.code, "NETWORK_ERROR");
+      return true;
+    },
+  );
+});
+
 test("createServerApiClient returns a callable client when base URL is set", async () => {
   process.env.NEUROWEALTH_API_BASE_URL = "https://api.example.com";
   process.env.NEUROWEALTH_API_AUTH_TOKEN = "test-token";

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -27,6 +27,13 @@
  *                                    (default: /transactions)
  *   NEUROWEALTH_STRATEGY_PATH        Backend path for strategy preference
  *                                    (default: /strategy/preference)
+ *
+ * ── Related docs ──────────────────────────────────────────────────────────────
+ *
+ *   NEUROWEALTH_API.md      Full HTTP contract — paths, auth headers, error envelope
+ *   docs/env.md             Deployment notes and validation scripts
+ *   docs/api-integration.md Endpoint schemas and integration checklist
+ *   README.md               Mock vs real API mode overview for contributors
  */
 
 interface EnvConfig {

--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isLogLevelEnabled, scrubPII } from "@/lib/logger";
+
+const originalEnv = { ...process.env };
+
+test.afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+test("scrubPII redacts sensitive keys", () => {
+  const result = scrubPII({
+    email: "user@example.com",
+    operation: "sign_in",
+    nested: { token: "abc123", count: 1 },
+  }) as Record<string, unknown>;
+
+  assert.equal(result.email, "***REDACTED***");
+  assert.equal(result.operation, "sign_in");
+  assert.equal((result.nested as Record<string, unknown>).token, "***REDACTED***");
+  assert.equal((result.nested as Record<string, unknown>).count, 1);
+});
+
+test("scrubPII redacts email patterns in string values", () => {
+  const result = scrubPII("Contact user@example.com for help");
+  assert.equal(result, "Contact ***REDACTED*** for help");
+});
+
+test("isLogLevelEnabled respects NEXT_PUBLIC_LOG_LEVEL=silent", () => {
+  process.env.NEXT_PUBLIC_LOG_LEVEL = "silent";
+  assert.equal(isLogLevelEnabled("error"), false);
+});
+
+test("isLogLevelEnabled defaults to warn minimum in production", () => {
+  process.env.NODE_ENV = "production";
+  delete process.env.NEXT_PUBLIC_LOG_LEVEL;
+  assert.equal(isLogLevelEnabled("info"), false);
+  assert.equal(isLogLevelEnabled("warn"), true);
+  assert.equal(isLogLevelEnabled("error"), true);
+});

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,16 +1,100 @@
 import { random } from "./seeded-rng";
 
+/**
+ * Centralized application logger with PII scrubbing and configurable log levels.
+ *
+ * ── Safe logging guidelines (contributors) ───────────────────────────────────
+ *
+ * DO log:
+ *   - Operation names and coarse outcomes ("auth_sign_in_failed", "portfolio_fetch")
+ *   - Non-identifying correlation IDs, error codes, HTTP status codes
+ *   - Scrubbed context objects (always pass objects — never interpolate PII into messages)
+ *
+ * DO NOT log:
+ *   - Emails, names, phone numbers, wallet addresses, session tokens, passwords
+ *   - Full request/response bodies, support message content, Authorization headers
+ *   - Raw Error objects that may contain user input in `.message`
+ *
+ * Prefer `analytics.track(name, { ... })` for product events — params are scrubbed
+ * automatically. Use `logger` for diagnostics and dev tooling only.
+ *
+ * ── Log levels ────────────────────────────────────────────────────────────────
+ *
+ * Set NEXT_PUBLIC_LOG_LEVEL to one of: info | warn | error | silent
+ * Default: info in development, warn in production (errors always emit unless silent).
+ */
+
 export type LogLevel = "info" | "warn" | "error";
+export type LogLevelConfig = LogLevel | "silent";
 
 export interface LogEntry {
   id: string;
   timestamp: string;
   level: LogLevel;
   message: string;
-  context?: any;
+  context?: unknown;
 }
 
-// Simple event bus for logs
+const LEVEL_RANK: Record<LogLevel, number> = {
+  info: 0,
+  warn: 1,
+  error: 2,
+};
+
+const SENSITIVE_KEY_FRAGMENTS = [
+  "email",
+  "address",
+  "phone",
+  "password",
+  "secret",
+  "key",
+  "name",
+  "token",
+  "userid",
+  "user_id",
+  "ip",
+  "ssn",
+  "dob",
+  "dateofbirth",
+  "creditcard",
+  "cardnumber",
+  "accountnumber",
+  "authorization",
+  "cookie",
+  "session",
+  "jwt",
+  "bearer",
+  "message",
+  "content",
+  "body",
+  "wallet",
+  "mnemonic",
+  "seed",
+  "private",
+] as const;
+
+const SENSITIVE_VALUE_PATTERN =
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b|Bearer\s+\S+/gi;
+
+function resolveMinLogLevel(): LogLevelConfig {
+  const configured = process.env.NEXT_PUBLIC_LOG_LEVEL?.toLowerCase();
+  if (
+    configured === "info" ||
+    configured === "warn" ||
+    configured === "error" ||
+    configured === "silent"
+  ) {
+    return configured;
+  }
+  return process.env.NODE_ENV === "production" ? "warn" : "info";
+}
+
+export function isLogLevelEnabled(level: LogLevel): boolean {
+  const min = resolveMinLogLevel();
+  if (min === "silent") return false;
+  return LEVEL_RANK[level] >= LEVEL_RANK[min];
+}
+
 type LogListener = (entry: LogEntry) => void;
 const listeners: LogListener[] = [];
 
@@ -26,52 +110,84 @@ const notifyListeners = (entry: LogEntry) => {
   listeners.forEach((l) => l(entry));
 };
 
-export const scrubPII = (data: any): any => {
-  if (!data) return data;
-  const sensitiveKeys = [
-    "email", "address", "phone", "password", "secret", "key",
-    "name", "token", "userid", "ip", "ssn", "dob", "dateofbirth",
-    "creditcard", "cardnumber", "accountnumber",
-  ];
-  if (typeof data === "object") {
-    const scrubbed = Array.isArray(data) ? [...data] : { ...data };
-    for (const key in scrubbed) {
-      if (sensitiveKeys.some((sk) => key.toLowerCase().includes(sk))) {
-        scrubbed[key] = "***REDACTED***";
-      } else if (typeof scrubbed[key] === "object") {
-        scrubbed[key] = scrubPII(scrubbed[key]);
-      }
-    }
-    return scrubbed;
+export const scrubPII = (data: unknown): unknown => {
+  if (data == null) return data;
+
+  if (typeof data === "string") {
+    return data.replace(SENSITIVE_VALUE_PATTERN, "***REDACTED***");
   }
-  return data;
+
+  if (typeof data !== "object") return data;
+
+  const scrubbed = Array.isArray(data) ? [...data] : { ...(data as Record<string, unknown>) };
+
+  for (const key of Object.keys(scrubbed)) {
+    const value = (scrubbed as Record<string, unknown>)[key];
+    if (
+      SENSITIVE_KEY_FRAGMENTS.some((fragment) =>
+        key.toLowerCase().includes(fragment),
+      )
+    ) {
+      (scrubbed as Record<string, unknown>)[key] = "***REDACTED***";
+    } else if (typeof value === "object" && value !== null) {
+      (scrubbed as Record<string, unknown>)[key] = scrubPII(value);
+    } else if (typeof value === "string") {
+      (scrubbed as Record<string, unknown>)[key] = scrubPII(value);
+    }
+  }
+
+  return scrubbed;
 };
 
-const createEntry = (level: LogLevel, message: string, context?: any): LogEntry => ({
+const createEntry = (
+  level: LogLevel,
+  message: string,
+  context?: unknown,
+): LogEntry => ({
   id: random().toString(36).substring(7),
   timestamp: new Date().toISOString(),
   level,
   message,
-  context: scrubPII(context),
+  context: context === undefined ? undefined : scrubPII(context),
 });
 
+const emitToConsole = (level: LogLevel, message: string, context?: unknown) => {
+  if (!isLogLevelEnabled(level)) return;
+
+  const prefix = level.toUpperCase();
+  const payload = context === undefined ? "" : scrubPII(context);
+
+  switch (level) {
+    case "info":
+      console.log(`[${prefix}] ${message}`, payload);
+      break;
+    case "warn":
+      console.warn(`[${prefix}] ${message}`, payload);
+      break;
+    case "error":
+      console.error(`[${prefix}] ${message}`, payload);
+      break;
+  }
+};
+
 export const logger = {
-  info: (message: string, context?: any) => {
+  info: (message: string, context?: unknown) => {
     const entry = createEntry("info", message, context);
-    console.log(`[INFO] ${message}`, entry.context || "");
+    emitToConsole("info", message, entry.context);
     notifyListeners(entry);
   },
-  warn: (message: string, context?: any) => {
+  warn: (message: string, context?: unknown) => {
     const entry = createEntry("warn", message, context);
-    console.warn(`[WARN] ${message}`, entry.context || "");
+    emitToConsole("warn", message, entry.context);
     notifyListeners(entry);
   },
-  error: (message: string, error?: any) => {
-    const entry = createEntry("error", message, {
-      error: error instanceof Error ? error.message : error,
-      stack: error instanceof Error ? error.stack : undefined,
-    });
-    console.error(`[ERROR] ${message}`, entry.context || "");
+  error: (message: string, error?: unknown) => {
+    const context =
+      error instanceof Error
+        ? { error: error.message, stack: error.stack }
+        : error;
+    const entry = createEntry("error", message, context);
+    emitToConsole("error", message, entry.context);
     notifyListeners(entry);
   },
 };

--- a/src/lib/mock-services.ts
+++ b/src/lib/mock-services.ts
@@ -100,7 +100,7 @@ const STORAGE_KEY = "nw_auth_session";
 
 export const mockAuthService: AuthService = {
   async signIn(email, password, opts = {}) {
-    logger.info("mockAuthService.signIn", { email });
+    logger.info("mockAuthService.signIn");
     await delay(opts.latencyMs ?? 800);
 
     if (shouldFail(opts.outcome)) {
@@ -130,7 +130,7 @@ export const mockAuthService: AuthService = {
   },
 
   async signUp(email, name, password, opts = {}) {
-    logger.info("mockAuthService.signUp", { email, name });
+    logger.info("mockAuthService.signUp");
     await delay(opts.latencyMs ?? 1000);
 
     if (shouldFail(opts.outcome)) {


### PR DESCRIPTION
## Summary

Resolves cleanup issues **#357**, **#358**, **#359**, and **#360** from `CLEANUP_ISSUES_2026-05.md` in a single focused PR.

### #357 — Request timeout and abort strategy
- `useAsyncData` now passes an `AbortSignal` to fetchers and aborts in-flight requests on unmount or dependency change
- Exported `formatAsyncErrorMessage()` for actionable UI copy on `REQUEST_TIMEOUT` and `NETWORK_ERROR`
- Added api-client tests for timeout (`408 REQUEST_TIMEOUT`) and external abort forwarding

### #358 — Replace stray console.error with shared logger
- Sandbox files already used `logger.error`; this PR adds **production log-level gating** via `NEXT_PUBLIC_LOG_LEVEL` (`info` | `warn` | `error` | `silent`)
- Default: `info` in development, `warn` in production (errors always emit unless `silent`)

### #359 — Audit logging and analytics for PII leakage
- Expanded `scrubPII()` key list and email/Bearer token pattern redaction in string values
- Added `sanitizeAnalyticsParams()` — auth events (`auth_*`) only allow non-PII keys (`method`, `provider`, `step`); `userId` is stripped
- Documented safe logging/analytics guidelines in module headers for contributors
- Removed email/name from mock auth service log context (`mock-services.ts`)

### #360 — Document backend integration contract
- README: new **Backend integration (mock vs real API)** section — mode table, paths, headers, error envelope, cross-links
- `src/lib/env.ts`: cross-links to `NEUROWEALTH_API.md`, `docs/env.md`, `docs/api-integration.md`, and README

## Test plan

- [x] `yarn test` — new unit tests:
  - `src/lib/api-client.test.ts` — timeout and abort signal cases
  - `src/lib/logger.test.ts` — PII scrubbing and log-level gating
  - `src/lib/analytics.test.ts` — auth param sanitization
  - `src/hooks/useAsyncData.test.ts` — timeout/network error messaging
- [ ] Manual QA: load `/dashboard/sandbox` in dev — scenario toggles persist; errors log via `[ERROR]` prefix, not raw `console.error`
- [ ] Manual QA: set `NEXT_PUBLIC_LOG_LEVEL=warn` in production build — info logs suppressed, warnings/errors visible
- [ ] Manual QA: sign in/out — analytics events fire without `userId` in console output

## Labels

`cleanup`, `docs`, `api`, `maintenance`, `security`

Closes #357
Closes #358
Closes #359
Closes #360

Made with [Cursor](https://cursor.com)