### PR TITLE
fix: resolve issues #369 #370 #371 #372

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,0 @@
-{
-  "extends": ["next/core-web-vitals"]
-}

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Next.js uses the **SWC compiler** for both development (Fast Refresh) and produc
 No Babel configuration is present; SWC is the default when using Next.js 13+. The SWC binary
 is resolved automatically by Next.js — no extra install step is needed.
 
+**Platform-specific dependency**: `@tailwindcss/oxide-linux-x64-gnu` is listed under
+`optionalDependencies` in `package.json`. This is the native Rust engine binary for
+Tailwind CSS v4 on Linux x86-64 GNU targets (e.g. most CI and Codespace environments).
+It is marked optional so `yarn install` does not fail on macOS or Windows — Tailwind CSS
+falls back to a pure-JS engine on those platforms automatically. No manual action needed.
+
 ## Quick start
 
 Requirements: Node.js 20+, Yarn (Corepack supported)
@@ -156,6 +162,21 @@ The mock auth flow stores the session in `localStorage` using `SESSION_STORAGE_K
 - Use `data-qa` only for smoke-flow anchors, with kebab-case names that describe the flow and
   action, for example `landing-primary-cta-button`, `wallet-connect-button`, and
   `transaction-submit-button`.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup instructions, CI gates, branch rules, and
+PR checklist.
+
+### Issue queues
+
+| Queue | Purpose |
+|-------|---------|
+| [Audit issues](/.github/audit-issues/) | 30 engineering/platform issues — auth, CI, performance, docs |
+| [Backlog](/.github/backlog/) | 50 scoped feature and design work items |
+| [Issues index](/.github/ISSUES.md) | Label guide and queue overview |
+
+When picking up work, choose an item from the audit queue (engineering clean-up) or the
+backlog (features), then open a GitHub issue using the closest
+[issue template](/.github/ISSUE_TEMPLATE/).
 
 ## Security
 

--- a/src/app/api/strategy/route.ts
+++ b/src/app/api/strategy/route.ts
@@ -87,6 +87,12 @@ export async function PUT(request: NextRequest) {
         cache: "no-store",
       });
 
+      if (!res.ok) {
+        return NextResponse.json(
+          errorResponse(ERROR_CODE.BACKEND_ERROR, "Strategy service temporarily unavailable."),
+          { status: HTTP_STATUS.SERVICE_UNAVAILABLE, headers: { "Cache-Control": "no-store" } },
+        );
+      }
       const text = await res.text();
       return new NextResponse(text, {
         status: res.status,

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -78,6 +78,12 @@ export async function POST(request: NextRequest) {
         },
       );
 
+      if (!response.ok) {
+        return NextResponse.json(
+          errorResponse(ERROR_CODE.BACKEND_ERROR, "Transaction service temporarily unavailable."),
+          { status: HTTP_STATUS.SERVICE_UNAVAILABLE },
+        );
+      }
       const text = await response.text();
 
       return new NextResponse(text, {
@@ -85,6 +91,7 @@ export async function POST(request: NextRequest) {
         headers: {
           "Content-Type":
             response.headers.get("Content-Type") ?? "application/json",
+          "Cache-Control": "no-store",
         },
       });
     } catch (error) {


### PR DESCRIPTION
#369: Remove stale .eslintrc.json — eslint.config.mjs is the sole
      authoritative ESLint config (flat config, Next.js 14+).

#370: Document @tailwindcss/oxide-linux-x64-gnu optional dependency in
      README — it is the native Rust engine for Linux x64 and is
      intentionally optional so installs succeed on other platforms.

#371: Expand README Contributing section with issue queue links (audit
      queue, backlog, issues index) and a pointer to CONTRIBUTING.md.

#372: Normalize backend error responses in strategy PUT and transactions
      POST route handlers — non-ok backend replies now return the
      standard { success: false, error: { code, message } } envelope
      via errorResponse() instead of passing through raw text.

Closes #369 
Closes #370 
Closes #371 
Closes #372 