### PR TITLE
Virtualize or paginate large audit and notification lists (#351)

### DIFF
--- a/src/components/audit/AuditTrail.tsx
+++ b/src/components/audit/AuditTrail.tsx
@@ -132,7 +132,7 @@ export function AuditTrail() {
 
       {/* Desktop Table */}
       <div className="audit-table-wrapper">
-        <table className="audit-table" role="grid">
+        <table className="audit-table">
           <thead>
             <tr>
               <th>Event Type</th>

--- a/src/components/notifications/NotificationCenter.tsx
+++ b/src/components/notifications/NotificationCenter.tsx
@@ -16,14 +16,21 @@ export function NotificationCenter() {
   const hasMore = paginatedNotifications.length < notifications.length;
 
   return (
-    <div className="w-80 bg-dark-800 border border-white/10 rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[500px]">
+    <div
+      className="w-80 bg-dark-800 border border-white/10 rounded-xl shadow-2xl overflow-hidden flex flex-col max-h-[500px]"
+      role="region"
+      aria-label="Notifications"
+    >
       <div className="p-4 border-b border-white/5 flex items-center justify-between bg-dark-900/50">
         <div className="flex items-center gap-2">
           <h3 className="font-bold text-white uppercase tracking-wider text-xs">
             {view === "list" ? "Notifications" : "Preferences"}
           </h3>
           {view === "list" && unreadCount > 0 && (
-            <span className="bg-brand-400 text-dark-900 text-[10px] font-bold px-1.5 py-0.5 rounded-full">
+            <span
+              className="bg-brand-400 text-dark-900 text-[10px] font-bold px-1.5 py-0.5 rounded-full"
+              aria-label={`${unreadCount} unread`}
+            >
               {unreadCount}
             </span>
           )}
@@ -31,10 +38,11 @@ export function NotificationCenter() {
         <div className="flex gap-2">
           <button
             onClick={() => setView(view === "list" ? "preferences" : "list")}
-            className="text-slate-400 hover:text-white transition-colors"
+            className="text-slate-400 hover:text-white transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 rounded"
+            aria-label={view === "list" ? "Open notification preferences" : "Back to notification list"}
             title={view === "list" ? "Preferences" : "Back to List"}
           >
-            {view === "list" ? "⚙️" : "🔙"}
+            <span aria-hidden="true">{view === "list" ? "⚙️" : "🔙"}</span>
           </button>
         </div>
       </div>
@@ -48,7 +56,7 @@ export function NotificationCenter() {
               </div>
             ) : (
               <>
-                <div className="divide-y divide-white/5">
+                <div className="divide-y divide-white/5" role="list" aria-label="Notification list">
                   {paginatedNotifications.map((notif) => (
                     <NotificationItem
                       key={notif.id}

--- a/src/components/notifications/NotificationItem.tsx
+++ b/src/components/notifications/NotificationItem.tsx
@@ -19,27 +19,51 @@ export function NotificationItem({ notification, onMarkAsRead }: NotificationIte
     error: "🔴",
   };
 
+  const statusLabels: Record<string, string> = {
+    info: "Info",
+    success: "Success",
+    warning: "Warning",
+    error: "Error",
+  };
+
   const formattedDate = new Date(timestamp).toLocaleTimeString([], {
     hour: "2-digit",
     minute: "2-digit",
   });
+
+  const handleRead = () => {
+    if (!isRead) {
+      onMarkAsRead(id);
+      analytics.track("notification_read", { id });
+    }
+  };
 
   return (
     <div
       className={`
         relative p-4 flex flex-col gap-2 transition-colors hover:bg-white/5
         ${!isRead ? "border-l-2 border-brand-400 bg-brand-400/5" : "border-l-2 border-transparent"}
+        ${!isRead ? "cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-inset" : ""}
       `}
-      onClick={() => {
-        if (!isRead) {
-          onMarkAsRead(id);
-          analytics.track("notification_read", { id });
-        }
-      }}
+      onClick={handleRead}
+      role="listitem"
+      tabIndex={!isRead ? 0 : undefined}
+      aria-label={!isRead ? `Mark as read: ${title}` : undefined}
+      onKeyDown={
+        !isRead
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                handleRead();
+              }
+            }
+          : undefined
+      }
     >
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-2">
-          <span>{statusIcons[status]}</span>
+          <span aria-hidden="true">{statusIcons[status]}</span>
+          <span className="sr-only">{statusLabels[status]}</span>
           <h4 className={`text-sm font-semibold ${!isRead ? "text-white" : "text-slate-300"}`}>
             {title}
           </h4>


### PR DESCRIPTION


## Summary

Investigated `AuditTrail.tsx` and `NotificationCenter.tsx` for the #351 cleanup issue. Pagination/windowing for both lists was already shipped in earlier commits (`f762175`, `4486eb3`, and the original `NotificationCenter` implementation), so the remaining open task was the acceptance criterion **"Verify keyboard and screen-reader access after changes"**. This PR is the a11y follow-up for that item — no new pagination abstraction was added (see "Why no new abstraction" below).

closes #351 
## What changed

**`src/components/audit/AuditTrail.tsx`**
- Removed `role="grid"` from the results table. `role="grid"` promises arrow-key cell navigation, which this table never implemented — leaving it in place gives screen reader users an interaction model that doesn't exist. The native `<table>` role already conveys the correct structure, and existing pagination controls, filter `<select>`, sort button, and per-row expand buttons already have proper `aria-label`s and are native, keyboard-operable elements.

**`src/components/notifications/NotificationItem.tsx`**
- The notification row was a plain `<div onClick>` — mouse-only, not focusable, not operable via keyboard. Added `tabIndex`, `onKeyDown` (Enter/Space), and `aria-label` for unread rows so "mark as read" is reachable without a mouse, plus a visible `focus-visible` ring.
- Added `role="listitem"` so the row participates correctly in the list semantics below.
- Status was conveyed only by emoji (🔵🟢🟡🔴). Added a visually-hidden (`sr-only`) text label (`Info`/`Success`/`Warning`/`Error`) next to an `aria-hidden` icon so screen readers announce the status.

**`src/components/notifications/NotificationCenter.tsx`**
- The panel now has `role="region" aria-label="Notifications"` so assistive tech can identify and jump to it.
- The notification list container got `role="list"` to pair with the `listitem` rows above.
- The settings/back toggle button relied on an emoji + `title` attribute for its accessible name (unreliable across screen readers); added an explicit `aria-label` and a visible focus ring.
- The unread-count badge got an `aria-label` (e.g. "3 unread") instead of relying on the bare number.

## Why no new duplicate abstraction

No new pagination/windowing component or hook was introduced. `AuditTrail` already has full pager (prev/next + numbered pages, 20/page over 250 mock events) and `NotificationCenter` already has "Load More" (5/page). Both preserve existing filter/sort behavior unchanged — this PR only touches ARIA attributes, focus handling, and one incorrect role.

## Scope

Limited to the two files named in the issue, plus their existing child component `NotificationItem.tsx` (rendered inside `NotificationCenter.tsx`'s list) since the keyboard-access gap lived there.

## QA / verification steps

- [ ] Tab through `AuditTrail`: filter select → sort button → row expand buttons → pagination buttons, confirm visible focus and correct `aria-label` announcements (e.g. via VoiceOver/NVDA).
- [ ] Confirm the audit table is announced as a table (not a grid) by a screen reader.
- [ ] Open `NotificationCenter`, Tab to an unread notification, press Enter/Space, confirm it's marked read and `analytics.track("notification_read")` fires — same as clicking.
- [ ] Confirm read notifications are not focusable stops (no-op is correctly not exposed as interactive).
- [ ] Confirm status icon is announced (e.g. "Success, Transaction Successful") rather than silently skipped or read as a raw emoji.
- [ ] Tab to the settings/back toggle button, confirm the announced name matches its action ("Open notification preferences" / "Back to notification list").
- [ ] Click "Load More" repeatedly and confirm filter/sort-equivalent behavior (read/unread state, mark-all-as-read) is unaffected.
- [ ] Re-run existing filter + sort combinations on `AuditTrail` to confirm no regression (page resets to 1 on filter/sort change, as before).

## Risk

Low — changes are additive ARIA attributes, `tabIndex`/`onKeyDown` handlers, and removal of one incorrect role. No changes to data fetching, pagination math, or filter/sort logic.
