### PR TITLE
fix: performance optimization pass on AuthContext, charts, and font loading

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,8 +20,7 @@ const nextConfig = {
   },
   // Enable experimental optimisation for package imports
   experimental: {
-    instrumentationHook: true,
-    optimizePackageImports: ["lucide-react"],
+    optimizePackageImports: ["lucide-react", "recharts"],
   },
 };
 

--- a/src/app/docs/charts/page.tsx
+++ b/src/app/docs/charts/page.tsx
@@ -1,11 +1,28 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { MAIN_CONTENT_LANDMARK_ID } from "@/lib/app-landmarks";
-import { LineChartWrapper } from "@/components/charts/LineChartWrapper";
-import { AreaChartWrapper } from "@/components/charts/AreaChartWrapper";
-import { BarChartWrapper } from "@/components/charts/BarChartWrapper";
-import { DonutChartWrapper } from "@/components/charts/DonutChartWrapper";
+
+const LineChartWrapper = dynamic(
+  () => import("@/components/charts/LineChartWrapper").then(m => ({ default: m.LineChartWrapper })),
+  { loading: () => <div className="h-64 bg-slate-900 animate-pulse rounded-xl" /> },
+);
+
+const AreaChartWrapper = dynamic(
+  () => import("@/components/charts/AreaChartWrapper").then(m => ({ default: m.AreaChartWrapper })),
+  { loading: () => <div className="h-64 bg-slate-900 animate-pulse rounded-xl" /> },
+);
+
+const BarChartWrapper = dynamic(
+  () => import("@/components/charts/BarChartWrapper").then(m => ({ default: m.BarChartWrapper })),
+  { loading: () => <div className="h-64 bg-slate-900 animate-pulse rounded-xl" /> },
+);
+
+const DonutChartWrapper = dynamic(
+  () => import("@/components/charts/DonutChartWrapper").then(m => ({ default: m.DonutChartWrapper })),
+  { loading: () => <div className="h-64 bg-slate-900 animate-pulse rounded-xl" /> },
+);
 import {
   portfolioValueData,
   monthlyYieldData,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import { Inter } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
 import { ClientProviders } from "@/components/ClientProviders";
@@ -7,6 +8,8 @@ import { DiagnosticsPanel } from "@/components/diagnostics/DiagnosticsPanel";
 import { CommandPalette } from "@/components/CommandPalette";
 import { MAIN_CONTENT_LANDMARK_ID } from "@/lib/app-landmarks";
 import { THEME_STORAGE_KEY } from "@/lib/theme-persistence";
+
+const inter = Inter({ subsets: ["latin"] });
 
 /**
  * Theme boot script: runs before page paint to prevent theme flash.
@@ -48,7 +51,7 @@ export default function RootLayout({
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeHtmlBootScript }} />
       </head>
-      <body className="antialiased font-sans bg-dark-900 text-slate-200">
+      <body className={`${inter.className} antialiased font-sans bg-dark-900 text-slate-200`}>
         <a
           href={`#${MAIN_CONTENT_LANDMARK_ID}`}
           className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[9999] focus:px-4 focus:py-2 focus:rounded-lg focus:bg-sky-500 focus:text-white focus:font-semibold focus:shadow-lg focus:outline focus:outline-2 focus:outline-offset-2 focus:outline-white"

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
   useEffect,
   useCallback,
+  useMemo,
 } from "react";
 import type { AuthSession } from "@/lib/auth-adapter";
 import { getAuthAdapter } from "@/lib/auth-provider-factory";
@@ -81,46 +82,57 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener("storage", handleStorageChange);
   }, [syncFromStorage]);
 
-  const signIn = async (email: string, password: string) => {
-    setLoading(true);
-    try {
-      const session = await authAdapter.signIn(email, password);
-      setUser(session.user);
-      setSessionCookie(session);
-      analytics.track("auth_sign_in", { userId: session.user.id });
-    } catch (err) {
-      analytics.track("auth_sign_in_failed");
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  };
+  const signIn = useCallback(
+    async (email: string, password: string) => {
+      setLoading(true);
+      try {
+        const session = await authAdapter.signIn(email, password);
+        setUser(session.user);
+        setSessionCookie(session);
+        analytics.track("auth_sign_in", { userId: session.user.id });
+      } catch (err) {
+        analytics.track("auth_sign_in_failed");
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [authAdapter],
+  );
 
-  const signUp = async (email: string, name: string, password: string) => {
-    setLoading(true);
-    try {
-      const session = await authAdapter.signUp(email, name, password);
-      setUser(session.user);
-      setSessionCookie(session);
-      analytics.track("auth_sign_up", { userId: session.user.id });
-    } catch (err) {
-      analytics.track("auth_sign_up_failed");
-      throw err;
-    } finally {
-      setLoading(false);
-    }
-  };
+  const signUp = useCallback(
+    async (email: string, name: string, password: string) => {
+      setLoading(true);
+      try {
+        const session = await authAdapter.signUp(email, name, password);
+        setUser(session.user);
+        setSessionCookie(session);
+        analytics.track("auth_sign_up", { userId: session.user.id });
+      } catch (err) {
+        analytics.track("auth_sign_up_failed");
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [authAdapter],
+  );
 
-  const signOut = () => {
+  const signOut = useCallback(() => {
     analytics.track("auth_sign_out", { userId: user?.id });
     authAdapter.signOut();
     clearSessionCookie();
     setUser(null);
     router.push(SIGN_IN_PATH);
-  };
+  }, [user, authAdapter, router]);
+
+  const value = useMemo(
+    () => ({ user, loading, signIn, signUp, signOut }),
+    [user, loading, signIn, signUp, signOut],
+  );
 
   return (
-    <AuthContext.Provider value={{ user, loading, signIn, signUp, signOut }}>
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## What
Performance and configuration improvements across auth context memoization, lazy-loaded chart documentation, package optimization, and font loading.

## Issues Resolved
Closes #557
Closes #558
Closes #559
Closes #560

## Changes

### #557 - Memoize AuthContext's provider value
Wrapped signIn, signUp, and signOut functions in useCallback and the context value in useMemo to prevent unnecessary re-renders of consumers like Navbar and dashboard pages when router state changes but auth state hasn't.

### #558 - Lazy-load individual chart wrappers on the charts documentation page
Converted static imports of LineChartWrapper, AreaChartWrapper, BarChartWrapper, and DonutChartWrapper to dynamic imports with loading placeholders to avoid bundling the entire recharts library on page load.

### #559 - Add recharts to next.config.mjs's optimizePackageImports
Added recharts to the optimizePackageImports array alongside lucide-react for proper tree-shaking, and removed the now-default-on instrumentationHook experimental flag.

### #560 - Load the Inter font via next/font or remove the dead reference
Added Inter font loading via next/font/google with Latin subset to the RootLayout, eliminating the dead CSS variable reference and ensuring the intended brand typography renders without fallback to system fonts.