### PR TITLE
Fix/dashboard search sandbox dynamic

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,6 @@ import { HeroSection } from "@/features/landing/HeroSection";
 import { HomeFooter } from "@/features/landing/HomeFooter";
 import { MAIN_CONTENT_LANDMARK_ID } from "@/lib/app-landmarks";
 
-export const dynamic = "force-dynamic";
-
 export const metadata: Metadata = {
   title: "NeuroWealth — AI-Powered Yield on Stellar",
   description:

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,7 +11,12 @@ import { NotificationToggle } from "./notifications/NotificationToggle";
 import { useAuth, useI18n } from "@/contexts";
 import { Button } from "./ui/Button";
 import { LocaleSwitcher } from "./LocaleSwitcher";
-import { GlobalSearch } from "./search/GlobalSearch";
+import dynamic from "next/dynamic";
+
+const GlobalSearch = dynamic(
+  () => import("./search/GlobalSearch").then((mod) => mod.GlobalSearch),
+  { ssr: false }
+);
 import { NavLinks, NavMobileLinks } from "./navbar/NavLinks";
 import { NavWalletStatus } from "./navbar/NavWalletStatus";
 
@@ -19,6 +24,7 @@ export function Navbar() {
   const { user, signOut } = useAuth();
   const { messages } = useI18n();
   const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
+  const [isDesktopSearchActive, setIsDesktopSearchActive] = useState(false);
   const mobileSearchRef = useRef<HTMLDivElement>(null);
   useFocusTrap(mobileSearchRef, isMobileSearchOpen);
 
@@ -40,7 +46,29 @@ export function Navbar() {
         <NavLinks />
 
         <search className="hidden md:block md:flex-1 md:max-w-xl">
-          <GlobalSearch placeholder="Search pages, actions, or records" />
+          {isDesktopSearchActive ? (
+            <GlobalSearch
+              placeholder="Search pages, actions, or records"
+              autoFocus
+              onRequestClose={() => setIsDesktopSearchActive(false)}
+            />
+          ) : (
+            <div className="relative">
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400"
+                size={18}
+                aria-hidden="true"
+              />
+              <input
+                type="text"
+                placeholder="Search pages, actions, or records"
+                onFocus={() => setIsDesktopSearchActive(true)}
+                onClick={() => setIsDesktopSearchActive(true)}
+                className="h-11 w-full rounded-xl border border-white/10 bg-slate-950/80 pl-10 pr-10 text-sm text-white shadow-inner shadow-black/20 outline-none transition focus:border-sky-400/60 focus:ring-2 focus:ring-sky-400/20"
+                readOnly
+              />
+            </div>
+          )}
         </search>
 
         <div className="ml-auto flex items-center gap-2 sm:gap-3 md:gap-4">

--- a/src/components/dashboard/PortfolioDashboard.tsx
+++ b/src/components/dashboard/PortfolioDashboard.tsx
@@ -18,6 +18,8 @@ import { ApiRequestError, apiRequest } from "@/lib/api-client";
 import { useSandbox, ScenarioType } from "@/contexts/SandboxContext";
 import { AllocationChart } from "./AllocationChart";
 import { useI18n } from "@/contexts/I18nContext";
+import { AppMessages } from "@/lib/i18n/messages";
+
 
 type ThemeMode = "light" | "dark";
 
@@ -72,7 +74,7 @@ function renderActivityIcon(kind: ActivityItem["kind"]) {
   }
 }
 
-function renderSourceLabel(source: PortfolioPayload["source"], t: any) {
+function renderSourceLabel(source: PortfolioPayload["source"], t: AppMessages["dashboard"]["portfolio"]) {
   if (source === "api") {
     return t.liveWidgets;
   }

--- a/src/components/dashboard/RealtimeDashboard.tsx
+++ b/src/components/dashboard/RealtimeDashboard.tsx
@@ -22,6 +22,8 @@ import {
 } from "lucide-react";
 import { useToast } from "@/components/notifications/ToastProvider";
 import { useI18n } from "@/contexts/I18nContext";
+import { AppMessages } from "@/lib/i18n/messages";
+
 import {
   useRealtimeStream,
   type StreamEvent,
@@ -39,7 +41,7 @@ function statusDot(status: StreamStatus) {
   return "bg-slate-600";
 }
 
-function statusLabel(status: StreamStatus, t: any) {
+function statusLabel(status: StreamStatus, t: AppMessages["dashboard"]["realtime"]) {
   if (status === "running") return t.status.live;
   if (status === "stopped") return t.status.paused;
   return t.status.idle;
@@ -58,7 +60,7 @@ function kindIcon(kind: StreamEventKind) {
 
 // ── Event log panel ───────────────────────────────────────────────────────────
 
-function EventLog({ events, t }: { events: StreamEvent[], t: any }) {
+function EventLog({ events, t }: { events: StreamEvent[], t: AppMessages["dashboard"]["realtime"] }) {
   if (events.length === 0) {
     return (
       <p className="text-xs text-slate-500 py-3 text-center">{t.noEvents}</p>

--- a/src/contexts/SandboxContext.tsx
+++ b/src/contexts/SandboxContext.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useState, useEffect, ReactNode } from "react";
+import { createContext, useContext, useState, useEffect, ReactNode, useCallback, useMemo } from "react";
 import { STORAGE_KEYS } from "@/lib/storage-keys";
 import { logger } from "@/lib/logger";
 
@@ -70,29 +70,32 @@ export function SandboxProvider({ children }: SandboxProviderProps) {
     }
   }, [scenarios, isClient, isSandboxMode]);
 
-  const updateScenario = (module: ModuleType, scenario: ScenarioType) => {
+  const updateScenario = useCallback((module: ModuleType, scenario: ScenarioType) => {
     if (isSandboxMode) {
       setScenarios((prev) => ({ ...prev, [module]: scenario }));
     }
-  };
+  }, [isSandboxMode]);
 
-  const getCurrentScenario = (module: ModuleType): ScenarioType => {
+  const getCurrentScenario = useCallback((module: ModuleType): ScenarioType => {
     return scenarios[module] || "success";
-  };
+  }, [scenarios]);
 
-  const resetAllScenarios = () => {
+  const resetAllScenarios = useCallback(() => {
     if (isSandboxMode) {
       setScenarios(defaultScenarios);
     }
-  };
+  }, [isSandboxMode]);
 
-  const value: SandboxContextType = {
-    scenarios,
-    updateScenario,
-    getCurrentScenario,
-    resetAllScenarios,
-    isSandboxMode,
-  };
+  const value = useMemo<SandboxContextType>(
+    () => ({
+      scenarios,
+      updateScenario,
+      getCurrentScenario,
+      resetAllScenarios,
+      isSandboxMode,
+    }),
+    [scenarios, updateScenario, getCurrentScenario, resetAllScenarios, isSandboxMode]
+  );
 
   return (
     <SandboxContext.Provider value={value}>


### PR DESCRIPTION
# Technical Cleanup and Performance Optimization

This pull request resolves a series of type safety issues and performance inefficiencies identified in the dashboard, navigation search component, sandbox context, and landing page.

### Proposed Changes

#### Type Safety
- **Dashboard Type Safety**: Replaced the `any` type for translation namespace objects (`t: any`) with typed imports matching `AppMessages["dashboard"]["portfolio"]` and `AppMessages["dashboard"]["realtime"]` inside PortfolioDashboard.tsx and RealtimeDashboard.tsx. This prevents runtime display errors by ensuring internationalization keys are verified at compile time.

#### Performance & Bundling
- **Lazy Load GlobalSearch**: Converted `GlobalSearch` within Navbar.tsx to load dynamically on-demand using `next/dynamic`. A lightweight mock input is displayed until the search input is focused or clicked on desktop, or until the mobile search interface is triggered. This prevents search indices and UI libraries from bloating the initial bundle size on every page load.
- **Memoize SandboxContext**: Wrapped action handlers in `useCallback` and the state context provider value in `useMemo` in SandboxContext.tsx. This avoids unnecessary tree-wide re-renders of consuming components upon internal sandbox state updates.
- **Static Landing Page Optimization**: Removed the redundant `export const dynamic = "force-dynamic"` declaration in page.tsx to allow Next.js to compile and cache the homepage as a static route.

closes #541
closes #555
closes #556
closes #554