### PR TITLE
fixed audit

### DIFF
--- a/src/components/audit/AuditTrail.tsx
+++ b/src/components/audit/AuditTrail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import React, { Fragment, useState, useEffect } from "react";
 import { AuditEvent, mockAuditService } from "@/lib/mock-audit";
 import { Download, Filter, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/Button";
@@ -151,31 +151,54 @@ export function AuditTrail() {
                 </td>
               </tr>
             ) : (
-              pagedEvents.map((event) => (
-                <tr key={event.id} className="audit-row">
-                  <td>
-                    <span className={`audit-badge ${eventTypeColors[event.eventType]}`}>
-                      {eventTypeLabels[event.eventType]}
-                    </span>
-                  </td>
-                  <td className="audit-timestamp">
-                    {formatTimestamp(event.timestamp.toISOString())}
-                  </td>
-                  <td>{event.actor}</td>
-                  <td className="audit-ip">{event.ipAddress || "N/A"}</td>
-                  <td>
-                    <button
-                      onClick={() =>
-                        setExpandedId(expandedId === event.id ? null : event.id)
-                      }
-                      className="audit-expand-btn"
-                      aria-label={`${expandedId === event.id ? "Collapse" : "Expand"} details`}
-                    >
-                      {expandedId === event.id ? "Hide" : "Show"}
-                    </button>
-                  </td>
-                </tr>
-              ))
+              pagedEvents.map((event) => {
+                const isExpanded = expandedId === event.id;
+                const detailId = `audit-details-${event.id}`;
+
+                return (
+                  <Fragment key={event.id}>
+                    <tr key={event.id} className="audit-row">
+                      <td>
+                        <span className={`audit-badge ${eventTypeColors[event.eventType]}`}>
+                          {eventTypeLabels[event.eventType]}
+                        </span>
+                      </td>
+                      <td className="audit-timestamp">
+                        {formatTimestamp(event.timestamp.toISOString())}
+                      </td>
+                      <td>{event.actor}</td>
+                      <td className="audit-ip">{event.ipAddress || "N/A"}</td>
+                      <td>
+                        <button
+                          onClick={() =>
+                            setExpandedId((current) => (current === event.id ? null : event.id))
+                          }
+                          className="audit-expand-btn"
+                          aria-expanded={isExpanded}
+                          aria-controls={detailId}
+                          aria-label={`${isExpanded ? "Collapse" : "Expand"} details`}
+                        >
+                          {isExpanded ? "Hide" : "Show"}
+                        </button>
+                      </td>
+                    </tr>
+                    {isExpanded && (
+                      <tr key={`${event.id}-details`}>
+                        <td colSpan={5}>
+                          <div id={detailId} className="audit-detail-panel" role="region" aria-label="Expanded event details">
+                            <div className="audit-metadata">
+                              <p className="audit-metadata-label">Metadata</p>
+                              <pre className="audit-metadata-content">
+                                {JSON.stringify(event.metadata, null, 2)}
+                              </pre>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })
             )}
           </tbody>
         </table>
@@ -194,9 +217,10 @@ export function AuditTrail() {
                 </span>
                 <button
                   onClick={() =>
-                    setExpandedId(expandedId === event.id ? null : event.id)
+                    setExpandedId((current) => (current === event.id ? null : event.id))
                   }
                   className="audit-card-toggle"
+                  aria-expanded={expandedId === event.id}
                   aria-label={`${expandedId === event.id ? "Collapse" : "Expand"} details`}
                 >
                   <ChevronDown
@@ -327,6 +351,13 @@ export function AuditTrail() {
           background: rgba(15, 23, 42, 0.6);
           border: 1px solid rgba(148, 163, 184, 0.2);
           border-radius: 8px;
+          transition: border-color 0.2s, box-shadow 0.2s;
+        }
+
+        .audit-filter-group:focus-within,
+        .audit-sort-group:focus-within {
+          border-color: rgba(56, 189, 248, 0.6);
+          box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.2);
         }
 
         .audit-select {
@@ -336,6 +367,11 @@ export function AuditTrail() {
           font-size: 14px;
           cursor: pointer;
           outline: none;
+          padding-right: 4px;
+        }
+
+        .audit-select:focus-visible {
+          color: #f8fafc;
         }
 
         .audit-select option {
@@ -412,7 +448,7 @@ export function AuditTrail() {
         .audit-ip {
           font-family: "Monaco", "Courier New", monospace;
           font-size: 12px;
-          color: #64748b;
+          color: #e2e8f0;
         }
 
         .audit-badge {
@@ -439,10 +475,17 @@ export function AuditTrail() {
           color: #0ea5e9;
         }
 
+        .audit-expand-btn:focus-visible,
+        .audit-card-toggle:focus-visible {
+          outline: 2px solid rgba(56, 189, 248, 0.8);
+          outline-offset: 2px;
+          border-radius: 4px;
+        }
+
         .audit-empty {
           text-align: center;
           padding: 32px 16px;
-          color: #64748b;
+          color: #e2e8f0;
         }
 
         /* Mobile Cards */
@@ -476,6 +519,7 @@ export function AuditTrail() {
           display: flex;
           align-items: center;
           transition: color 0.2s;
+          border-radius: 4px;
         }
 
         .audit-card-toggle:hover {
@@ -541,10 +585,14 @@ export function AuditTrail() {
           overflow-y: auto;
         }
 
+        .audit-detail-panel {
+          padding: 8px 0 4px;
+        }
+
         .audit-empty-mobile {
           text-align: center;
           padding: 32px 16px;
-          color: #64748b;
+          color: #e2e8f0;
           font-size: 14px;
         }
 

--- a/src/components/ui/DataTable.test.ts
+++ b/src/components/ui/DataTable.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
+import { DataTable, type DataTableColumn } from "./DataTable";
 import {
   applyColumnFilters,
   ariaSortValue,
@@ -138,4 +141,29 @@ test("getPaginatedSlice handles empty data", () => {
 test("getPaginatedSlice handles out-of-range page gracefully", () => {
   const items = [1, 2, 3, 4, 5];
   assert.deepEqual(getPaginatedSlice(items, 10, 3), []);
+});
+
+test("interactive rows expose keyboard semantics", () => {
+  type TestRow = { id: string; name: string };
+  const columns: DataTableColumn<TestRow>[] = [
+    {
+      key: "name",
+      header: "Name",
+      accessor: (row) => row.name,
+    },
+  ];
+
+  const markup = renderToStaticMarkup(
+    React.createElement(DataTable<TestRow>, {
+      data: [{ id: "1", name: "Alpha" }],
+      columns,
+      rowKey: (row) => row.id,
+      onRowClick: () => undefined,
+      pageSize: 10,
+      searchable: false,
+    }),
+  );
+
+  assert.match(markup, /role="button"/);
+  assert.match(markup, /tabindex="0"/);
 });

--- a/src/components/ui/DataTable.tsx
+++ b/src/components/ui/DataTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import {
+import React, {
+  type KeyboardEvent,
   type ReactNode,
   useEffect,
   useId,
@@ -74,7 +75,7 @@ export interface DataTableProps<T> {
   /** Accessible caption / description. */
   caption?: string;
   emptyMessage?: string;
-  /** Optional row click handler (also makes rows keyboard-activatable). */
+  /** Optional row click handler (also makes rows keyboard-activatable with Enter/Space). */
   onRowClick?: (row: T) => void;
   className?: string;
   /** Rows per page for client-side pagination. 0 or undefined shows all rows. */
@@ -211,6 +212,14 @@ export function DataTable<T extends object>({
     if (column.render) return column.render(row);
     const value = column.accessor(row);
     return value == null || value === "" ? "—" : String(value);
+  };
+
+  const handleRowKeyDown = (event: KeyboardEvent<HTMLElement>, row: T) => {
+    if (!onRowClick) return;
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onRowClick(row);
+    }
   };
 
   const SortIcon = ({ column }: { column: DataTableColumn<T> }) => {
@@ -422,6 +431,9 @@ export function DataTable<T extends object>({
                 <tr
                   key={rowKey(row)}
                   onClick={onRowClick ? () => onRowClick(row) : undefined}
+                  onKeyDown={onRowClick ? (event) => handleRowKeyDown(event, row) : undefined}
+                  role={onRowClick ? "button" : undefined}
+                  tabIndex={onRowClick ? 0 : undefined}
                   className={cn(
                     "transition-colors",
                     striped && "even:bg-slate-50/70 dark:even:bg-white/[0.02]",
@@ -458,6 +470,9 @@ export function DataTable<T extends object>({
             <li
               key={rowKey(row)}
               onClick={onRowClick ? () => onRowClick(row) : undefined}
+              onKeyDown={onRowClick ? (event) => handleRowKeyDown(event, row) : undefined}
+              role={onRowClick ? "button" : undefined}
+              tabIndex={onRowClick ? 0 : undefined}
               className={cn(
                 "rounded-lg border border-slate-200 bg-white p-3 dark:border-white/10 dark:bg-slate-900/60",
                 onRowClick && "cursor-pointer active:bg-slate-50 dark:active:bg-white/5",


### PR DESCRIPTION


## ✅ Accessibility fixes implemented

The requested fixes are now in place in AuditTrail.tsx, DataTable.tsx, and covered by a regression test in DataTable.test.ts.


- Audit trail desktop rows now render expanded details inline, and the toggle buttons expose the correct `aria-expanded` state.
- The audit filter control now shows a visible focus indicator, and the low-contrast empty/IP text colors were lightened for better contrast.
- DataTable rows with `onRowClick` are now keyboard-accessible via `tabIndex=0`, `role="button"`, and Enter/Space handling, and the prop documentation now matches that behavior.

### Verification
- Ran:
  - `node --import tsx --test src/components/ui/DataTable.test.ts`
  - Result: 16 tests passed, 0 failed

### Manual QA check
1. Open the audit trail and confirm the desktop table shows expanded metadata when “Show” is clicked.
2. Tab to a DataTable row with row-click behavior and press Enter/Space to activate it.
3. Focus the audit filter select and verify the visible focus ring appears.

> A broader `yarn typecheck` still reports existing repository-wide issues in unrelated files, so I did not claim the workspace is fully type-clean.

Closes #528
Closes #529 
Closes #530 
Closes #531