### PR TITLE
fix: resolve issues #341-#344 — storage keys, sandbox scenario sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 /coverage
 **/__snapshots__
 **/*.snap
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 # next.js
 /.next/

--- a/src/app/api/portfolio/route.ts
+++ b/src/app/api/portfolio/route.ts
@@ -2,7 +2,7 @@ import {
   buildScenarioPayload,
   normalizePortfolioPayload,
 } from "@/lib/portfolio";
-import { isSandboxScenario, resolveSandboxScenario } from "@/lib/api-sandbox";
+import { isSandboxScenario, parseSandboxScenario } from "@/lib/sandbox-scenario";
 import {
   ERROR_CODE,
   HTTP_STATUS,
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const scenario = resolveSandboxScenario(parsedQuery.data.scenario);
+  const scenario = parseSandboxScenario(parsedQuery.data.scenario);
   const portfolioPath =
     process.env.NEUROWEALTH_PORTFOLIO_PATH ?? "/portfolio/overview";
 

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -16,7 +16,7 @@ import {
   zodErrorToDetails,
 } from "@/lib/validation/api";
 import { NextRequest, NextResponse } from "next/server";
-import { isSandboxScenario, resolveSandboxScenario } from "@/lib/api-sandbox";
+import { isSandboxScenario, parseSandboxScenario } from "@/lib/sandbox-scenario";
 import { createServerFetcher } from "@/lib/api-client";
 
 export async function POST(request: NextRequest) {
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
   const values = payload.values;
   const transactionPath =
     process.env.NEUROWEALTH_TRANSACTIONS_PATH ?? "/transactions";
-  const scenario = resolveSandboxScenario(
+  const scenario = parseSandboxScenario(
     request.nextUrl.searchParams.get("scenario"),
   );
   const fetchBackend = createServerFetcher();

--- a/src/app/dashboard/settings/preferences/page.tsx
+++ b/src/app/dashboard/settings/preferences/page.tsx
@@ -21,6 +21,7 @@ import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
 import { useTheme, ThemeMode } from "@/contexts/ThemeProvider";
 import { useI18n } from "@/contexts/I18nContext";
 import { LOCALE_OPTIONS as LOCALES } from "@/lib/locale-options";
+import { STORAGE_KEYS } from "@/lib/storage-keys";
 
 interface PreferencesData {
   locale: string;
@@ -47,7 +48,7 @@ const CURRENCIES = [
   { value: "CNY", label: "CNY — Chinese Yuan (¥)" },
 ];
 
-const STORAGE_KEY = "nw_preferences";
+const STORAGE_KEY = STORAGE_KEYS.PREFERENCES;
 const DEFAULT: PreferencesData = {
   locale: "en-US",
   timezone: "UTC",

--- a/src/app/dashboard/settings/security/page.tsx
+++ b/src/app/dashboard/settings/security/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/Button";
 export const dynamic = "force-dynamic";
 import { mockAuditService } from "@/lib/mock-audit";
 import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
+import { STORAGE_KEYS } from "@/lib/storage-keys";
 
 interface SecurityData {
   twoFactorEnabled: boolean;
@@ -15,7 +16,7 @@ interface SecurityData {
   loginAlerts: boolean;
 }
 
-const STORAGE_KEY = "nw_security";
+const STORAGE_KEY = STORAGE_KEYS.SECURITY;
 const DEFAULT: SecurityData = {
   twoFactorEnabled: false,
   lastPasswordChange: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),

--- a/src/components/onboarding/steps/FirstDepositStep.tsx
+++ b/src/components/onboarding/steps/FirstDepositStep.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { random } from '@/lib/seeded-rng';
+import { STORAGE_KEYS } from '@/lib/storage-keys';
 
 interface FirstDepositStepProps {
   onNext: () => void;
@@ -78,7 +79,7 @@ export default function FirstDepositStep({ onNext, onSkip, onBack }: FirstDeposi
           timestamp: Date.now(),
           isFirstDeposit: true
         };
-        localStorage.setItem('first-deposit', JSON.stringify(depositRecord));
+        localStorage.setItem(STORAGE_KEYS.ONBOARDING_FIRST_DEPOSIT, JSON.stringify(depositRecord));
         
         onNext();
       } else {

--- a/src/components/onboarding/steps/StrategyOverviewStep.tsx
+++ b/src/components/onboarding/steps/StrategyOverviewStep.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { logger } from '@/lib/logger';
+import { STORAGE_KEYS } from '@/lib/storage-keys';
 
 interface StrategyOverviewStepProps {
   onNext: () => void;
@@ -58,7 +59,7 @@ export default function StrategyOverviewStep({ onNext, onSkip, onBack }: Strateg
       await new Promise(resolve => setTimeout(resolve, 1500));
       
       // Save to localStorage for persistence
-      localStorage.setItem('user-strategy', selectedStrategy);
+      localStorage.setItem(STORAGE_KEYS.ONBOARDING_USER_STRATEGY, selectedStrategy);
       
       onNext();
     } catch (error) {

--- a/src/components/settings/OnboardingSettings.tsx
+++ b/src/components/settings/OnboardingSettings.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/components/notifications/ToastProvider';
 import { clearOnboardingState, loadOnboardingState as getOnboardingState } from '@/lib/onboarding-state';
 import { logger } from '@/lib/logger';
 import { formatDate } from '@/lib/formatters';
+import { STORAGE_KEYS } from '@/lib/storage-keys';
 
 interface OnboardingState {
   completed: boolean;
@@ -42,8 +43,8 @@ export default function OnboardingSettings() {
     try {
       // Clear onboarding state
       clearOnboardingState();
-      localStorage.removeItem('user-strategy');
-      localStorage.removeItem('first-deposit');
+      localStorage.removeItem(STORAGE_KEYS.ONBOARDING_USER_STRATEGY);
+      localStorage.removeItem(STORAGE_KEYS.ONBOARDING_FIRST_DEPOSIT);
       
       // Reset state
       setOnboardingState(null);

--- a/src/lib/api-sandbox.ts
+++ b/src/lib/api-sandbox.ts
@@ -1,12 +1,13 @@
-import { parseScenario, PortfolioScenario } from "@/lib/portfolio";
-
-export function resolveSandboxScenario(
-  scenarioValue: string | null | undefined,
-): PortfolioScenario {
-  return parseScenario(scenarioValue ?? null);
-}
-
-export function isSandboxScenario(scenario: PortfolioScenario): boolean {
-  return scenario !== "live";
-}
-
+/**
+ * Re-exports from src/lib/sandbox-scenario.ts for backwards compatibility.
+ *
+ * Previously this file delegated to portfolio.ts. It now uses the dedicated
+ * sandbox-scenario module so that no unrelated portfolio logic is imported by
+ * the transactions route (or any other sandbox-aware route).
+ */
+export {
+  type SandboxScenario,
+  parseSandboxScenario,
+  parseSandboxScenario as resolveSandboxScenario,
+  isSandboxScenario,
+} from "@/lib/sandbox-scenario";

--- a/src/lib/sandbox-scenario.test.ts
+++ b/src/lib/sandbox-scenario.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for src/lib/sandbox-scenario.ts
+ *
+ * Covers:
+ * - parseSandboxScenario: all valid scenarios, invalid values, edge cases
+ * - isSandboxScenario: guard correctly distinguishes live from sandbox
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  parseSandboxScenario,
+  isSandboxScenario,
+} from "./sandbox-scenario";
+
+describe("parseSandboxScenario", () => {
+  it("returns 'empty' for the string 'empty'", () => {
+    assert.equal(parseSandboxScenario("empty"), "empty");
+  });
+
+  it("returns 'loading' for the string 'loading'", () => {
+    assert.equal(parseSandboxScenario("loading"), "loading");
+  });
+
+  it("returns 'partial-failure' for the string 'partial-failure'", () => {
+    assert.equal(parseSandboxScenario("partial-failure"), "partial-failure");
+  });
+
+  it("returns 'timeout' for the string 'timeout'", () => {
+    assert.equal(parseSandboxScenario("timeout"), "timeout");
+  });
+
+  it("returns 'live' for null", () => {
+    assert.equal(parseSandboxScenario(null), "live");
+  });
+
+  it("returns 'live' for undefined", () => {
+    assert.equal(parseSandboxScenario(undefined), "live");
+  });
+
+  it("returns 'live' for an empty string", () => {
+    assert.equal(parseSandboxScenario(""), "live");
+  });
+
+  it("returns 'live' for an unknown string value", () => {
+    assert.equal(parseSandboxScenario("unknown-scenario"), "live");
+  });
+
+  it("returns 'live' for a numeric-looking string", () => {
+    assert.equal(parseSandboxScenario("123"), "live");
+  });
+
+  it("is case-sensitive — 'Empty' is not a valid scenario", () => {
+    assert.equal(parseSandboxScenario("Empty"), "live");
+  });
+
+  it("is case-sensitive — 'LOADING' is not a valid scenario", () => {
+    assert.equal(parseSandboxScenario("LOADING"), "live");
+  });
+});
+
+describe("isSandboxScenario", () => {
+  it("returns false for 'live'", () => {
+    assert.equal(isSandboxScenario("live"), false);
+  });
+
+  it("returns true for 'empty'", () => {
+    assert.equal(isSandboxScenario("empty"), true);
+  });
+
+  it("returns true for 'loading'", () => {
+    assert.equal(isSandboxScenario("loading"), true);
+  });
+
+  it("returns true for 'partial-failure'", () => {
+    assert.equal(isSandboxScenario("partial-failure"), true);
+  });
+
+  it("returns true for 'timeout'", () => {
+    assert.equal(isSandboxScenario("timeout"), true);
+  });
+
+  it("parseSandboxScenario → isSandboxScenario round-trip: known values", () => {
+    const sandboxValues = ["empty", "loading", "partial-failure", "timeout"];
+    for (const v of sandboxValues) {
+      assert.equal(
+        isSandboxScenario(parseSandboxScenario(v)),
+        true,
+        `Expected isSandboxScenario to be true for '${v}'`,
+      );
+    }
+  });
+
+  it("parseSandboxScenario → isSandboxScenario round-trip: fallback values", () => {
+    const fallbacks = [null, undefined, "", "live", "bad-value"];
+    for (const v of fallbacks) {
+      assert.equal(
+        isSandboxScenario(parseSandboxScenario(v)),
+        false,
+        `Expected isSandboxScenario to be false for ${JSON.stringify(v)}`,
+      );
+    }
+  });
+});

--- a/src/lib/sandbox-scenario.ts
+++ b/src/lib/sandbox-scenario.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared sandbox scenario parsing utilities.
+ *
+ * Persistence approach: scenario is passed as a URL query parameter (?scenario=<value>)
+ * from the client and read in the API route handlers. This keeps the server routes
+ * stateless — no module-level variable or server-side storage is required.
+ *
+ * Both the portfolio and transactions routes import from this module so that the
+ * valid scenario set and the fallback ("live") live in exactly one place.
+ */
+
+/** Recognised mock scenarios that alter API route behaviour. */
+export type SandboxScenario =
+  | "live"
+  | "empty"
+  | "loading"
+  | "partial-failure"
+  | "timeout";
+
+/** The set of non-live sandbox scenarios (convenience for type narrowing). */
+const SANDBOX_SCENARIOS = new Set<SandboxScenario>([
+  "empty",
+  "loading",
+  "partial-failure",
+  "timeout",
+]);
+
+/**
+ * Parse a raw query-parameter or localStorage value into a typed SandboxScenario.
+ *
+ * Unknown / missing values fall back to `"live"` so that routes behave normally
+ * when no sandbox override is active.
+ *
+ * @param value - Raw string from a URL search param or null/undefined when absent.
+ * @returns A validated SandboxScenario value.
+ */
+export function parseSandboxScenario(
+  value: string | null | undefined,
+): SandboxScenario {
+  if (value === "empty") return "empty";
+  if (value === "loading") return "loading";
+  if (value === "partial-failure") return "partial-failure";
+  if (value === "timeout") return "timeout";
+  return "live";
+}
+
+/**
+ * Returns `true` when the scenario represents an active sandbox override (i.e. not
+ * "live"). Use this as a guard before returning mock data from an API route.
+ *
+ * @param scenario - A SandboxScenario produced by `parseSandboxScenario`.
+ */
+export function isSandboxScenario(scenario: SandboxScenario): boolean {
+  return SANDBOX_SCENARIOS.has(scenario);
+}


### PR DESCRIPTION
#341: SandboxClientPage and SandboxContext already used STORAGE_KEYS.SANDBOX_SCENARIOS — confirmed clean, no changes needed.

#342: Replace all raw localStorage key strings with STORAGE_KEYS registry constants.
- settings/security/page.tsx: 'nw_security' → STORAGE_KEYS.SECURITY
- settings/preferences/page.tsx: 'nw_preferences' → STORAGE_KEYS.PREFERENCES
- OnboardingSettings.tsx: 'user-strategy'/'first-deposit' → STORAGE_KEYS constants
- FirstDepositStep.tsx: 'first-deposit' → STORAGE_KEYS.ONBOARDING_FIRST_DEPOSIT
- StrategyOverviewStep.tsx: 'user-strategy' → STORAGE_KEYS.ONBOARDING_USER_STRATEGY All previously unused registry keys (SECURITY, PREFERENCES, ONBOARDING_USER_STRATEGY, ONBOARDING_FIRST_DEPOSIT) are now wired up.

#343: Strategy route already used cookie-based mock persistence — confirmed clean, no changes needed.

#344: Extract shared sandbox scenario parsing into src/lib/sandbox-scenario.ts.
- New: SandboxScenario type, parseSandboxScenario(), isSandboxScenario() in sandbox-scenario.ts
- api-sandbox.ts now re-exports from sandbox-scenario.ts (backwards-compatible)
- portfolio/route.ts and transactions/route.ts import directly from sandbox-scenario.ts
- Added unit tests in sandbox-scenario.test.ts covering all valid values, nullish inputs, invalid strings, and round-trip assertions

.gitignore: add Playwright report/results directories
closes
closes #341 
closes #342
closes #343 
closes #344 