### PR TITLE
fix: gate dev-error routes centrally and exclude from breadcrumbs

### DIFF
--- a/src/app/dashboard/dev-errors/boundary-error/page.tsx
+++ b/src/app/dashboard/dev-errors/boundary-error/page.tsx
@@ -1,13 +1,6 @@
-import { notFound } from "next/navigation";
 import TriggerBoundaryError from "./TriggerBoundaryError";
 
-const DEV_ERRORS_ENABLED = process.env.NODE_ENV !== "production";
-
 export default function DashboardBoundaryErrorPage() {
-  if (!DEV_ERRORS_ENABLED) {
-    notFound();
-  }
-
   return (
     <main className="space-y-4">
       <h1 className="text-2xl font-semibold text-text-primary">

--- a/src/app/dashboard/dev-errors/layout.tsx
+++ b/src/app/dashboard/dev-errors/layout.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+import type { ReactNode } from "react";
+
+const DEV_ERRORS_ENABLED = process.env.NODE_ENV !== "production";
+
+export default function DevErrorsLayout({ children }: { children: ReactNode }) {
+  if (!DEV_ERRORS_ENABLED) {
+    notFound();
+  }
+
+  return (
+    <div className="rounded-lg border border-dashed border-yellow-500/40 bg-yellow-500/5 p-4">
+      <p className="mb-4 text-xs font-semibold uppercase tracking-wider text-yellow-400">
+        Internal — dev-only route
+      </p>
+      {children}
+    </div>
+  );
+}

--- a/src/app/dashboard/dev-errors/page.tsx
+++ b/src/app/dashboard/dev-errors/page.tsx
@@ -1,13 +1,6 @@
 import Link from "next/link";
-import { notFound } from "next/navigation";
-
-const DEV_ERRORS_ENABLED = process.env.NODE_ENV !== "production";
 
 export default function DashboardDevErrorsPage() {
-  if (!DEV_ERRORS_ENABLED) {
-    notFound();
-  }
-
   return (
     <main className="space-y-8">
       <header>

--- a/src/app/dashboard/dev-errors/route-error/page.tsx
+++ b/src/app/dashboard/dev-errors/route-error/page.tsx
@@ -1,11 +1,3 @@
-import { notFound } from "next/navigation";
-
-const DEV_ERRORS_ENABLED = process.env.NODE_ENV !== "production";
-
 export default function DashboardRouteErrorPage() {
-  if (!DEV_ERRORS_ENABLED) {
-    notFound();
-  }
-
   throw new Error("Intentional dashboard route error for boundary testing");
 }

--- a/src/lib/routeMetadata.test.ts
+++ b/src/lib/routeMetadata.test.ts
@@ -200,3 +200,11 @@ test("breadcrumbs for docs/tokens path are correct", () => {
     ["Home", "Docs", "Design Tokens"],
   );
 });
+
+test("breadcrumbs skip devOnly routes", () => {
+  const breadcrumbs = buildBreadcrumbsFromPath("/dashboard/dev-errors/boundary-error");
+  const labels = breadcrumbs.map((b) => b.label);
+  assert.ok(!labels.includes("Dev Errors"), "dev-errors should not appear in breadcrumbs");
+  assert.ok(!labels.includes("Boundary Error"), "boundary-error should not appear in breadcrumbs");
+  assert.deepEqual(labels, ["Home", "Dashboard"]);
+});

--- a/src/lib/routeMetadata.tsx
+++ b/src/lib/routeMetadata.tsx
@@ -240,6 +240,10 @@ export function getRouteLabel(pathname: string, fallback = "Dashboard"): string 
 export function buildBreadcrumbsFromPath(
   pathname: string,
 ): import("@/types/breadcrumb.types").BreadcrumbItem[] {
+  const devOnlyHrefs = new Set(
+    appRouteDefinitions.filter((d) => d.devOnly).map((d) => d.href),
+  );
+
   const segments = pathname.split("/").filter(Boolean);
   const items: import("@/types/breadcrumb.types").BreadcrumbItem[] = [
     { label: "Home", href: "/", icon: routeMetadata["/"]?.icon },
@@ -248,6 +252,11 @@ export function buildBreadcrumbsFromPath(
   let cumulative = "";
   segments.forEach((seg, idx) => {
     cumulative += `/${seg}`;
+
+    if (devOnlyHrefs.has(cumulative)) {
+      return;
+    }
+
     const meta = routeMetadata[cumulative];
     items.push({
       label: meta?.label ?? seg.charAt(0).toUpperCase() + seg.slice(1),


### PR DESCRIPTION
Closes #331

---

## Summary

Dev error-boundary test pages under `/dashboard/dev-errors` were individually guarded but still appeared in breadcrumbs. This PR centralizes the gate and excludes them from breadcrumb navigation.

## Changes

**New: `src/app/dashboard/dev-errors/layout.tsx`**
- Single `NODE_ENV !== "production"` gate via `notFound()` — replaces 3 per-page guards
- Wraps child routes in a dashed-border "Internal — dev-only route" banner for visual clarity

**Removed per-page guards**
- `dev-errors/page.tsx` — removed `DEV_ERRORS_ENABLED` check + `notFound()`
- `dev-errors/boundary-error/page.tsx` — same
- `dev-errors/route-error/page.tsx` — same

**`src/lib/routeMetadata.tsx`**
- `buildBreadcrumbsFromPath()` now skips `devOnly` route segments
- `/dashboard/dev-errors/boundary-error` renders as `Home > Dashboard` (not `Home > Dashboard > Dev Errors > Boundary Error`)

**`src/lib/routeMetadata.test.ts`**
- New test: `breadcrumbs skip devOnly routes` — verifies dev-errors segments are excluded

## What was already working (no changes needed)
- Sidebar/mobile nav: already excluded `devOnly` routes via `.filter(!devOnly)`
- Command palette: already excluded via `!definition.devOnly` in `isCommandPaletteRoute()`
- Playwright tests: URLs unchanged, dev server runs in `development` mode so `layout.tsx` gate passes

## Acceptance criteria
- [x] Scope limited to the files listed (plus layout.tsx)
- [x] 546/546 tests pass including new breadcrumb test
- [x] No behavior regressions — routes still accessible in dev mode
- [x] No new abstractions

## Suggested labels
cleanup, routing, testing
