### PR TITLE
fix: add keyboard focus ring to Switch component

### DIFF
--- a/src/components/ui/Switch.tsx
+++ b/src/components/ui/Switch.tsx
@@ -25,7 +25,10 @@ export function Switch({ checked, onChange, label, disabled = false }: SwitchPro
         />
         <div
           className={`
-            w-11 h-6 bg-slate-700 peer-focus:outline-none rounded-full peer 
+            w-11 h-6 bg-slate-700 rounded-full peer 
+            peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-sky-500
+            peer-focus-visible:ring-offset-2 peer-focus-visible:ring-offset-white
+            dark:peer-focus-visible:ring-offset-slate-900
             peer-checked:after:translate-x-full peer-checked:after:border-white 
             after:content-[''] after:absolute after:top-[2px] after:left-[2px] 
             after:bg-white after:border-gray-300 after:border after:rounded-full 


### PR DESCRIPTION
Closes #525

---

## Summary

The Switch component hides its real checkbox input (`sr-only peer`) and applies `peer-focus:outline-none` on the visible track with no compensating focus ring. Keyboard users can't see which toggle is focused when tabbing through Settings > Notifications.

## Change

**`src/components/ui/Switch.tsx`**
- Replaced `peer-focus:outline-none` with `peer-focus-visible:ring-2` using the app's existing focus token (`ring-sky-500 ring-offset-2`) from `DataTable.tsx`
- `focus-visible` ensures the ring only appears on keyboard navigation, not mouse clicks
- Light theme: `ring-offset-white` background; dark theme: `ring-offset-slate-900` background

## QA steps

1. Open `/dashboard/settings/notifications`
2. Press `Tab` to focus the first Switch toggle — a sky-blue ring with offset should appear
3. Press `Tab` again — focus moves to the next toggle with the same ring
4. Click a toggle with mouse — no ring appears
5. Verify in both light and dark themes

## Acceptance criteria
- [x] Scope limited to `Switch.tsx` (NotificationPreferences.tsx unchanged — it's a consumer)
- [x] Change is verifiable via QA steps above
- [x] No behavior regressions — only adds visual focus indicator
- [x] No new abstractions — reuses existing DataTable focus token pattern

## Suggested labels
a11y, cleanup, good first issue
