### PR TITLE
Fix audit docs misquotes, use shared date formatter, and gate demo routes

### DIFF
--- a/docs/error-boundary-matrix.md
+++ b/docs/error-boundary-matrix.md
@@ -17,21 +17,24 @@ boundary catches the error, what the user sees, and how they recover.
 
 | Route segment | Throws? | Cause | Caught by | User-visible copy | Recovery action |
 | --- | --- | --- | --- | --- | --- |
-| `/dashboard/dev-errors/route-error` (dev only) | Yes — intentional | `throw new Error(…)` in the page component | `src/app/dashboard/error.tsx` | "Dashboard unavailable — Your funds and wallet connection remain safe." | "Try again" (calls `reset()`) or "Back to dashboard home" (`href=/dashboard`) |
-| `/dashboard/dev-errors/boundary-error` (dev only) | Yes — on button click | `TriggerBoundaryError` sets `shouldThrow = true`, causing a render throw | Global `ErrorBoundary` in `src/app/layout.tsx` | "We hit a temporary app issue. Try reloading this view." | "Try again" button resets `hasError` state; full reload also recovers |
-| `/dashboard/**` (all live dashboard segments) | Possible (data fetch, runtime) | Unhandled exception in a server component or async route handler | `src/app/dashboard/error.tsx` | "Dashboard unavailable — Your funds and wallet connection remain safe." | "Try again" or "Back to dashboard home" |
-| `/onboarding` | Possible | Unhandled exception in onboarding server components | `src/app/onboarding/error.tsx` | "Onboarding unavailable — Your current progress remains safe." | "Try again" or "Back to home" |
-| `/profile` | Possible | Unhandled exception in profile server components | `src/app/profile/error.tsx` | "Profile unavailable — Your saved preferences remain unchanged." | "Try again" or "Back to dashboard" |
-| All other routes (global fallback) | Possible | Unhandled runtime exception outside a named error segment | `src/app/error.tsx` | "We ran into an unexpected issue — Your account and funds remain safe." | "Try again" or "Back to home" |
-| Client component crash (any route) | Possible | Unhandled render throw in a `"use client"` component | Global `ErrorBoundary` (`src/app/layout.tsx`) | "We hit a temporary app issue. Try reloading this view." | "Try again" button resets the React error boundary state |
+| `/dashboard/dev-errors/route-error` (dev only) | Yes — intentional | `throw new Error(…)` in the page component | `src/app/dashboard/error.tsx` | Title: "Dashboard unavailable"; Description: "We are having trouble loading this dashboard view right now. Your funds and wallet connection remain safe." | Primary: "Back to dashboard home" (`href=/dashboard`); Secondary: "Try again" (calls `reset()`) |
+| `/dashboard/dev-errors/boundary-error` (dev only) | Yes — on button click | `TriggerBoundaryError` sets `shouldThrow = true`, causing a render throw | Global `ErrorBoundary` in `src/app/layout.tsx` | Heading: "We hit a temporary app issue."; Body: "Try reloading this view. If the issue keeps happening, return shortly while we investigate." | "Try again" button resets `hasError` state; full reload also recovers |
+| `/dashboard/**` (all live dashboard segments) | Possible (data fetch, runtime) | Unhandled exception in a server component or async route handler | `src/app/dashboard/error.tsx` | Title: "Dashboard unavailable"; Description: "We are having trouble loading this dashboard view right now. Your funds and wallet connection remain safe." | Primary: "Back to dashboard home"; Secondary: "Try again" |
+| `/onboarding` | Possible | Unhandled exception in onboarding server components | `src/app/onboarding/error.tsx` | Title: "Onboarding unavailable"; Description: "We could not load the onboarding flow. Your current progress remains safe, and you can retry the route when ready." | Primary: "Back to home" (`href=/`); Secondary: "Try again" |
+| `/profile` | Possible | Unhandled exception in profile server components | `src/app/profile/error.tsx` | Title: "Profile unavailable"; Description: "We could not load your profile view. Your saved preferences remain unchanged, and you can try loading this route again." | Primary: "Back to dashboard" (`href=/dashboard`); Secondary: "Try again" |
+| All other routes (global fallback) | Possible | Unhandled runtime exception outside a named error segment | `src/app/error.tsx` | Title: "We ran into an unexpected issue"; Description: "The page could not finish loading. Your account and funds remain safe. Try again now or return home." | Primary: "Back to home" (`href=/`); Secondary: "Try again" |
+| Client component crash (any route) | Possible | Unhandled render throw in a `"use client"` component | Global `ErrorBoundary` (`src/app/layout.tsx`) | Heading: "We hit a temporary app issue."; Body: "Try reloading this view. If the issue keeps happening, return shortly while we investigate." | "Try again" button resets the React error boundary state |
 
 ## Copy tone check
 
 All error pages use `src/components/ui/ErrorPage` and follow the same tone pattern:
 
-1. **What broke** (short, no blame): "Dashboard unavailable", "We ran into an unexpected issue"
-2. **Safety reassurance** (funds / session are unaffected): "Your funds and wallet connection remain safe"
-3. **Recovery action** (try-again and/or a safe navigation target)
+1. **Title** (what broke, short, no blame): "Dashboard unavailable", "We ran into an unexpected issue"
+2. **Description** (context + safety reassurance): "We are having trouble loading this dashboard view right now. Your funds and wallet connection remain safe."
+3. **Recovery actions** (primary navigation and/or try-again): e.g. "Back to dashboard home" (primary) + "Try again" (secondary)
+
+The global `ErrorBoundary` (`src/components/ErrorBoundary.tsx`) renders its own inline
+fallback rather than using `ErrorPage`, but follows the same heading + body pattern.
 
 No error page exposes stack traces, error codes, or internal server details to users.
 The raw `error` prop is accepted but intentionally unused (`error: _error`) in every

--- a/docs/qa/cookie-consent-integration-checklist.md
+++ b/docs/qa/cookie-consent-integration-checklist.md
@@ -9,7 +9,7 @@ This document verifies the end-to-end functionality of the cookie consent flow, 
 
 ## 1. User Accepts Cookies
 - [ ] Observe that the Cookie Banner is visible at the bottom of the screen.
-- [ ] Click **"Accept All"** on the Cookie Banner.
+- [ ] Click **"Accept all"** on the Cookie Banner.
 - [ ] Verify the banner disappears.
 - [ ] Check Local Storage:
   - Key \`nw_cookie_consent\` should exist.
@@ -20,7 +20,7 @@ This document verifies the end-to-end functionality of the cookie consent flow, 
 
 ## 2. User Rejects Cookies
 - [ ] Clear the \`nw_cookie_consent\` key from Local Storage and refresh the page.
-- [ ] Click **"Reject All"** on the Cookie Banner.
+- [ ] Click **"Reject"** on the Cookie Banner.
 - [ ] Verify the banner disappears.
 - [ ] Check Local Storage:
   - Key \`nw_cookie_consent\` should exist.
@@ -41,7 +41,7 @@ This document verifies the end-to-end functionality of the cookie consent flow, 
 ## 4. Custom Preferences
 - [ ] From the Cookie Banner or Settings, click **"Manage preferences"**.
 - [ ] In the Privacy Modal, toggle **Analytics** to "On", leave others "Off".
-- [ ] Click **"Save Preferences"**.
+- [ ] Click **"Save preferences"**.
 - [ ] Check Local Storage:
   - Key \`nw_cookie_consent\` should exist.
   - The value should be a JSON object with \`status: "custom"\`.

--- a/src/app/demo/datetime/page.tsx
+++ b/src/app/demo/datetime/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import DatePicker from "@/components/datetime/DatePicker";
 import TimePicker, { TimeValue } from "@/components/datetime/TimePicker";
 import DateRangePicker from "@/components/datetime/DateRangePicker";
+import { formatDate } from "@/lib/formatters";
 import {
   useDateFilter,
   useDateRangeFilter,
@@ -135,7 +136,7 @@ function PickersTab() {
           <div className="text-sm">
             <p className="text-gray-400">Selected:</p>
             <p className="font-mono">
-              {date ? date.toLocaleDateString("en-US") : "—"}
+              {date ? formatDate(date) : "—"}
             </p>
           </div>
         </div>
@@ -189,7 +190,7 @@ function PickersTab() {
             <p className="text-gray-400">Selected:</p>
             <p className="font-mono">
               {range.start && range.end
-                ? `${range.start.toLocaleDateString("en-US")} &rarr; ${range.end.toLocaleDateString("en-US")}`
+                ? `${formatDate(range.start)} &rarr; ${formatDate(range.end)}`
                 : "—"}
             </p>
           </div>

--- a/src/app/demo/layout.tsx
+++ b/src/app/demo/layout.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation";
+import type { ReactNode } from "react";
+
+const DEMO_ENABLED_IN_PRODUCTION =
+  process.env.NEXT_PUBLIC_ENABLE_DEMO_ROUTES === "true";
+
+const CAN_ACCESS_DEMO =
+  process.env.NODE_ENV !== "production" || DEMO_ENABLED_IN_PRODUCTION;
+
+export default function DemoLayout({ children }: { children: ReactNode }) {
+  if (!CAN_ACCESS_DEMO) {
+    redirect("/dashboard");
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/demo/table/page.tsx
+++ b/src/app/demo/table/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { DataTable, type DataTableColumn } from "@/components/ui/DataTable";
+import { formatDate } from "@/lib/formatters";
 
 interface Holding {
   id: string;
@@ -91,12 +92,7 @@ const columns: DataTableColumn<Holding>[] = [
     accessor: (r) => r.date,
     sortable: true,
     defaultHidden: false,
-    render: (r) =>
-      new Date(r.date).toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-        year: "numeric",
-      }),
+    render: (r) => formatDate(r.date),
   },
 ];
 

--- a/src/lib/routeMetadata.tsx
+++ b/src/lib/routeMetadata.tsx
@@ -175,6 +175,13 @@ const appRouteDefinitions: AppRouteDefinition[] = [
   { href: "/signup", label: "Sign Up", icon: LogIn },
   { href: "/unauthorized", label: "Unauthorized", icon: Shield },
   { href: "/forbidden", label: "Forbidden", icon: Shield },
+  { href: "/demo/avatar", label: "Avatar Demo", icon: UserRound, devOnly: true },
+  { href: "/demo/datetime", label: "Date/Time Demo", icon: Activity, devOnly: true },
+  { href: "/demo/notifications", label: "Notifications Demo", icon: Bell, devOnly: true },
+  { href: "/demo/pagination-filters", label: "Pagination & Filters Demo", icon: SlidersHorizontal, devOnly: true },
+  { href: "/demo/release-checklist", label: "Release Checklist Demo", icon: Newspaper, devOnly: true },
+  { href: "/demo/table", label: "Table Demo", icon: Blocks, devOnly: true },
+  { href: "/demo/wallet", label: "Wallet Demo", icon: Wallet, devOnly: true },
 ];
 
 export const siteNavigationLinks: SiteNavigationLink[] = [


### PR DESCRIPTION
## Summary

Addresses 4 audit follow-up issues (#634, #635, #636, #638) from the 2026-07-25 round-2 audit.

### Changes

1. **Fix error-boundary-matrix.md misquoted user-visible copy** (#638)
   - Replaced em-dash-joined single strings with accurate title/description structure matching the real `ErrorPage` component output
   - Restored missing middle sentences in onboarding, profile, and global error descriptions
   - Updated the "Copy tone check" section to reflect the actual component pattern (title + description + recovery actions)
   - Updated boundary-error row to match the actual `ErrorBoundary` fallback text

2. **Fix cookie-consent-integration-checklist.md button labels** (#636)
   - "Accept All" → "Accept all" (matches `CookieBanner.tsx` line 52)
   - "Reject All" → "Reject" (matches `CookieBanner.tsx` line 46)
   - "Save Preferences" → "Save preferences" (matches `PrivacyModal.tsx` line 80)

3. **Use shared date formatter in demo pages** (#635)
   - Replaced raw `new Date(r.date).toLocaleDateString("en-US", ...)` in `demo/table/page.tsx` with `formatDate()` from `lib/formatters`
   - Replaced 3 raw `toLocaleDateString("en-US")` calls in `demo/datetime/page.tsx` with `formatDate()`
   - This aligns demo pages with the app-wide locale-aware formatting standard documented in README.md

4. **Make /demo/* pages discoverable or remove from build** (#634)
   - Registered all 7 `/demo/*` routes in `routeMetadata.tsx` with `devOnly: true`
   - Created `src/app/demo/layout.tsx` with a production guard that redirects to `/dashboard` (same pattern as the existing sandbox routes)
   - Demo routes are now discoverable via breadcrumbs/nav in dev mode and hidden in production

### Files changed
- `docs/error-boundary-matrix.md`
- `docs/qa/cookie-consent-integration-checklist.md`
- `src/app/demo/table/page.tsx`
- `src/app/demo/datetime/page.tsx`
- `src/lib/routeMetadata.tsx`
- `src/app/demo/layout.tsx` (new)

### Acceptance criteria
- [x] Scope limited to the files listed in each issue
- [x] No behavior regressions — all changes are doc-only or add dev-gating that matches existing patterns
- [x] No new duplicate abstractions

Closes #634
Closes #635
Closes #636
Closes #638