### PR TITLE
fix: resolve audit issues #639, #640, #643, and #644

### DIFF
--- a/src/components/ClientProviders.remount.test.ts
+++ b/src/components/ClientProviders.remount.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Verifies the #640 remount fix used by ClientProviders:
+ * composeProviders() must not run inside a component body, or React treats the
+ * result as a new component type every render and remounts the whole subtree.
+ *
+ * Full ClientProviders mount is skipped here — WalletProvider pulls Albedo which
+ * needs a browser FetchAPI polyfill. These tests cover the exact remount
+ * mechanism ClientProviders had/fixed.
+ */
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createElement,
+  useEffect,
+  type ReactNode,
+} from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { act } from "react";
+
+import { setupDomGlobals } from "@/test-setup";
+import { composeProviders } from "@/lib/composeProviders";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+setupDomGlobals();
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function Passthrough({ children }: { children: ReactNode }) {
+  return createElement("div", { "data-testid": "passthrough" }, children);
+}
+
+function MountProbe({ onMount }: { onMount: () => void }) {
+  useEffect(() => {
+    onMount();
+  }, [onMount]);
+  return createElement("span", { "data-testid": "probe" }, "mounted");
+}
+
+function renderToContainer(ui: ReactNode): {
+  root: Root;
+  container: HTMLDivElement;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+  return { root, container };
+}
+
+function cleanup(root: Root, container: HTMLDivElement) {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+}
+
+test("composing providers inside render remounts children on parent re-render", () => {
+  let mountCount = 0;
+  const onMount = () => {
+    mountCount += 1;
+  };
+
+  function BrokenParent({ tick }: { tick: number }) {
+    // Bug pattern (pre-#640 ClientProviders): new ComposedProviders identity every render
+    const Providers = composeProviders([Passthrough]);
+    return createElement(
+      Providers,
+      null,
+      createElement(MountProbe, { onMount }),
+      createElement("span", null, String(tick)),
+    );
+  }
+
+  const { root, container } = renderToContainer(
+    createElement(BrokenParent, { tick: 0 }),
+  );
+  assert.equal(mountCount, 1);
+
+  act(() => {
+    root.render(createElement(BrokenParent, { tick: 1 }));
+  });
+  assert.equal(
+    mountCount,
+    2,
+    "unstable composeProviders identity must remount children",
+  );
+
+  cleanup(root, container);
+});
+
+test("module-scoped composeProviders keeps children mounted across parent re-renders", () => {
+  let mountCount = 0;
+  const onMount = () => {
+    mountCount += 1;
+  };
+
+  // Fix pattern used by ClientProviders: stable identity at module scope
+  const Providers = composeProviders([Passthrough]);
+
+  function StableParent({ tick }: { tick: number }) {
+    return createElement(
+      Providers,
+      null,
+      createElement(MountProbe, { onMount }),
+      createElement("span", null, String(tick)),
+    );
+  }
+
+  const { root, container } = renderToContainer(
+    createElement(StableParent, { tick: 0 }),
+  );
+  assert.equal(mountCount, 1);
+
+  act(() => {
+    root.render(createElement(StableParent, { tick: 1 }));
+  });
+  act(() => {
+    root.render(createElement(StableParent, { tick: 2 }));
+  });
+  assert.equal(
+    mountCount,
+    1,
+    "stable composeProviders identity must not remount children",
+  );
+
+  cleanup(root, container);
+});
+
+test("ClientProviders hoists composeProviders and resolveStellarConfig to module scope", () => {
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const source = readFileSync(join(dir, "ClientProviders.tsx"), "utf8");
+
+  const componentBody = source.slice(
+    source.indexOf("export function ClientProviders"),
+  );
+
+  assert.match(
+    source,
+    /const stellarConfig = resolveStellarConfig\(\)/,
+    "resolveStellarConfig must be called once at module scope",
+  );
+  assert.match(
+    source,
+    /const Providers = composeProviders\(\[/,
+    "composeProviders must be called once at module scope",
+  );
+  assert.doesNotMatch(
+    componentBody,
+    /composeProviders\(/,
+    "ClientProviders body must not call composeProviders",
+  );
+  assert.doesNotMatch(
+    componentBody,
+    /resolveStellarConfig\(/,
+    "ClientProviders body must not call resolveStellarConfig",
+  );
+});

--- a/src/components/ClientProviders.tsx
+++ b/src/components/ClientProviders.tsx
@@ -31,19 +31,22 @@ function resolveStellarConfig() {
   };
 }
 
+// Hoisted to module scope so provider component identity stays stable across
+// ClientProviders re-renders. Calling composeProviders() inside the component
+// body created a new component type every render and remounted the whole tree.
+const stellarConfig = resolveStellarConfig();
+
+const Providers = composeProviders([
+  SandboxProvider,
+  ThemeProvider,
+  I18nProvider,
+  AuthProvider,
+  [WalletProvider, { network: stellarConfig.network, horizonUrl: stellarConfig.horizonUrl }],
+  ToastProvider,
+  CookieConsentProvider,
+]);
+
 export function ClientProviders({ children }: { children: ReactNode }) {
-  const { network, horizonUrl } = resolveStellarConfig();
-
-  const Providers = composeProviders([
-    SandboxProvider,
-    ThemeProvider,
-    I18nProvider,
-    AuthProvider,
-    [WalletProvider, { network, horizonUrl }],
-    ToastProvider,
-    CookieConsentProvider,
-  ]);
-
   return (
     <Providers>
       <ErrorTrackingMount />

--- a/src/components/transactions/TransactionFlow.tsx
+++ b/src/components/transactions/TransactionFlow.tsx
@@ -4,101 +4,42 @@ import { startTransition, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import styles from "./transaction-flow.module.css";
-import { formatCurrency, formatTimestamp } from "@/lib/formatters";
+import { formatCurrency } from "@/lib/formatters";
 import {
   buildPreviewSnapshot,
   buildStatusChips,
   buildTransactionReceipt,
-  getDefaultTransactionValues,
   getTransactionContext,
   parsePreviewState,
   parseTransactionKind,
   PendingTransaction,
-  TransactionFieldErrors,
-  TransactionFormValues,
   TransactionKind,
   TransactionPreviewState,
   TransactionQuote,
   TransactionReceipt,
-  validateTransactionValues,
-  getTransactionRecoveryUI,
   type RecoveryAction,
-  type TransactionRecoveryUI,
 } from "@/lib/transactions";
-import { ApiRequestError, apiRequest } from "@/lib/api-client";
 import { useSandbox } from "@/contexts/SandboxContext";
 import { TransactionErrorRecovery } from "./TransactionErrorRecovery";
+import { TransactionFormStage } from "./stages/TransactionFormStage";
+import { TransactionConfirmStage } from "./stages/TransactionConfirmStage";
+import { TransactionPendingStage } from "./stages/TransactionPendingStage";
+import { TransactionReceiptStage } from "./stages/TransactionReceiptStage";
+import { useTransactionForm } from "./hooks/useTransactionForm";
+import { useTransactionAPI } from "./hooks/useTransactionAPI";
+import {
+  currentStepIndex,
+  getTheme,
+} from "./utils/transaction-utils";
+import { getToneClassName } from "./utils/transaction-style-utils";
 
 type ThemeMode = "light" | "dark";
-
-function getTheme(searchParams: Pick<URLSearchParams, "get">): ThemeMode {
-  return searchParams.get("theme") === "dark" ? "dark" : "light";
-}
-
-function getToneClassName(tone: "error" | "success" | "warning"): string {
-  if (tone === "error") {
-    return styles.statusError;
-  }
-
-  if (tone === "warning") {
-    return styles.statusWarning;
-  }
-
-  return styles.statusSuccess;
-}
-
-function getInputStateClassName(
-  value: string,
-  error?: string,
-  isValidated?: boolean,
-): string {
-  if (error) {
-    return styles.inputError;
-  }
-
-  if (isValidated && value) {
-    return styles.inputSuccess;
-  }
-
-  return "";
-}
-
-function sanitizeAmount(value: string): string {
-  return value.replace(/[^\d.]/g, "");
-}
-
-function detailsToFieldErrors(
-  details?: Record<string, string | string[]>,
-): TransactionFieldErrors {
-  if (!details) {
-    return {};
-  }
-
-  const readValue = (key: string): string | undefined => {
-    const value = details[key];
-
-    if (Array.isArray(value)) {
-      return value[0];
-    }
-
-    return typeof value === "string" ? value : undefined;
-  };
-
-  return {
-    amount: readValue("amount") ?? readValue("values.amount"),
-    walletAddress: readValue("walletAddress") ?? readValue("values.walletAddress"),
-    walletConnected:
-      readValue("walletConnected") ?? readValue("values.walletConnected"),
-    form: readValue("form") ?? readValue("body"),
-  };
-}
 
 export function TransactionFlow() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { getCurrentScenario, isSandboxMode } = useSandbox();
   const timeoutRef = useRef<number | null>(null);
-  const requestControllerRef = useRef<AbortController | null>(null);
 
   const [theme, setTheme] = useState<ThemeMode>(() => getTheme(searchParams));
   const [kind, setKind] = useState<TransactionKind>(() =>
@@ -110,18 +51,35 @@ export function TransactionFlow() {
   const [stage, setStage] = useState<
     "form" | "confirm" | "pending" | "success" | "failure" | "error"
   >("form");
-  const [formValues, setFormValues] = useState<TransactionFormValues>(() =>
-    getDefaultTransactionValues(kind),
-  );
-  const [fieldErrors, setFieldErrors] = useState<TransactionFieldErrors>({});
   const [quote, setQuote] = useState<TransactionQuote | null>(null);
   const [pending, setPending] = useState<PendingTransaction | null>(null);
   const [receipt, setReceipt] = useState<TransactionReceipt | null>(null);
   const [requestMessage, setRequestMessage] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [recovery, setRecovery] = useState<TransactionRecoveryUI | null>(null);
-  const [lastErrorReference, setLastErrorReference] = useState<string | null>(null);
-  const [lastFailedAction, setLastFailedAction] = useState<"review" | "confirm" | null>(null);
+  const [lastFailedAction, setLastFailedAction] = useState<
+    "review" | "confirm" | null
+  >(null);
+
+  const {
+    formValues,
+    fieldErrors,
+    updateField,
+    validate,
+    reset: resetForm,
+    setErrors,
+    setValues,
+  } = useTransactionForm(kind);
+
+  const {
+    isSubmitting,
+    recovery,
+    lastErrorReference,
+    requestQuote,
+    submitTransaction,
+    clearRecovery,
+    setSubmitting,
+    cancelRequest,
+    reset: resetApi,
+  } = useTransactionAPI();
 
   const context = getTransactionContext(kind);
   const statusChips = buildStatusChips(kind, formValues);
@@ -133,69 +91,77 @@ export function TransactionFlow() {
       timeoutRef.current = null;
     }
 
-    const snapshot = buildPreviewSnapshot(kind, preview);
+    cancelRequest();
 
     if (preview === "interactive") {
       setStage("form");
-      setFormValues(getDefaultTransactionValues(kind));
-      setFieldErrors({});
+      resetForm();
       setQuote(null);
       setPending(null);
       setReceipt(null);
       setRequestMessage(null);
-      setIsSubmitting(false);
-      setRecovery(null);
-      setLastErrorReference(null);
+      resetApi();
       setLastFailedAction(null);
       return;
     }
 
+    const snapshot = buildPreviewSnapshot(kind, preview);
+
     setStage(snapshot.stage);
-    setFormValues(snapshot.form);
-    setFieldErrors(snapshot.fieldErrors);
+    setValues(snapshot.form);
+    setErrors(snapshot.fieldErrors);
     setQuote(snapshot.quote);
     setPending(snapshot.pending);
     setReceipt(snapshot.receipt);
     setRequestMessage(null);
-    setIsSubmitting(false);
-    setRecovery(null);
-    setLastErrorReference(null);
+    resetApi();
     setLastFailedAction(null);
-  }, [kind, preview]);
+  }, [
+    kind,
+    preview,
+    cancelRequest,
+    resetForm,
+    resetApi,
+    setValues,
+    setErrors,
+  ]);
 
   // Handle sandbox scenarios
   useEffect(() => {
     if (isSandboxMode && scenario !== "success") {
       if (scenario === "loading") {
-        setIsSubmitting(true);
+        setSubmitting(true);
         setRequestMessage("Loading transaction data...");
         const timer = setTimeout(() => {
-          setIsSubmitting(false);
+          setSubmitting(false);
           setRequestMessage(null);
         }, 3000);
         return () => clearTimeout(timer);
       } else if (scenario === "timeout") {
-        setIsSubmitting(true);
+        setSubmitting(true);
         setRequestMessage("Request timed out. Please try again.");
         const timer = setTimeout(() => {
-          setIsSubmitting(false);
-          setRequestMessage("Connection timeout. Please check your network and retry.");
+          setSubmitting(false);
+          setRequestMessage(
+            "Connection timeout. Please check your network and retry.",
+          );
         }, 5000);
         return () => clearTimeout(timer);
       } else if (scenario === "partial-failure") {
-        setRequestMessage("Partial service degradation. Some features may be unavailable.");
+        setRequestMessage(
+          "Partial service degradation. Some features may be unavailable.",
+        );
         setStage("form");
       } else if (scenario === "empty") {
         setStage("form");
-        setFormValues(getDefaultTransactionValues(kind));
-        setFieldErrors({});
+        resetForm();
         setQuote(null);
         setPending(null);
         setReceipt(null);
         setRequestMessage("No transaction data available.");
       }
     }
-  }, [scenario, isSandboxMode, kind]);
+  }, [scenario, isSandboxMode, kind, setSubmitting, resetForm]);
 
   useEffect(() => {
     return () => {
@@ -203,27 +169,11 @@ export function TransactionFlow() {
         window.clearTimeout(timeoutRef.current);
         timeoutRef.current = null;
       }
-      if (requestControllerRef.current) {
-        requestControllerRef.current.abort();
-        requestControllerRef.current = null;
-      }
-      // Clean up all state on unmount to prevent memory leaks
-      // This ensures pending states and timers are cleared when component is destroyed
+      // Abort any in-flight request on unmount to prevent state updates on an
+      // unmounted component and to avoid leaking the pending completion timer.
+      cancelRequest();
     };
-  }, []);
-
-  function beginApiRequest() {
-    requestControllerRef.current?.abort();
-    const controller = new AbortController();
-    requestControllerRef.current = controller;
-    return controller;
-  }
-
-  function endApiRequest(controller: AbortController) {
-    if (requestControllerRef.current === controller) {
-      requestControllerRef.current = null;
-    }
-  }
+  }, [cancelRequest]);
 
   function syncRoute(
     nextTheme: ThemeMode,
@@ -262,22 +212,6 @@ export function TransactionFlow() {
     syncRoute(theme, kind, nextPreview);
   }
 
-  function updateField<K extends keyof TransactionFormValues>(
-    field: K,
-    value: TransactionFormValues[K],
-  ) {
-    setFormValues((current) => ({
-      ...current,
-      [field]: value,
-    }));
-
-    setFieldErrors((current) => ({
-      ...current,
-      [field]: undefined,
-      form: undefined,
-    }));
-  }
-
   function handleMaxAmount() {
     updateField("amount", context.availableAmount.toFixed(2));
   }
@@ -287,67 +221,31 @@ export function TransactionFlow() {
       return;
     }
 
-    const localErrors = validateTransactionValues(kind, formValues);
-
-    if (Object.keys(localErrors).length > 0) {
-      setFieldErrors(localErrors);
+    if (!validate()) {
       return;
     }
 
-    setIsSubmitting(true);
     setRequestMessage(null);
-    setRecovery(null);
+    clearRecovery();
     setLastFailedAction(null);
 
-    const controller = beginApiRequest();
+    const result = await requestQuote(kind, formValues, quote?.reference);
 
-    try {
-      const payload = await apiRequest<{ quote: TransactionQuote }>(
-        "/api/transactions",
-        {
-          method: "POST",
-          body: {
-            intent: "quote",
-            kind,
-            values: formValues,
-          },
-          timeoutMs: 12000,
-          signal: controller.signal,
-        },
-      );
-
-      setFieldErrors({});
-      setQuote(payload.quote);
-      setStage("confirm");
-      setRecovery(null);
-      setLastFailedAction(null);
-    } catch (error) {
-      if (controller.signal.aborted) {
-        return;
-      }
-
-      setLastFailedAction("review");
-
-      if (error instanceof ApiRequestError) {
-        // Map API error code to recovery UI with actionable copy
-        const recoveryUI = getTransactionRecoveryUI(error.code, quote?.reference);
-        setRecovery(recoveryUI);
-        setLastErrorReference(quote?.reference || null);
-        setFieldErrors(detailsToFieldErrors(error.details));
-        setStage("error");
-        return;
-      }
-
-      // Handle unexpected errors by mapping to unknown error mode
-      const recoveryUI = getTransactionRecoveryUI("unknown_error");
-      setRecovery(recoveryUI);
-      setStage("error");
-    } finally {
-      endApiRequest(controller);
-      if (!controller.signal.aborted) {
-        setIsSubmitting(false);
-      }
+    if (result.status === "aborted") {
+      return;
     }
+
+    if (result.status === "success") {
+      setErrors({});
+      setQuote(result.quote);
+      setStage("confirm");
+      setLastFailedAction(null);
+      return;
+    }
+
+    setLastFailedAction("review");
+    setErrors(result.fieldErrors);
+    setStage("error");
   }
 
   async function handleReview(event: React.FormEvent<HTMLFormElement>) {
@@ -360,76 +258,38 @@ export function TransactionFlow() {
       return;
     }
 
-    setIsSubmitting(true);
     setRequestMessage(null);
-    setRecovery(null);
+    clearRecovery();
     setLastFailedAction(null);
 
-    const controller = beginApiRequest();
+    const result = await submitTransaction(kind, formValues, quote?.reference);
 
-    try {
-      const payload = await apiRequest<{ pending: PendingTransaction }>(
-        "/api/transactions",
-        {
-          method: "POST",
-          body: {
-            intent: "submit",
-            kind,
-            values: formValues,
-          },
-          timeoutMs: 12000,
-          signal: controller.signal,
-        },
-      );
+    if (result.status === "aborted") {
+      return;
+    }
 
-      setPending(payload.pending);
-      setQuote(payload.pending.quote);
+    if (result.status === "success") {
+      setPending(result.pending);
+      setQuote(result.pending.quote);
       setStage("pending");
-      setLastErrorReference(payload.pending.reference);
       setLastFailedAction(null);
 
       timeoutRef.current = window.setTimeout(() => {
         const nextReceipt = buildTransactionReceipt(
-          payload.pending,
-          payload.pending.nextStatus === "failure"
-            ? "failure"
-            : "success",
+          result.pending,
+          result.pending.nextStatus === "failure" ? "failure" : "success",
         );
 
         setReceipt(nextReceipt);
         setStage(nextReceipt.status);
-        setIsSubmitting(false);
-      }, payload.pending.completionDelayMs);
-    } catch (error) {
-      if (controller.signal.aborted) {
-        return;
-      }
-
-      setLastFailedAction("confirm");
-
-      if (error instanceof ApiRequestError) {
-        // Map API error code to recovery UI with actionable copy and transaction reference
-        const recoveryUI = getTransactionRecoveryUI(
-          error.code,
-          quote?.reference,
-        );
-        setRecovery(recoveryUI);
-        setLastErrorReference(quote?.reference || null);
-        setFieldErrors(detailsToFieldErrors(error.details));
-        setStage("error");
-      } else {
-        // Handle unexpected errors by mapping to unknown error mode
-        const recoveryUI = getTransactionRecoveryUI("unknown_error", quote?.reference);
-        setRecovery(recoveryUI);
-        setLastErrorReference(quote?.reference || null);
-        setStage("error");
-      }
-    } finally {
-      endApiRequest(controller);
-      if (!controller.signal.aborted) {
-        setIsSubmitting(false);
-      }
+        setSubmitting(false);
+      }, result.pending.completionDelayMs);
+      return;
     }
+
+    setLastFailedAction("confirm");
+    setErrors(result.fieldErrors);
+    setStage("error");
   }
 
   function resetFlow() {
@@ -444,7 +304,7 @@ export function TransactionFlow() {
     switch (action) {
       case "retry": {
         // Clear error state and retry the failed operation with the saved values.
-        setRecovery(null);
+        clearRecovery();
         setRequestMessage("Retrying request...");
         if (lastFailedAction === "confirm" && quote) {
           void handleConfirm();
@@ -456,8 +316,8 @@ export function TransactionFlow() {
       case "edit": {
         // Return to form so user can review and edit amount or wallet details
         setStage("form");
-        setRecovery(null);
-        setIsSubmitting(false);
+        clearRecovery();
+        setSubmitting(false);
         setLastFailedAction(null);
         break;
       }
@@ -475,38 +335,6 @@ export function TransactionFlow() {
       }
     }
   }
-
-  function currentStepIndex(): number {
-    if (stage === "form" || stage === "error") {
-      return 0;
-    }
-
-    if (stage === "confirm") {
-      return 1;
-    }
-
-    return 2;
-  }
-
-  const amountInputClassName = [
-    styles.input,
-    getInputStateClassName(
-      formValues.amount,
-      fieldErrors.amount,
-      Boolean(formValues.amount) && !fieldErrors.amount,
-    ),
-  ].join(" ");
-
-  const walletInputClassName = [
-    styles.input,
-    getInputStateClassName(
-      formValues.walletAddress,
-      fieldErrors.walletAddress,
-      kind === "withdrawal" &&
-        Boolean(formValues.walletAddress) &&
-        !fieldErrors.walletAddress,
-    ),
-  ].join(" ");
 
   return (
     <div className={styles.page}>
@@ -626,7 +454,7 @@ export function TransactionFlow() {
                   <div
                     className={[
                       styles.step,
-                      currentStepIndex() === index ? styles.stepActive : "",
+                      currentStepIndex(stage) === index ? styles.stepActive : "",
                     ].join(" ")}
                     key={step.label}
                   >
@@ -637,341 +465,30 @@ export function TransactionFlow() {
               </div>
 
               {stage === "form" ? (
-                <form className={styles.form} onSubmit={handleReview}>
-                  <div className={styles.fieldGroup}>
-                    <div className={styles.labelRow}>
-                      <label className={styles.fieldLabel} htmlFor="amount">
-                        {context.amountLabel}
-                      </label>
-                      <span className={styles.fieldHint}>
-                        Available {formatCurrency(context.availableAmount)}
-                      </span>
-                    </div>
-
-                    <div className={styles.amountRow}>
-                      <input
-                        className={amountInputClassName}
-                        id="amount"
-                        inputMode="decimal"
-                        onChange={(event) =>
-                          updateField(
-                            "amount",
-                            sanitizeAmount(event.target.value),
-                          )
-                        }
-                        placeholder="0.00"
-                        value={formValues.amount}
-                      />
-                      <button
-                        className={styles.inlineButton}
-                        onClick={handleMaxAmount}
-                        type="button"
-                      >
-                        Max
-                      </button>
-                    </div>
-
-                    <p className={styles.supportingCopy}>
-                      {context.amountHint}
-                    </p>
-                    {fieldErrors.amount ? (
-                      <p
-                        className={`${styles.fieldMessage} ${styles.errorMessage}`}
-                      >
-                        {fieldErrors.amount}
-                      </p>
-                    ) : formValues.amount ? (
-                      <p
-                        className={`${styles.fieldMessage} ${styles.successMessage}`}
-                      >
-                        Amount looks valid for the next confirmation step.
-                      </p>
-                    ) : null}
-                  </div>
-
-                  <div className={styles.fieldGroup}>
-                    <div className={styles.labelRow}>
-                      <label className={styles.fieldLabel} htmlFor="wallet">
-                        {context.walletLabel}
-                      </label>
-                      <span className={styles.fieldHint}>
-                        {context.reviewLabel}
-                      </span>
-                    </div>
-
-                    {kind === "deposit" ? (
-                      <>
-                        <div className={styles.walletDisplay}>
-                          <div>
-                            <div className={styles.fieldLabel}>
-                              {context.connectedWalletLabel}
-                            </div>
-                            <div className={styles.walletAddress}>
-                              {context.connectedWalletAddress}
-                            </div>
-                          </div>
-                          <button
-                            className={styles.walletToggle}
-                            onClick={() =>
-                              updateField(
-                                "walletConnected",
-                                !formValues.walletConnected,
-                              )
-                            }
-                            type="button"
-                          >
-                            {formValues.walletConnected
-                              ? "Disconnect"
-                              : "Reconnect"}
-                          </button>
-                        </div>
-                        <p className={styles.supportingCopy}>
-                          {context.walletHint}
-                        </p>
-                        {fieldErrors.walletConnected ? (
-                          <p
-                            className={`${styles.fieldMessage} ${styles.errorMessage}`}
-                          >
-                            {fieldErrors.walletConnected}
-                          </p>
-                        ) : (
-                          <p
-                            className={`${styles.fieldMessage} ${styles.successMessage}`}
-                          >
-                            Deposit uses the connected funding wallet shown
-                            above.
-                          </p>
-                        )}
-                      </>
-                    ) : (
-                      <>
-                        <input
-                          className={walletInputClassName}
-                          id="wallet"
-                          onChange={(event) =>
-                            updateField(
-                              "walletAddress",
-                              event.target.value.toUpperCase().trim(),
-                            )
-                          }
-                          placeholder="G..."
-                          value={formValues.walletAddress}
-                        />
-                        <div className={styles.connectRow}>
-                          <button
-                            className={styles.walletToggle}
-                            onClick={() =>
-                              updateField(
-                                "walletConnected",
-                                !formValues.walletConnected,
-                              )
-                            }
-                            type="button"
-                          >
-                            {formValues.walletConnected
-                              ? "Disconnect vault"
-                              : "Reconnect vault"}
-                          </button>
-                          <span className={styles.fieldHint}>
-                            {context.walletHint}
-                          </span>
-                        </div>
-                        {fieldErrors.walletAddress ? (
-                          <p
-                            className={`${styles.fieldMessage} ${styles.errorMessage}`}
-                          >
-                            {fieldErrors.walletAddress}
-                          </p>
-                        ) : (
-                          <p
-                            className={`${styles.fieldMessage} ${styles.successMessage}`}
-                          >
-                            Destination address passes the Stellar public key
-                            format check.
-                          </p>
-                        )}
-                        {fieldErrors.walletConnected ? (
-                          <p
-                            className={`${styles.fieldMessage} ${styles.errorMessage}`}
-                          >
-                            {fieldErrors.walletConnected}
-                          </p>
-                        ) : null}
-                      </>
-                    )}
-                  </div>
-
-                  {requestMessage ? (
-                    <p
-                      className={`${styles.fieldMessage} ${styles.warningMessage}`}
-                    >
-                      {requestMessage}
-                    </p>
-                  ) : null}
-
-                  <div className={styles.actionBar}>
-                    <div className={styles.actionMeta}>
-                      Primary action stays anchored at the bottom on mobile for
-                      longer forms.
-                    </div>
-                    <div className={styles.actionButtons}>
-                      <button
-                        className={`${styles.button} ${styles.buttonPrimary}`}
-                        disabled={isSubmitting}
-                        type="submit"
-                        data-qa="transaction-review-button"
-                      >
-                        {isSubmitting
-                          ? "Preparing..."
-                          : context.primaryActionLabel}
-                      </button>
-                    </div>
-                  </div>
-                </form>
+                <TransactionFormStage
+                  kind={kind}
+                  formValues={formValues}
+                  fieldErrors={fieldErrors}
+                  isSubmitting={isSubmitting}
+                  requestMessage={requestMessage}
+                  onFieldChange={updateField}
+                  onMaxAmount={handleMaxAmount}
+                  onSubmit={handleReview}
+                />
               ) : null}
 
               {stage === "confirm" && quote ? (
-                <div className={styles.form}>
-                  <div className={styles.summaryCard}>
-                    <p className={styles.heroAmount}>
-                      {formatCurrency(quote.amount)}
-                    </p>
-                    <p className={styles.heroSubtext}>
-                      {kind === "deposit"
-                        ? "Deposit amount"
-                        : "Withdrawal amount"}
-                    </p>
-                  </div>
-
-                  <div className={styles.detailList}>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>Amount</span>
-                      <span
-                        className={`${styles.detailValue} ${styles.detailValueMono}`}
-                      >
-                        {formatCurrency(quote.amount)}
-                      </span>
-                    </div>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>Fees</span>
-                      <span
-                        className={`${styles.detailValue} ${styles.detailValueMono}`}
-                      >
-                        {formatCurrency(quote.fee)}
-                      </span>
-                    </div>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>
-                        {kind === "deposit"
-                          ? "Total debit"
-                          : "Net destination amount"}
-                      </span>
-                      <span
-                        className={`${styles.detailValue} ${styles.detailValueMono}`}
-                      >
-                        {formatCurrency(
-                          kind === "deposit"
-                            ? quote.totalDebit
-                            : quote.netAmount,
-                        )}
-                      </span>
-                    </div>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>Strategy</span>
-                      <span className={styles.detailValue}>
-                        {quote.strategyLabel}
-                      </span>
-                    </div>
-                  </div>
-
-                  <div className={styles.referenceCard}>
-                    <p className={styles.referenceLabel}>
-                      Transaction reference
-                    </p>
-                    <p className={styles.referenceValue}>{quote.reference}</p>
-                    <p className={styles.supportingCopy}>
-                      Share this reference with support if you need help tracing
-                      the request.
-                    </p>
-                  </div>
-
-                  <div className={styles.actionBar}>
-                    <div className={styles.actionMeta}>
-                      Confirm after reviewing amount, fees, and reference.
-                    </div>
-                    <div className={styles.actionButtons}>
-                      <button
-                        className={`${styles.button} ${styles.buttonSecondary}`}
-                        onClick={() => setStage("form")}
-                        type="button"
-                      >
-                        Back
-                      </button>
-                      <button
-                        className={`${styles.button} ${styles.buttonPrimary}`}
-                        onClick={handleConfirm}
-                        type="button"
-                        data-qa="transaction-submit-button"
-                      >
-                        {context.confirmActionLabel}
-                      </button>
-                    </div>
-                  </div>
-                </div>
+                <TransactionConfirmStage
+                  kind={kind}
+                  quote={quote}
+                  isSubmitting={isSubmitting}
+                  onBack={() => setStage("form")}
+                  onConfirm={handleConfirm}
+                />
               ) : null}
 
               {stage === "pending" && pending ? (
-                <div className={`${styles.pendingCard} ${styles.form}`}>
-                  <div className={styles.pendingLayout}>
-                    <div className={styles.pendingSpinner} />
-                    <div className={styles.sectionHeading}>
-                      <h3 className={styles.sectionTitle}>
-                        {pending.statusLabel}
-                      </h3>
-                      <p className={styles.sectionCopy}>{pending.message}</p>
-                    </div>
-                  </div>
-
-                  <div className={styles.referenceCard}>
-                    <p className={styles.referenceLabel}>
-                      Transaction reference
-                    </p>
-                    <p className={styles.referenceValue}>{pending.reference}</p>
-                    <p className={styles.supportingCopy}>
-                      Keep this reference visible while the transaction is
-                      moving through the network.
-                    </p>
-                  </div>
-
-                  <div className={styles.detailList}>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>
-                        Requested amount
-                      </span>
-                      <span
-                        className={`${styles.detailValue} ${styles.detailValueMono}`}
-                      >
-                        {formatCurrency(pending.quote.amount)}
-                      </span>
-                    </div>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>Fees</span>
-                      <span
-                        className={`${styles.detailValue} ${styles.detailValueMono}`}
-                      >
-                        {formatCurrency(pending.quote.fee)}
-                      </span>
-                    </div>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>
-                        Settlement target
-                      </span>
-                      <span className={styles.detailValue}>
-                        {pending.quote.estimatedSettlement}
-                      </span>
-                    </div>
-                  </div>
-                </div>
+                <TransactionPendingStage pending={pending} />
               ) : null}
 
               {stage === "error" && recovery ? (
@@ -983,110 +500,16 @@ export function TransactionFlow() {
               ) : null}
 
               {(stage === "success" || stage === "failure") && receipt ? (
-                <div className={`${styles.receiptCard} ${styles.form}`}>
-                  <div className={styles.receiptBanner}>
-                    <span
-                      className={`${styles.statusChip} ${
-                        receipt.status === "success"
-                          ? styles.statusSuccess
-                          : styles.statusError
-                      }`}
-                    >
-                      {receipt.status === "success" ? "Success" : "Failed"}
-                    </span>
-                    <h3 className={styles.receiptTitle}>{receipt.message}</h3>
-                    {receipt.failureReason ? (
-                      <p
-                        className={`${styles.fieldMessage} ${styles.errorMessage}`}
-                      >
-                        {receipt.failureReason}
-                      </p>
-                    ) : (
-                      <p
-                        className={`${styles.fieldMessage} ${styles.successMessage}`}
-                      >
-                        Receipt includes the amount, fees, and reference for
-                        follow-up.
-                      </p>
-                    )}
-                  </div>
-
-                  <div className={styles.referenceCard}>
-                    <p className={styles.referenceLabel}>
-                      Transaction reference
-                    </p>
-                    <p className={styles.referenceValue}>{receipt.reference}</p>
-                    <p className={styles.supportingCopy}>
-                      {receipt.explorerLabel ??
-                        "Retry after reviewing the validation state and updated quote."}
-                    </p>
-                  </div>
-
-                  <div className={styles.detailList}>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>Amount</span>
-                      <span
-                        className={`${styles.detailValue} ${styles.detailValueMono}`}
-                      >
-                        {formatCurrency(receipt.quote.amount)}
-                      </span>
-                    </div>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>Fees</span>
-                      <span
-                        className={`${styles.detailValue} ${styles.detailValueMono}`}
-                      >
-                        {formatCurrency(receipt.quote.fee)}
-                      </span>
-                    </div>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>
-                        {kind === "deposit"
-                          ? "Credited amount"
-                          : "Destination amount"}
-                      </span>
-                      <span
-                        className={`${styles.detailValue} ${styles.detailValueMono}`}
-                      >
-                        {formatCurrency(receipt.quote.netAmount)}
-                      </span>
-                    </div>
-                    <div className={styles.detailRow}>
-                      <span className={styles.detailLabel}>Settled at</span>
-                      <span className={styles.detailValue}>
-                        {formatTimestamp(receipt.settledAt)}
-                      </span>
-                    </div>
-                  </div>
-
-                  <div className={styles.actionBar}>
-                    <div className={styles.actionMeta}>
-                      {receipt.status === "success"
-                        ? "Start a new transaction or switch flows."
-                        : "Retry after reviewing the updated validation details."}
-                    </div>
-                    <div className={styles.actionButtons}>
-                      <button
-                        className={`${styles.button} ${styles.buttonSecondary}`}
-                        onClick={resetFlow}
-                        type="button"
-                      >
-                        New transaction
-                      </button>
-                      <button
-                        className={`${styles.button} ${styles.buttonPrimary}`}
-                        onClick={() =>
-                          handleKindChange(
-                            kind === "deposit" ? "withdrawal" : "deposit",
-                          )
-                        }
-                        type="button"
-                      >
-                        Switch flow
-                      </button>
-                    </div>
-                  </div>
-                </div>
+                <TransactionReceiptStage
+                  kind={kind}
+                  receipt={receipt}
+                  onNewTransaction={resetFlow}
+                  onSwitchFlow={() =>
+                    handleKindChange(
+                      kind === "deposit" ? "withdrawal" : "deposit",
+                    )
+                  }
+                />
               ) : null}
             </section>
 

--- a/src/components/transactions/hooks/useTransactionAPI.test.ts
+++ b/src/components/transactions/hooks/useTransactionAPI.test.ts
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { renderHook, act } from "@/test-utils/render-hook";
+import { useTransactionAPI } from "./useTransactionAPI";
+
+const originalFetch = globalThis.fetch;
+
+test.afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function mockErrorResponse(details: Record<string, string | string[]>) {
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        success: false,
+        error: {
+          code: "VALIDATION_FAILED",
+          message: "Invalid payload",
+          details,
+        },
+      }),
+      {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+}
+
+function mockSuccessQuote() {
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        success: true,
+        data: {
+          quote: {
+            kind: "deposit",
+            amount: 100,
+            fee: 1,
+            totalDebit: 101,
+            netAmount: 100,
+            strategyLabel: "Balanced",
+            estimatedSettlement: "Instant",
+            reference: "NW-DEP-TEST",
+          },
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+}
+
+test("requestQuote returns fieldErrors from API details instead of discarding them", async () => {
+  mockErrorResponse({
+    amount: ["Amount exceeds available balance"],
+    "values.walletConnected": "Connect a funding wallet",
+  });
+
+  const { result } = renderHook(() => useTransactionAPI());
+
+  let quoteResult: Awaited<ReturnType<typeof result.current.requestQuote>> | undefined;
+
+  await act(async () => {
+    quoteResult = await result.current.requestQuote("deposit", {
+      amount: "999999",
+      walletAddress: "",
+      walletConnected: false,
+    });
+  });
+
+  assert.equal(quoteResult?.status, "error");
+  if (quoteResult?.status !== "error") {
+    throw new Error("Expected error result");
+  }
+
+  assert.equal(quoteResult.fieldErrors.amount, "Amount exceeds available balance");
+  assert.equal(quoteResult.fieldErrors.walletConnected, "Connect a funding wallet");
+  assert.equal(result.current.isSubmitting, false);
+  assert.ok(result.current.recovery);
+});
+
+test("submitTransaction returns fieldErrors from API details instead of discarding them", async () => {
+  mockErrorResponse({
+    "values.walletAddress": "Use a valid Stellar public address",
+  });
+
+  const { result } = renderHook(() => useTransactionAPI());
+
+  let submitResult:
+    | Awaited<ReturnType<typeof result.current.submitTransaction>>
+    | undefined;
+
+  await act(async () => {
+    submitResult = await result.current.submitTransaction(
+      "withdrawal",
+      {
+        amount: "100",
+        walletAddress: "BAD",
+        walletConnected: true,
+      },
+      "NW-WDR-REF",
+    );
+  });
+
+  assert.equal(submitResult?.status, "error");
+  if (submitResult?.status !== "error") {
+    throw new Error("Expected error result");
+  }
+
+  assert.equal(
+    submitResult.fieldErrors.walletAddress,
+    "Use a valid Stellar public address",
+  );
+  assert.equal(result.current.lastErrorReference, "NW-WDR-REF");
+  assert.ok(result.current.recovery);
+});
+
+test("requestQuote returns the quote on success", async () => {
+  mockSuccessQuote();
+
+  const { result } = renderHook(() => useTransactionAPI());
+
+  let quoteResult: Awaited<ReturnType<typeof result.current.requestQuote>> | undefined;
+
+  await act(async () => {
+    quoteResult = await result.current.requestQuote("deposit", {
+      amount: "100",
+      walletAddress: "",
+      walletConnected: true,
+    });
+  });
+
+  assert.equal(quoteResult?.status, "success");
+  if (quoteResult?.status !== "success") {
+    throw new Error("Expected success result");
+  }
+
+  assert.equal(quoteResult.quote.reference, "NW-DEP-TEST");
+  assert.equal(result.current.isSubmitting, false);
+  assert.equal(result.current.recovery, null);
+});

--- a/src/components/transactions/hooks/useTransactionAPI.ts
+++ b/src/components/transactions/hooks/useTransactionAPI.ts
@@ -2,11 +2,15 @@
  * useTransactionAPI.ts
  *
  * Custom hook for transaction API operations.
- * Handles quote requests, submissions, and error mapping.
+ * Handles quote requests, submissions, error mapping, and in-flight request
+ * cancellation. Results are returned as discriminated unions so callers can act
+ * on success, mapped field errors, or an aborted request without inspecting
+ * hook state (which updates asynchronously).
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
+    TransactionFieldErrors,
     TransactionFormValues,
     TransactionKind,
     TransactionQuote,
@@ -23,23 +27,47 @@ export interface TransactionAPIState {
     lastErrorReference: string | null;
 }
 
+export type QuoteResult =
+    | { status: "success"; quote: TransactionQuote }
+    | { status: "error"; fieldErrors: TransactionFieldErrors }
+    | { status: "aborted" };
+
+export type SubmitResult =
+    | { status: "success"; pending: PendingTransaction }
+    | { status: "error"; fieldErrors: TransactionFieldErrors }
+    | { status: "aborted" };
+
+const INITIAL_STATE: TransactionAPIState = {
+    isSubmitting: false,
+    recovery: null,
+    lastErrorReference: null,
+};
+
 export function useTransactionAPI() {
-    const [state, setState] = useState<TransactionAPIState>({
-        isSubmitting: false,
-        recovery: null,
-        lastErrorReference: null,
-    });
+    const [state, setState] = useState<TransactionAPIState>(INITIAL_STATE);
+    const requestControllerRef = useRef<AbortController | null>(null);
+
+    const beginApiRequest = useCallback(() => {
+        requestControllerRef.current?.abort();
+        const controller = new AbortController();
+        requestControllerRef.current = controller;
+        return controller;
+    }, []);
+
+    const endApiRequest = useCallback((controller: AbortController) => {
+        if (requestControllerRef.current === controller) {
+            requestControllerRef.current = null;
+        }
+    }, []);
 
     const requestQuote = useCallback(
         async (
             kind: TransactionKind,
             formValues: TransactionFormValues,
-        ): Promise<{ quote: TransactionQuote } | null> => {
-            setState((prev) => ({
-                ...prev,
-                isSubmitting: true,
-                recovery: null,
-            }));
+            quoteReference?: string,
+        ): Promise<QuoteResult> => {
+            const controller = beginApiRequest();
+            setState((prev) => ({ ...prev, isSubmitting: true, recovery: null }));
 
             try {
                 const payload = await apiRequest<{ quote: TransactionQuote }>(
@@ -52,21 +80,26 @@ export function useTransactionAPI() {
                             values: formValues,
                         },
                         timeoutMs: 12000,
+                        signal: controller.signal,
                     },
                 );
 
-                setState((prev) => ({
-                    ...prev,
-                    isSubmitting: false,
-                }));
+                setState((prev) => ({ ...prev, isSubmitting: false }));
 
-                return payload;
+                return { status: "success", quote: payload.quote };
             } catch (error) {
-                const recoveryUI =
-                    error instanceof ApiRequestError
-                        ? getTransactionRecoveryUI(error.code)
-                        : getTransactionRecoveryUI("unknown_error");
+                if (controller.signal.aborted) {
+                    setState((prev) => ({ ...prev, isSubmitting: false }));
+                    return { status: "aborted" };
+                }
 
+                const recovery =
+                    error instanceof ApiRequestError
+                        ? getTransactionRecoveryUI(error.code, quoteReference)
+                        : getTransactionRecoveryUI("unknown_error", quoteReference);
+
+                // Surface server-side field errors to the caller instead of
+                // discarding them, so the form can highlight the offending inputs.
                 const fieldErrors =
                     error instanceof ApiRequestError
                         ? detailsToFieldErrors(error.details)
@@ -75,14 +108,16 @@ export function useTransactionAPI() {
                 setState((prev) => ({
                     ...prev,
                     isSubmitting: false,
-                    recovery: recoveryUI,
-                    lastErrorReference: null,
+                    recovery,
+                    lastErrorReference: quoteReference ?? null,
                 }));
 
-                return null;
+                return { status: "error", fieldErrors };
+            } finally {
+                endApiRequest(controller);
             }
         },
-        [],
+        [beginApiRequest, endApiRequest],
     );
 
     const submitTransaction = useCallback(
@@ -90,12 +125,9 @@ export function useTransactionAPI() {
             kind: TransactionKind,
             formValues: TransactionFormValues,
             quoteReference?: string,
-        ): Promise<{ pending: PendingTransaction } | null> => {
-            setState((prev) => ({
-                ...prev,
-                isSubmitting: true,
-                recovery: null,
-            }));
+        ): Promise<SubmitResult> => {
+            const controller = beginApiRequest();
+            setState((prev) => ({ ...prev, isSubmitting: true, recovery: null }));
 
             try {
                 const payload = await apiRequest<{ pending: PendingTransaction }>(
@@ -108,6 +140,7 @@ export function useTransactionAPI() {
                             values: formValues,
                         },
                         timeoutMs: 12000,
+                        signal: controller.signal,
                     },
                 );
 
@@ -117,13 +150,20 @@ export function useTransactionAPI() {
                     lastErrorReference: payload.pending.reference,
                 }));
 
-                return payload;
+                return { status: "success", pending: payload.pending };
             } catch (error) {
-                const recoveryUI =
+                if (controller.signal.aborted) {
+                    setState((prev) => ({ ...prev, isSubmitting: false }));
+                    return { status: "aborted" };
+                }
+
+                const recovery =
                     error instanceof ApiRequestError
                         ? getTransactionRecoveryUI(error.code, quoteReference)
                         : getTransactionRecoveryUI("unknown_error", quoteReference);
 
+                // Surface server-side field errors to the caller instead of
+                // discarding them, so the form can highlight the offending inputs.
                 const fieldErrors =
                     error instanceof ApiRequestError
                         ? detailsToFieldErrors(error.details)
@@ -132,21 +172,33 @@ export function useTransactionAPI() {
                 setState((prev) => ({
                     ...prev,
                     isSubmitting: false,
-                    recovery: recoveryUI,
-                    lastErrorReference: quoteReference || null,
+                    recovery,
+                    lastErrorReference: quoteReference ?? null,
                 }));
 
-                return null;
+                return { status: "error", fieldErrors };
+            } finally {
+                endApiRequest(controller);
             }
         },
-        [],
+        [beginApiRequest, endApiRequest],
     );
 
     const clearRecovery = useCallback(() => {
-        setState((prev) => ({
-            ...prev,
-            recovery: null,
-        }));
+        setState((prev) => ({ ...prev, recovery: null }));
+    }, []);
+
+    const setSubmitting = useCallback((value: boolean) => {
+        setState((prev) => ({ ...prev, isSubmitting: value }));
+    }, []);
+
+    const cancelRequest = useCallback(() => {
+        requestControllerRef.current?.abort();
+        requestControllerRef.current = null;
+    }, []);
+
+    const reset = useCallback(() => {
+        setState(INITIAL_STATE);
     }, []);
 
     return {
@@ -154,5 +206,8 @@ export function useTransactionAPI() {
         requestQuote,
         submitTransaction,
         clearRecovery,
+        setSubmitting,
+        cancelRequest,
+        reset,
     };
 }

--- a/src/components/transactions/hooks/useTransactionForm.ts
+++ b/src/components/transactions/hooks/useTransactionForm.ts
@@ -60,6 +60,12 @@ export function useTransactionForm(kind: TransactionKind) {
         setFieldErrors(errors);
     }, []);
 
+    // Needed to hydrate the form from a preview snapshot, which supplies a full
+    // set of arbitrary values rather than resetting to per-kind defaults.
+    const setValues = useCallback((values: TransactionFormValues) => {
+        setFormValues(values);
+    }, []);
+
     return {
         formValues,
         fieldErrors,
@@ -67,5 +73,6 @@ export function useTransactionForm(kind: TransactionKind) {
         validate,
         reset,
         setErrors,
+        setValues,
     };
 }

--- a/src/components/transactions/stages/TransactionFormStage.tsx
+++ b/src/components/transactions/stages/TransactionFormStage.tsx
@@ -13,10 +13,8 @@ import {
   getTransactionContext,
 } from "@/lib/transactions";
 import styles from "../transaction-flow.module.css";
-import {
-  getInputStateClassName,
-  sanitizeAmount,
-} from "../utils/transaction-utils";
+import { sanitizeAmount } from "../utils/transaction-utils";
+import { getInputStateClassName } from "../utils/transaction-style-utils";
 import type { TransactionFieldErrors } from "@/lib/transactions";
 
 interface TransactionFormStageProps {

--- a/src/components/transactions/utils/transaction-style-utils.ts
+++ b/src/components/transactions/utils/transaction-style-utils.ts
@@ -1,0 +1,39 @@
+/**
+ * transaction-style-utils.ts
+ *
+ * CSS-module-coupled class helpers for the transaction flow.
+ * Kept separate from the pure helpers in transaction-utils.ts so those
+ * remain unit-testable under the Node test runner (which cannot load .css).
+ */
+
+import styles from "../transaction-flow.module.css";
+
+export function getToneClassName(
+  tone: "error" | "success" | "warning",
+): string {
+  if (tone === "error") {
+    return styles.statusError;
+  }
+
+  if (tone === "warning") {
+    return styles.statusWarning;
+  }
+
+  return styles.statusSuccess;
+}
+
+export function getInputStateClassName(
+  value: string,
+  error?: string,
+  isValidated?: boolean,
+): string {
+  if (error) {
+    return styles.inputError;
+  }
+
+  if (isValidated && value) {
+    return styles.inputSuccess;
+  }
+
+  return "";
+}

--- a/src/components/transactions/utils/transaction-utils.test.ts
+++ b/src/components/transactions/utils/transaction-utils.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  currentStepIndex,
+  detailsToFieldErrors,
+  getTheme,
+  sanitizeAmount,
+} from "./transaction-utils";
+
+test("getTheme returns dark only when theme=dark", () => {
+  assert.equal(getTheme(new URLSearchParams("theme=dark")), "dark");
+  assert.equal(getTheme(new URLSearchParams("theme=light")), "light");
+  assert.equal(getTheme(new URLSearchParams("")), "light");
+});
+
+test("sanitizeAmount strips non-numeric characters except decimal points", () => {
+  assert.equal(sanitizeAmount("$1,250.50"), "1250.50");
+  assert.equal(sanitizeAmount("abc"), "");
+  assert.equal(sanitizeAmount("12.34.56"), "12.34.56");
+});
+
+test("detailsToFieldErrors maps top-level and nested values.* keys", () => {
+  assert.deepEqual(
+    detailsToFieldErrors({
+      amount: "Too large",
+      "values.walletAddress": "Invalid address",
+      walletConnected: ["Reconnect required", "ignored"],
+      body: "Malformed payload",
+    }),
+    {
+      amount: "Too large",
+      walletAddress: "Invalid address",
+      walletConnected: "Reconnect required",
+      form: "Malformed payload",
+    },
+  );
+});
+
+test("detailsToFieldErrors returns undefined fields when details are empty", () => {
+  assert.deepEqual(detailsToFieldErrors(undefined), {});
+  assert.deepEqual(detailsToFieldErrors({}), {
+    amount: undefined,
+    walletAddress: undefined,
+    walletConnected: undefined,
+    form: undefined,
+  });
+});
+
+test("currentStepIndex maps stages to the stepper index", () => {
+  assert.equal(currentStepIndex("form"), 0);
+  assert.equal(currentStepIndex("error"), 0);
+  assert.equal(currentStepIndex("confirm"), 1);
+  assert.equal(currentStepIndex("pending"), 2);
+  assert.equal(currentStepIndex("success"), 2);
+  assert.equal(currentStepIndex("failure"), 2);
+});

--- a/src/components/transactions/utils/transaction-utils.ts
+++ b/src/components/transactions/utils/transaction-utils.ts
@@ -1,90 +1,60 @@
 /**
  * transaction-utils.ts
  *
- * Utility functions for transaction flow.
- * Extracted from TransactionFlow for reusability.
+ * Pure utility functions for the transaction flow.
+ * Extracted from TransactionFlow for reusability and unit testing.
+ * CSS-coupled class helpers live in transaction-style-utils.ts.
  */
 
 import { TransactionFieldErrors } from "@/lib/transactions";
-import styles from "../transaction-flow.module.css";
 
 export function getTheme(
-    searchParams: Pick<URLSearchParams, "get">,
+  searchParams: Pick<URLSearchParams, "get">,
 ): "light" | "dark" {
-    return searchParams.get("theme") === "dark" ? "dark" : "light";
-}
-
-export function getToneClassName(
-    tone: "error" | "success" | "warning",
-): string {
-    if (tone === "error") {
-        return styles.statusError;
-    }
-
-    if (tone === "warning") {
-        return styles.statusWarning;
-    }
-
-    return styles.statusSuccess;
-}
-
-export function getInputStateClassName(
-    value: string,
-    error?: string,
-    isValidated?: boolean,
-): string {
-    if (error) {
-        return styles.inputError;
-    }
-
-    if (isValidated && value) {
-        return styles.inputSuccess;
-    }
-
-    return "";
+  return searchParams.get("theme") === "dark" ? "dark" : "light";
 }
 
 export function sanitizeAmount(value: string): string {
-    return value.replace(/[^\d.]/g, "");
+  return value.replace(/[^\d.]/g, "");
 }
 
 export function detailsToFieldErrors(
-    details?: Record<string, string | string[]>,
+  details?: Record<string, string | string[]>,
 ): TransactionFieldErrors {
-    if (!details) {
-        return {};
+  if (!details) {
+    return {};
+  }
+
+  const readValue = (key: string): string | undefined => {
+    const value = details[key];
+
+    if (Array.isArray(value)) {
+      return value[0];
     }
 
-    const readValue = (key: string): string | undefined => {
-        const value = details[key];
+    return typeof value === "string" ? value : undefined;
+  };
 
-        if (Array.isArray(value)) {
-            return value[0];
-        }
-
-        return typeof value === "string" ? value : undefined;
-    };
-
-    return {
-        amount: readValue("amount") ?? readValue("values.amount"),
-        walletAddress:
-            readValue("walletAddress") ?? readValue("values.walletAddress"),
-        walletConnected:
-            readValue("walletConnected") ?? readValue("values.walletConnected"),
-        form: readValue("form") ?? readValue("body"),
-    };
+  return {
+    amount: readValue("amount") ?? readValue("values.amount"),
+    walletAddress:
+      readValue("walletAddress") ?? readValue("values.walletAddress"),
+    walletConnected:
+      readValue("walletConnected") ?? readValue("values.walletConnected"),
+    form: readValue("form") ?? readValue("body"),
+  };
 }
 
 export function currentStepIndex(
-    stage: "form" | "confirm" | "pending" | "success" | "failure" | "error",
+  stage: "form" | "confirm" | "pending" | "success" | "failure" | "error",
 ): number {
-    if (stage === "form" || stage === "error") {
-        return 0;
-    }
+  if (stage === "form" || stage === "error") {
+    return 0;
+  }
 
-    if (stage === "confirm") {
-        return 1;
-    }
+  if (stage === "confirm") {
+    return 1;
+  }
 
-    return 2;
+  return 2;
 }

--- a/src/lib/composeProviders.tsx
+++ b/src/lib/composeProviders.tsx
@@ -1,4 +1,8 @@
-import { type ComponentType, type ReactNode } from "react";
+import {
+  createElement,
+  type ComponentType,
+  type ReactNode,
+} from "react";
 
 type ProviderComponent =
   | ComponentType<{ children: ReactNode }>
@@ -17,16 +21,19 @@ type ProviderComponent =
  *
  * return <AllProviders>{children}</AllProviders>;
  * ```
+ *
+ * Call once at module scope (or memoize) — invoking inside a component body
+ * creates a new component type every render and remounts the provider tree.
  */
 export function composeProviders(providers: ProviderComponent[]) {
   return function ComposedProviders({ children }: { children: ReactNode }) {
     return providers.reduceRight<ReactNode>((acc, entry) => {
       if (Array.isArray(entry)) {
         const [Provider, props] = entry;
-        return <Provider {...props}>{acc}</Provider>;
+        return createElement(Provider, props, acc);
       }
       const Provider = entry;
-      return <Provider>{acc}</Provider>;
+      return createElement(Provider, null, acc);
     }, children);
   };
 }

--- a/src/lib/service-layer/transaction-service.test.ts
+++ b/src/lib/service-layer/transaction-service.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { TransactionService, type Transaction } from "./transaction-service";
+
+function createService() {
+  return new TransactionService({ simulateLatency: false, simulateFailure: false });
+}
+
+test("getTransactionStats computes all counters in one pass for mock user_1", async () => {
+  const service = createService();
+  const response = await service.getTransactionStats("user_1");
+
+  assert.equal(response.data.totalTransactions, 3);
+  assert.equal(response.data.completedTransactions, 2);
+  assert.equal(response.data.pendingTransactions, 1);
+  assert.equal(response.data.failedTransactions, 0);
+  // Only completed amounts: 10000 + 5000
+  assert.equal(response.data.totalVolume, 15000);
+});
+
+test("getTransactionStats returns zeros for a user with no transactions", async () => {
+  const service = createService();
+  const response = await service.getTransactionStats("user_unknown");
+
+  assert.deepEqual(response.data, {
+    totalVolume: 0,
+    totalTransactions: 0,
+    completedTransactions: 0,
+    pendingTransactions: 0,
+    failedTransactions: 0,
+  });
+});
+
+test("getTransactionStats counts failed volume separately from totalVolume", async () => {
+  const service = createService();
+  const failed: Transaction = {
+    id: "tx_failed",
+    userId: "user_stats",
+    type: "withdrawal",
+    amount: 999,
+    asset: "USDC",
+    status: "failed",
+    createdAt: new Date().toISOString(),
+  };
+  const completed: Transaction = {
+    id: "tx_ok",
+    userId: "user_stats",
+    type: "deposit",
+    amount: 100,
+    asset: "USDC",
+    status: "completed",
+    createdAt: new Date().toISOString(),
+  };
+
+  // Seed via the private mock map used by the service (test-only).
+  (
+    service as unknown as { mockTransactions: Map<string, Transaction[]> }
+  ).mockTransactions.set("user_stats", [failed, completed]);
+
+  const response = await service.getTransactionStats("user_stats");
+
+  assert.equal(response.data.totalTransactions, 2);
+  assert.equal(response.data.completedTransactions, 1);
+  assert.equal(response.data.failedTransactions, 1);
+  assert.equal(response.data.pendingTransactions, 0);
+  assert.equal(response.data.totalVolume, 100);
+});

--- a/src/lib/service-layer/transaction-service.ts
+++ b/src/lib/service-layer/transaction-service.ts
@@ -1,5 +1,10 @@
 import { BaseAdapter } from "./base-adapter";
-import { ServiceResponse, PaginatedResponse, PaginationParams } from "./types";
+import {
+  ServiceResponse,
+  PaginatedResponse,
+  PaginationParams,
+  type ServiceConfig,
+} from "./types";
 import { random } from "../seeded-rng";
 
 export interface Transaction {
@@ -38,8 +43,8 @@ export interface TransactionFilter {
 export class TransactionService extends BaseAdapter {
   private mockTransactions: Map<string, Transaction[]> = new Map();
 
-  constructor() {
-    super();
+  constructor(config: Partial<ServiceConfig> = {}) {
+    super(config);
     this.initializeMockData();
   }
 
@@ -154,13 +159,15 @@ export class TransactionService extends BaseAdapter {
           transactions = transactions.filter((t) => t.asset === params.filter!.asset);
         }
         if (params.filter.startDate) {
+          const startDate = new Date(params.filter.startDate);
           transactions = transactions.filter(
-            (t) => new Date(t.createdAt) >= new Date(params.filter!.startDate!)
+            (t) => new Date(t.createdAt) >= startDate
           );
         }
         if (params.filter.endDate) {
+          const endDate = new Date(params.filter.endDate);
           transactions = transactions.filter(
-            (t) => new Date(t.createdAt) <= new Date(params.filter!.endDate!)
+            (t) => new Date(t.createdAt) <= endDate
           );
         }
       }
@@ -214,15 +221,28 @@ export class TransactionService extends BaseAdapter {
     return this.executeWithRetry(async () => {
       const transactions = this.mockTransactions.get(userId) || [];
 
-      const stats = {
-        totalVolume: transactions
-          .filter((t) => t.status === "completed")
-          .reduce((sum, t) => sum + t.amount, 0),
-        totalTransactions: transactions.length,
-        completedTransactions: transactions.filter((t) => t.status === "completed").length,
-        pendingTransactions: transactions.filter((t) => t.status === "pending").length,
-        failedTransactions: transactions.filter((t) => t.status === "failed").length,
-      };
+      // Single pass over the list — previously four .filter()/.reduce() scans
+      // (including a duplicated status === "completed" pass).
+      const stats = transactions.reduce(
+        (acc, t) => {
+          if (t.status === "completed") {
+            acc.totalVolume += t.amount;
+            acc.completedTransactions += 1;
+          } else if (t.status === "pending") {
+            acc.pendingTransactions += 1;
+          } else if (t.status === "failed") {
+            acc.failedTransactions += 1;
+          }
+          return acc;
+        },
+        {
+          totalVolume: 0,
+          totalTransactions: transactions.length,
+          completedTransactions: 0,
+          pendingTransactions: 0,
+          failedTransactions: 0,
+        },
+      );
 
       return this.createResponse(stats);
     }, "TransactionService.getTransactionStats");


### PR DESCRIPTION
## Summary
- **#639** — Finish migrating `TransactionFlow` to compose the orphaned stage components (`TransactionFormStage` / `Confirm` / `Pending` / `Receipt`) and hooks (`useTransactionForm`, `useTransactionAPI`); fix the discarded field-errors bug so API validation details reach the form.
- **#640** — Hoist `composeProviders([...])` and `resolveStellarConfig()` to module scope in `ClientProviders` so the provider tree no longer remounts on every parent re-render.
- **#643** — Replace four `.filter()`/`.reduce()` scans in `getTransactionStats` with a single `reduce` for volume + completed/pending/failed counts.
- **#644** — Parse `startDate`/`endDate` once before the date-range `.filter()` callbacks instead of reconstructing `Date` on every element.

### Rationale for small helper split
CSS-coupled class helpers live in `transaction-style-utils.ts` so pure helpers in `transaction-utils.ts` stay unit-testable under the Node test runner (which cannot load `.module.css`).

## Test plan
- [x] `useTransactionAPI` tests: field errors returned on quote/submit failure
- [x] `ClientProviders.remount.test.ts`: unstable compose remounts; module-scoped compose does not; source hoist check
- [x] `transaction-service` stats tests (single-pass behavior / empty user / failed vs volume)
- [x] `transaction-utils` unit tests
- [x] `next lint` on changed files — clean
- [ ] Manual: `/dashboard/transactions` form → confirm → pending → receipt; screenshot state buttons; theme toggle
- [ ] Manual: app shell re-renders (e.g. theme) without resetting wallet/auth provider state

Closes #639
Closes #640
Closes #643
Closes #644