### PR TITLE
Extract shared settings-form hook and wire i18n into strategies/security settings

### DIFF
--- a/src/app/dashboard/settings/notifications/page.tsx
+++ b/src/app/dashboard/settings/notifications/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { AlertCircle, Bell, Mail, Save, ShieldAlert, X } from "lucide-react";
 import { useToast } from "@/components/notifications/ToastProvider";
 import { useI18n } from "@/contexts/I18nContext";
@@ -9,7 +8,7 @@ import { STORAGE_KEYS } from "@/lib/storage-keys";
 export const dynamic = "force-dynamic";
 import { Button, Card, InlineBanner } from "@/components/ui";
 import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
-import { mockAuditService } from "@/lib/mock-audit";
+import { useSettingsForm } from "@/hooks/useSettingsForm";
 
 interface NotificationPreferences {
   emailNotifications: boolean;
@@ -70,82 +69,52 @@ export default function NotificationsSettingsPage() {
   const { pushToast } = useToast();
   const { messages } = useI18n();
   const t = messages.settings.notifications;
-  const [saved, setSaved] = useState(DEFAULT_PREFERENCES);
-  const [draft, setDraft] = useState(DEFAULT_PREFERENCES);
-  const [editing, setEditing] = useState(false);
-  const [pageLoading, setPageLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored) {
-          const parsed = JSON.parse(stored) as NotificationPreferences;
-          setSaved(parsed);
-          setDraft(parsed);
-        }
-      } catch {
-        // Keep defaults if storage is invalid.
-      } finally {
-        setPageLoading(false);
-      }
-    }, 500);
-
-    return () => clearTimeout(timer);
-  }, []);
-
-  if (pageLoading) {
-    return <SettingsSectionSkeleton rows={5} />;
-  }
-
-  const isDirty = JSON.stringify(draft) !== JSON.stringify(saved);
-  const enabledCount = Object.values(draft).filter(Boolean).length;
-
-  const togglePreference = (key: keyof NotificationPreferences) => {
-    setDraft((current) => ({ ...current, [key]: !current[key] }));
-  };
-
-  const handleCancel = () => {
-    setDraft(saved);
-    setEditing(false);
-    setStatus("idle");
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    setStatus("idle");
-
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 800));
-
-      if (!draft.securityAlerts) {
+  const {
+    draft,
+    setDraft,
+    editing,
+    setEditing,
+    saving,
+    status,
+    pageLoading,
+    isDirty,
+    handleSave,
+    handleCancel,
+  } = useSettingsForm<NotificationPreferences>(STORAGE_KEY, DEFAULT_PREFERENCES, {
+    auditSection: "notifications",
+    loadDelayMs: 500,
+    saveDelayMs: 800,
+    validate: (current) => {
+      if (!current.securityAlerts) {
         throw new Error("Security alerts must stay enabled in this mock.");
       }
-
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(draft));
-      setSaved(draft);
-      setEditing(false);
-      setStatus("success");
-      mockAuditService.logEvent("settings_change", { section: "notifications", changes: draft });
+    },
+    onSaveSuccess: () => {
       pushToast({
         variant: "success",
         title: t.toast.savedTitle,
         description: t.toast.savedDesc,
         duration: 4000,
       });
-    } catch {
-      setStatus("error");
+    },
+    onSaveError: () => {
       pushToast({
         variant: "error",
         title: t.toast.failTitle,
         description: t.toast.failDesc,
         duration: 6000,
       });
-    } finally {
-      setSaving(false);
-    }
+    },
+  });
+
+  if (pageLoading) {
+    return <SettingsSectionSkeleton rows={5} />;
+  }
+
+  const enabledCount = Object.values(draft).filter(Boolean).length;
+
+  const togglePreference = (key: keyof NotificationPreferences) => {
+    setDraft((current) => ({ ...current, [key]: !current[key] }));
   };
 
   return (

--- a/src/app/dashboard/settings/preferences/page.tsx
+++ b/src/app/dashboard/settings/preferences/page.tsx
@@ -1,10 +1,8 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import {
   Globe,
   Clock,
-  DollarSign,
   Save,
   X,
   AlertCircle,
@@ -16,12 +14,13 @@ import {
 import { Button } from "@/components/ui/Button";
 
 export const dynamic = "force-dynamic";
-import { mockAuditService } from "@/lib/mock-audit";
 import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
-import { useTheme, ThemeMode } from "@/contexts/ThemeProvider";
+import { ThemeMode } from "@/contexts/ThemeProvider";
 import { useI18n } from "@/contexts/I18nContext";
 import { LOCALE_OPTIONS as LOCALES } from "@/lib/locale-options";
 import { STORAGE_KEYS } from "@/lib/storage-keys";
+import { useSettingsForm } from "@/hooks/useSettingsForm";
+import styles from "../settings.module.css";
 
 interface PreferencesData {
   locale: string;
@@ -59,98 +58,63 @@ const DEFAULT: PreferencesData = {
 export default function PreferencesPage() {
   const { messages } = useI18n();
   const t = messages.settings.preferences;
-  const [saved, setSaved] = useState<PreferencesData>(DEFAULT);
-  const [draft, setDraft] = useState<PreferencesData>(DEFAULT);
-  const [editing, setEditing] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
-  const [pageLoading, setPageLoading] = useState(true);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored) {
-          const data = JSON.parse(stored);
-          setSaved(data);
-          setDraft(data);
-        }
-      } catch {}
-      setPageLoading(false);
-    }, 600);
-    return () => clearTimeout(timer);
-  }, []);
+  const {
+    saved,
+    draft,
+    setDraft,
+    editing,
+    setEditing,
+    saving,
+    status,
+    pageLoading,
+    isDirty,
+    handleSave,
+    handleCancel,
+  } = useSettingsForm<PreferencesData>(STORAGE_KEY, DEFAULT, {
+    auditSection: "preferences",
+  });
 
   if (pageLoading) {
     return <SettingsSectionSkeleton rows={3} />;
   }
 
-  const isDirty = JSON.stringify(draft) !== JSON.stringify(saved);
-
-  const handleSave = async () => {
-    setSaving(true);
-    setStatus("idle");
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 600));
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(draft));
-      setSaved(draft);
-      setStatus("success");
-      setEditing(false);
-      mockAuditService.logEvent("settings_change", {
-        section: "preferences",
-        changes: draft,
-      });
-      setTimeout(() => setStatus("idle"), 3000);
-    } catch {
-      setStatus("error");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleCancel = () => {
-    setDraft(saved);
-    setEditing(false);
-    setStatus("idle");
-  };
-
   return (
-    <div className="preferences-page">
-      <div className="settings-header">
+    <div className={styles.page}>
+      <div className={styles.settingsHeader}>
         <div>
-          <h1 className="settings-title">{t.title}</h1>
-          <p className="settings-subtitle">{t.subtitle}</p>
+          <h1 className={styles.settingsTitle}>{t.title}</h1>
+          <p className={styles.settingsSubtitle}>{t.subtitle}</p>
         </div>
       </div>
 
       {status === "success" && (
-        <div className="settings-banner settings-banner-success" role="status">
+        <div className={`${styles.settingsBanner} ${styles.settingsBannerSuccess}`} role="status">
           <CheckCircle2 size={16} />
           <span>{t.savedSuccess}</span>
         </div>
       )}
 
       {status === "error" && (
-        <div className="settings-banner settings-banner-error" role="alert">
+        <div className={`${styles.settingsBanner} ${styles.settingsBannerError}`} role="alert">
           <AlertCircle size={16} />
           <span>{t.saveError}</span>
         </div>
       )}
 
-      <div className="settings-card">
-        <div className="settings-card-header">
-          <div className="settings-card-icon">
+      <div className={styles.settingsCard}>
+        <div className={styles.settingsCardHeader}>
+          <div className={styles.settingsCardIcon}>
             <Globe size={18} />
           </div>
           <div>
-            <h2 className="settings-card-title">{t.localisation.title}</h2>
-            <p className="settings-card-desc">{t.localisation.desc}</p>
+            <h2 className={styles.settingsCardTitle}>{t.localisation.title}</h2>
+            <p className={styles.settingsCardDesc}>{t.localisation.desc}</p>
           </div>
         </div>
 
-        <div className="settings-card-body">
-          <div className="settings-field">
-            <label htmlFor="locale" className="settings-label">
+        <div className={styles.settingsCardBody}>
+          <div className={styles.settingsField}>
+            <label htmlFor="locale" className={styles.settingsLabel}>
               {t.localisation.localeLabel}
             </label>
             {editing ? (
@@ -158,7 +122,7 @@ export default function PreferencesPage() {
                 id="locale"
                 value={draft.locale}
                 onChange={(e) => setDraft({ ...draft, locale: e.target.value })}
-                className="settings-select"
+                className={styles.settingsSelect}
               >
                 {LOCALES.map((l) => (
                   <option key={l.value} value={l.value}>
@@ -167,7 +131,7 @@ export default function PreferencesPage() {
                 ))}
               </select>
             ) : (
-              <p className="settings-value">
+              <p className={styles.settingsValue}>
                 {LOCALES.find((l) => l.value === saved.locale)?.label ||
                   saved.locale}
               </p>
@@ -176,20 +140,20 @@ export default function PreferencesPage() {
         </div>
       </div>
 
-      <div className="settings-card">
-        <div className="settings-card-header">
-          <div className="settings-card-icon">
+      <div className={styles.settingsCard}>
+        <div className={styles.settingsCardHeader}>
+          <div className={styles.settingsCardIcon}>
             <Monitor size={18} />
           </div>
           <div>
-            <h2 className="settings-card-title">{t.appearance.title}</h2>
-            <p className="settings-card-desc">{t.appearance.desc}</p>
+            <h2 className={styles.settingsCardTitle}>{t.appearance.title}</h2>
+            <p className={styles.settingsCardDesc}>{t.appearance.desc}</p>
           </div>
         </div>
 
-        <div className="settings-card-body">
-          <div className="settings-field">
-            <label className="settings-label">{t.appearance.themeLabel}</label>
+        <div className={styles.settingsCardBody}>
+          <div className={styles.settingsField}>
+            <label className={styles.settingsLabel}>{t.appearance.themeLabel}</label>
             {editing ? (
               <div className="theme-options">
                 <button
@@ -221,7 +185,7 @@ export default function PreferencesPage() {
                 </button>
               </div>
             ) : (
-              <p className="settings-value">
+              <p className={styles.settingsValue}>
                 {saved.theme === "light" && t.appearance.light}
                 {saved.theme === "dark" && t.appearance.dark}
                 {saved.theme === "system" && t.appearance.system}
@@ -231,20 +195,20 @@ export default function PreferencesPage() {
         </div>
       </div>
 
-      <div className="settings-card">
-        <div className="settings-card-header">
-          <div className="settings-card-icon">
+      <div className={styles.settingsCard}>
+        <div className={styles.settingsCardHeader}>
+          <div className={styles.settingsCardIcon}>
             <Clock size={18} />
           </div>
           <div>
-            <h2 className="settings-card-title">{t.timeCurrency.title}</h2>
-            <p className="settings-card-desc">{t.timeCurrency.desc}</p>
+            <h2 className={styles.settingsCardTitle}>{t.timeCurrency.title}</h2>
+            <p className={styles.settingsCardDesc}>{t.timeCurrency.desc}</p>
           </div>
         </div>
 
-        <div className="settings-card-body">
-          <div className="settings-field">
-            <label htmlFor="timezone" className="settings-label">
+        <div className={styles.settingsCardBody}>
+          <div className={styles.settingsField}>
+            <label htmlFor="timezone" className={styles.settingsLabel}>
               {t.timeCurrency.timezoneLabel}
             </label>
             {editing ? (
@@ -254,7 +218,7 @@ export default function PreferencesPage() {
                 onChange={(e) =>
                   setDraft({ ...draft, timezone: e.target.value })
                 }
-                className="settings-select"
+                className={styles.settingsSelect}
               >
                 {TIMEZONES.map((tz) => (
                   <option key={tz.value} value={tz.value}>
@@ -263,15 +227,15 @@ export default function PreferencesPage() {
                 ))}
               </select>
             ) : (
-              <p className="settings-value">
+              <p className={styles.settingsValue}>
                 {TIMEZONES.find((tz) => tz.value === saved.timezone)?.label ||
                   saved.timezone}
               </p>
             )}
           </div>
 
-          <div className="settings-field">
-            <label htmlFor="currency" className="settings-label">
+          <div className={styles.settingsField}>
+            <label htmlFor="currency" className={styles.settingsLabel}>
               {t.timeCurrency.currencyLabel}
             </label>
             {editing ? (
@@ -281,7 +245,7 @@ export default function PreferencesPage() {
                 onChange={(e) =>
                   setDraft({ ...draft, currencyFormat: e.target.value })
                 }
-                className="settings-select"
+                className={styles.settingsSelect}
               >
                 {CURRENCIES.map((c) => (
                   <option key={c.value} value={c.value}>
@@ -290,7 +254,7 @@ export default function PreferencesPage() {
                 ))}
               </select>
             ) : (
-              <p className="settings-value">
+              <p className={styles.settingsValue}>
                 {CURRENCIES.find((c) => c.value === saved.currencyFormat)
                   ?.label || saved.currencyFormat}
               </p>
@@ -307,16 +271,16 @@ export default function PreferencesPage() {
 
       {editing && (
         <div
-          className="settings-action-bar"
+          className={styles.settingsActionBar}
           role="group"
           aria-label="Save or cancel changes"
         >
           {isDirty && (
-            <span className="settings-dirty-indicator">
+            <span className={styles.settingsDirtyIndicator}>
               {t.actions.unsaved}
             </span>
           )}
-          <div className="settings-actions">
+          <div className={styles.settingsActions}>
             <Button
               onClick={handleCancel}
               variant="ghost"
@@ -334,7 +298,7 @@ export default function PreferencesPage() {
             >
               {saving ? (
                 <>
-                  <span className="settings-spinner" aria-hidden="true" />
+                  <span className={styles.settingsSpinner} aria-hidden="true" />
                   {t.actions.saving}
                 </>
               ) : (
@@ -347,233 +311,6 @@ export default function PreferencesPage() {
           </div>
         </div>
       )}
-
-      <style>{`
-        .preferences-page {
-          display: flex;
-          flex-direction: column;
-          gap: 24px;
-        }
-
-        .settings-header {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          gap: 16px;
-        }
-
-        .settings-title {
-          font-size: 24px;
-          font-weight: 700;
-          color: #e2e8f0;
-          margin: 0 0 4px;
-        }
-
-        .settings-subtitle {
-          font-size: 14px;
-          color: #94a3b8;
-          margin: 0;
-        }
-
-        .settings-banner {
-          display: flex;
-          align-items: center;
-          gap: 12px;
-          padding: 12px 16px;
-          border-radius: 10px;
-          font-size: 13px;
-          border: 1px solid;
-          animation: slideDown 0.2s ease-out;
-        }
-
-        @keyframes slideDown {
-          from {
-            opacity: 0;
-            transform: translateY(-10px);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0);
-          }
-        }
-
-        .settings-banner-success {
-          background: rgba(16, 185, 129, 0.08);
-          border-color: rgba(16, 185, 129, 0.3);
-          color: #6ee7b7;
-        }
-
-        .settings-banner-success svg {
-          color: #10b981;
-          flex-shrink: 0;
-        }
-
-        .settings-banner-error {
-          background: rgba(239, 68, 68, 0.08);
-          border-color: rgba(239, 68, 68, 0.3);
-          color: #fca5a5;
-        }
-
-        .settings-banner-error svg {
-          color: #ef4444;
-          flex-shrink: 0;
-        }
-
-        .settings-card {
-          background: rgba(15, 23, 42, 0.6);
-          border: 1px solid rgba(148, 163, 184, 0.15);
-          border-radius: 14px;
-          overflow: hidden;
-        }
-
-        .settings-card-header {
-          display: flex;
-          align-items: flex-start;
-          gap: 12px;
-          padding: 20px 24px 16px;
-          border-bottom: 1px solid rgba(148, 163, 184, 0.1);
-        }
-
-        .settings-card-icon {
-          width: 34px;
-          height: 34px;
-          border-radius: 8px;
-          background: rgba(56, 189, 248, 0.1);
-          border: 1px solid rgba(56, 189, 248, 0.2);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          color: #38bdf8;
-          flex-shrink: 0;
-        }
-
-        .settings-card-title {
-          font-size: 14px;
-          font-weight: 600;
-          color: #e2e8f0;
-          margin: 0 0 2px;
-        }
-
-        .settings-card-desc {
-          font-size: 12px;
-          color: #64748b;
-          margin: 0;
-        }
-
-        .settings-card-body {
-          padding: 20px 24px;
-          display: flex;
-          flex-direction: column;
-          gap: 18px;
-        }
-
-        .settings-field {
-          display: flex;
-          flex-direction: column;
-          gap: 6px;
-        }
-
-        .settings-label {
-          font-size: 12px;
-          font-weight: 600;
-          color: #94a3b8;
-          text-transform: uppercase;
-          letter-spacing: 0.05em;
-        }
-
-        .settings-value {
-          font-size: 14px;
-          color: #e2e8f0;
-          margin: 0;
-          padding: 9px 0;
-        }
-
-        .settings-select {
-          background: rgba(15, 23, 42, 0.8);
-          border: 1px solid rgba(148, 163, 184, 0.2);
-          border-radius: 8px;
-          padding: 10px 14px;
-          color: #e2e8f0;
-          font-size: 14px;
-          outline: none;
-          transition: all 0.2s;
-        }
-
-        .settings-select:focus {
-          border-color: #38bdf8;
-          box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.12);
-        }
-
-        .settings-select option {
-          background: #0f172a;
-          color: #e2e8f0;
-        }
-
-        .settings-action-bar {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          gap: 12px;
-          padding: 14px 20px;
-          /* #423: add safe-area-inset-bottom so buttons clear the home indicator */
-          padding-bottom: max(14px, calc(14px + var(--sai-bottom, 0px)));
-          background: rgba(2, 6, 23, 0.88);
-          backdrop-filter: blur(16px);
-          border: 1px solid rgba(148, 163, 184, 0.15);
-          border-radius: 12px;
-          position: sticky;
-          bottom: 24px;
-          z-index: 40;
-          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-        }
-
-        .settings-dirty-indicator {
-          font-size: 12px;
-          color: #f59e0b;
-        }
-
-        .settings-actions {
-          display: flex;
-          gap: 10px;
-          margin-left: auto;
-        }
-
-        .settings-spinner {
-          display: inline-block;
-          width: 14px;
-          height: 14px;
-          border: 2px solid rgba(255, 255, 255, 0.25);
-          border-top-color: #fff;
-          border-radius: 50%;
-          animation: spin 0.65s linear infinite;
-        }
-
-        @keyframes spin {
-          to {
-            transform: rotate(360deg);
-          }
-        }
-
-        @media (max-width: 520px) {
-          .settings-card-header {
-            padding: 16px;
-          }
-
-          .settings-card-body {
-            padding: 16px;
-          }
-
-          .settings-action-bar {
-            flex-direction: column;
-            align-items: stretch;
-          }
-
-          .settings-actions {
-            flex-direction: column;
-            margin-left: 0;
-          }
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/app/dashboard/settings/security/page.tsx
+++ b/src/app/dashboard/settings/security/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useRef } from "react";
 import { Lock, Shield, AlertCircle, CheckCircle2, Save, X } from "lucide-react";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { Button } from "@/components/ui/Button";
@@ -8,7 +8,10 @@ import { Button } from "@/components/ui/Button";
 export const dynamic = "force-dynamic";
 import { mockAuditService } from "@/lib/mock-audit";
 import { SettingsSectionSkeleton } from "@/components/ui/Skeleton";
+import { useI18n } from "@/contexts/I18nContext";
 import { STORAGE_KEYS } from "@/lib/storage-keys";
+import { useSettingsForm } from "@/hooks/useSettingsForm";
+import styles from "../settings.module.css";
 
 interface SecurityData {
   twoFactorEnabled: boolean;
@@ -24,61 +27,34 @@ const DEFAULT: SecurityData = {
 };
 
 export default function SecurityPage() {
-  const [saved, setSaved] = useState<SecurityData>(DEFAULT);
-  const [draft, setDraft] = useState<SecurityData>(DEFAULT);
-  const [editing, setEditing] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const [status, setStatus] = useState<"idle" | "success" | "error">("idle");
+  const { messages } = useI18n();
+  const t = messages.settings.security;
+  const {
+    saved,
+    setSaved,
+    draft,
+    setDraft,
+    editing,
+    setEditing,
+    saving,
+    setSaving,
+    status,
+    setStatus,
+    pageLoading,
+    isDirty,
+    handleSave,
+    handleCancel,
+  } = useSettingsForm<SecurityData>(STORAGE_KEY, DEFAULT, {
+    auditSection: "security",
+  });
   const [showPasswordModal, setShowPasswordModal] = useState(false);
   const [newPassword, setNewPassword] = useState("");
-  const [pageLoading, setPageLoading] = useState(true);
   const passwordModalRef = useRef<HTMLDivElement>(null);
   useFocusTrap(passwordModalRef, showPasswordModal);
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        if (stored) {
-          const data = JSON.parse(stored);
-          setSaved(data);
-          setDraft(data);
-        }
-      } catch {}
-      setPageLoading(false);
-    }, 600);
-    return () => clearTimeout(timer);
-  }, []);
 
   if (pageLoading) {
     return <SettingsSectionSkeleton rows={3} />;
   }
-
-  const isDirty = JSON.stringify(draft) !== JSON.stringify(saved);
-
-  const handleSave = async () => {
-    setSaving(true);
-    setStatus("idle");
-    try {
-      await new Promise((resolve) => setTimeout(resolve, 600));
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(draft));
-      setSaved(draft);
-      setStatus("success");
-      setEditing(false);
-      mockAuditService.logEvent("settings_change", { section: "security", changes: draft });
-      setTimeout(() => setStatus("idle"), 3000);
-    } catch {
-      setStatus("error");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleCancel = () => {
-    setDraft(saved);
-    setEditing(false);
-    setStatus("idle");
-  };
 
   const handleChangePassword = async () => {
     if (!newPassword) return;
@@ -110,50 +86,50 @@ export default function SecurityPage() {
   );
 
   return (
-    <div className="security-page">
-      <div className="settings-header">
+    <div className={styles.page}>
+      <div className={styles.settingsHeader}>
         <div>
-          <h1 className="settings-title">Security</h1>
-          <p className="settings-subtitle">Manage your account security and authentication</p>
+          <h1 className={styles.settingsTitle}>{t.title}</h1>
+          <p className={styles.settingsSubtitle}>{t.subtitle}</p>
         </div>
       </div>
 
       {status === "success" && (
-        <div className="settings-banner settings-banner-success" role="status">
+        <div className={`${styles.settingsBanner} ${styles.settingsBannerSuccess}`} role="status">
           <CheckCircle2 size={16} />
-          <span>Security settings updated successfully</span>
+          <span>{t.banner.success}</span>
         </div>
       )}
 
       {status === "error" && (
-        <div className="settings-banner settings-banner-error" role="alert">
+        <div className={`${styles.settingsBanner} ${styles.settingsBannerError}`} role="alert">
           <AlertCircle size={16} />
-          <span>Failed to update security settings. Please try again.</span>
+          <span>{t.banner.error}</span>
         </div>
       )}
 
       {/* Password Section */}
-      <div className="settings-card">
-        <div className="settings-card-header">
-          <div className="settings-card-icon">
+      <div className={styles.settingsCard}>
+        <div className={styles.settingsCardHeader}>
+          <div className={styles.settingsCardIcon}>
             <Lock size={18} />
           </div>
           <div>
-            <h2 className="settings-card-title">Password</h2>
-            <p className="settings-card-desc">Change your account password</p>
+            <h2 className={styles.settingsCardTitle}>{t.password.title}</h2>
+            <p className={styles.settingsCardDesc}>{t.password.desc}</p>
           </div>
         </div>
 
-        <div className="settings-card-body">
-          <div className="settings-field">
-            <label className="settings-label">Last Changed</label>
-            <p className="settings-value">
-              {lastPasswordChangeDate.toLocaleDateString()} ({daysSinceChange} days ago)
+        <div className={styles.settingsCardBody}>
+          <div className={styles.settingsField}>
+            <label className={styles.settingsLabel}>{t.password.lastChangedLabel}</label>
+            <p className={styles.settingsValue}>
+              {lastPasswordChangeDate.toLocaleDateString()} ({daysSinceChange} {t.password.daysAgoSuffix})
             </p>
             {daysSinceChange > 90 && (
-              <p className="settings-warning">
+              <p className={styles.settingsWarning}>
                 <AlertCircle size={14} />
-                Consider changing your password regularly for security
+                {t.password.warning}
               </p>
             )}
           </div>
@@ -164,74 +140,70 @@ export default function SecurityPage() {
             size="md"
             disabled={saving}
           >
-            Change Password
+            {t.password.changeAction}
           </Button>
         </div>
       </div>
 
       {/* Two-Factor Authentication */}
-      <div className="settings-card">
-        <div className="settings-card-header">
-          <div className="settings-card-icon">
+      <div className={styles.settingsCard}>
+        <div className={styles.settingsCardHeader}>
+          <div className={styles.settingsCardIcon}>
             <Shield size={18} />
           </div>
           <div>
-            <h2 className="settings-card-title">Two-Factor Authentication</h2>
-            <p className="settings-card-desc">Add an extra layer of security to your account</p>
+            <h2 className={styles.settingsCardTitle}>{t.twoFactor.title}</h2>
+            <p className={styles.settingsCardDesc}>{t.twoFactor.desc}</p>
           </div>
         </div>
 
-        <div className="settings-card-body">
-          <div className="settings-field">
-            <label htmlFor="2fa" className="settings-toggle-label">
+        <div className={styles.settingsCardBody}>
+          <div className={styles.settingsField}>
+            <label htmlFor="2fa" className={styles.settingsToggleLabel}>
               <input
                 id="2fa"
                 type="checkbox"
                 checked={draft.twoFactorEnabled}
                 onChange={(e) => setDraft({ ...draft, twoFactorEnabled: e.target.checked })}
-                className="settings-toggle"
+                className={styles.settingsToggle}
                 disabled={!editing}
               />
-              <span>Enable two-factor authentication</span>
+              <span>{t.twoFactor.enableLabel}</span>
             </label>
-            <p className="settings-hint">
-              {draft.twoFactorEnabled
-                ? "2FA is enabled. You'll need to verify with your authenticator app on login."
-                : "2FA is disabled. Enable it for enhanced security."}
+            <p className={styles.settingsHint}>
+              {draft.twoFactorEnabled ? t.twoFactor.enabledHint : t.twoFactor.disabledHint}
             </p>
           </div>
         </div>
       </div>
 
       {/* Login Alerts */}
-      <div className="settings-card">
-        <div className="settings-card-header">
-          <div className="settings-card-icon">
+      <div className={styles.settingsCard}>
+        <div className={styles.settingsCardHeader}>
+          <div className={styles.settingsCardIcon}>
             <AlertCircle size={18} />
           </div>
           <div>
-            <h2 className="settings-card-title">Login Alerts</h2>
-            <p className="settings-card-desc">Get notified of new login attempts</p>
+            <h2 className={styles.settingsCardTitle}>{t.loginAlerts.title}</h2>
+            <p className={styles.settingsCardDesc}>{t.loginAlerts.desc}</p>
           </div>
         </div>
 
-        <div className="settings-card-body">
-          <div className="settings-field">
-            <label htmlFor="alerts" className="settings-toggle-label">
+        <div className={styles.settingsCardBody}>
+          <div className={styles.settingsField}>
+            <label htmlFor="alerts" className={styles.settingsToggleLabel}>
               <input
                 id="alerts"
                 type="checkbox"
                 checked={draft.loginAlerts}
                 onChange={(e) => setDraft({ ...draft, loginAlerts: e.target.checked })}
-                className="settings-toggle"
+                className={styles.settingsToggle}
                 disabled={!editing}
               />
-              <span>Notify me of new login attempts</span>
+              <span>{t.loginAlerts.enableLabel}</span>
             </label>
-            <p className="settings-hint">
-              {draft.loginAlerts
-                ? "You'll receive email notifications for new login attempts."
-                : "Login alerts are disabled."}
+            <p className={styles.settingsHint}>
+              {draft.loginAlerts ? t.loginAlerts.enabledHint : t.loginAlerts.disabledHint}
             </p>
           </div>
         </div>
@@ -239,28 +211,28 @@ export default function SecurityPage() {
 
       {!editing && (
         <Button onClick={() => setEditing(true)} variant="secondary" size="md">
-          Edit Security Settings
+          {t.actions.edit}
         </Button>
       )}
 
       {editing && (
-        <div className="settings-action-bar" role="group" aria-label="Save or cancel changes">
-          {isDirty && <span className="settings-dirty-indicator">Unsaved changes</span>}
-          <div className="settings-actions">
+        <div className={styles.settingsActionBar} role="group" aria-label="Save or cancel changes">
+          {isDirty && <span className={styles.settingsDirtyIndicator}>{t.actions.unsaved}</span>}
+          <div className={styles.settingsActions}>
             <Button onClick={handleCancel} variant="ghost" size="md" disabled={saving}>
               <X size={16} />
-              Cancel
+              {t.actions.cancel}
             </Button>
             <Button onClick={handleSave} size="md" disabled={saving} aria-busy={saving}>
               {saving ? (
                 <>
-                  <span className="settings-spinner" aria-hidden="true" />
-                  Saving…
+                  <span className={styles.settingsSpinner} aria-hidden="true" />
+                  {t.actions.saving}
                 </>
               ) : (
                 <>
                   <Save size={16} />
-                  Save Changes
+                  {t.actions.save}
                 </>
               )}
             </Button>
@@ -270,44 +242,44 @@ export default function SecurityPage() {
 
       {/* Password Change Modal */}
       {showPasswordModal && (
-        <div className="modal-overlay" onClick={() => setShowPasswordModal(false)}>
-          <div ref={passwordModalRef} className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <div className="modal-header">
-              <h3 className="modal-title">Change Password</h3>
+        <div className={styles.modalOverlay} onClick={() => setShowPasswordModal(false)}>
+          <div ref={passwordModalRef} className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalHeader}>
+              <h3 className={styles.modalTitle}>{t.modal.title}</h3>
               <button
                 onClick={() => setShowPasswordModal(false)}
-                className="modal-close"
-                aria-label="Close modal"
+                className={styles.modalClose}
+                aria-label={t.modal.closeLabel}
               >
                 ✕
               </button>
             </div>
 
-            <div className="modal-body">
-              <div className="modal-field">
-                <label htmlFor="new-password" className="modal-label">
-                  New Password
+            <div className={styles.modalBody}>
+              <div className={styles.modalField}>
+                <label htmlFor="new-password" className={styles.modalLabel}>
+                  {t.modal.newPasswordLabel}
                 </label>
                 <input
                   id="new-password"
                   type="password"
                   value={newPassword}
                   onChange={(e) => setNewPassword(e.target.value)}
-                  placeholder="Enter new password"
-                  className="modal-input"
+                  placeholder={t.modal.newPasswordPlaceholder}
+                  className={styles.modalInput}
                   disabled={saving}
                 />
               </div>
             </div>
 
-            <div className="modal-footer">
+            <div className={styles.modalFooter}>
               <Button
                 onClick={() => setShowPasswordModal(false)}
                 variant="ghost"
                 size="md"
                 disabled={saving}
               >
-                Cancel
+                {t.modal.cancel}
               </Button>
               <Button
                 onClick={handleChangePassword}
@@ -315,366 +287,12 @@ export default function SecurityPage() {
                 disabled={saving || !newPassword}
                 aria-busy={saving}
               >
-                {saving ? "Updating..." : "Update Password"}
+                {saving ? t.modal.updating : t.modal.update}
               </Button>
             </div>
           </div>
         </div>
       )}
-
-      <style>{`
-        .security-page {
-          display: flex;
-          flex-direction: column;
-          gap: 24px;
-        }
-
-        .settings-header {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          gap: 16px;
-        }
-
-        .settings-title {
-          font-size: 24px;
-          font-weight: 700;
-          color: #e2e8f0;
-          margin: 0 0 4px;
-        }
-
-        .settings-subtitle {
-          font-size: 14px;
-          color: #94a3b8;
-          margin: 0;
-        }
-
-        .settings-banner {
-          display: flex;
-          align-items: center;
-          gap: 12px;
-          padding: 12px 16px;
-          border-radius: 10px;
-          font-size: 13px;
-          border: 1px solid;
-          animation: slideDown 0.2s ease-out;
-        }
-
-        @keyframes slideDown {
-          from {
-            opacity: 0;
-            transform: translateY(-10px);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0);
-          }
-        }
-
-        .settings-banner-success {
-          background: rgba(16, 185, 129, 0.08);
-          border-color: rgba(16, 185, 129, 0.3);
-          color: #6ee7b7;
-        }
-
-        .settings-banner-success svg {
-          color: #10b981;
-          flex-shrink: 0;
-        }
-
-        .settings-banner-error {
-          background: rgba(239, 68, 68, 0.08);
-          border-color: rgba(239, 68, 68, 0.3);
-          color: #fca5a5;
-        }
-
-        .settings-banner-error svg {
-          color: #ef4444;
-          flex-shrink: 0;
-        }
-
-        .settings-card {
-          background: rgba(15, 23, 42, 0.6);
-          border: 1px solid rgba(148, 163, 184, 0.15);
-          border-radius: 14px;
-          overflow: hidden;
-        }
-
-        .settings-card-header {
-          display: flex;
-          align-items: flex-start;
-          gap: 12px;
-          padding: 20px 24px 16px;
-          border-bottom: 1px solid rgba(148, 163, 184, 0.1);
-        }
-
-        .settings-card-icon {
-          width: 34px;
-          height: 34px;
-          border-radius: 8px;
-          background: rgba(56, 189, 248, 0.1);
-          border: 1px solid rgba(56, 189, 248, 0.2);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          color: #38bdf8;
-          flex-shrink: 0;
-        }
-
-        .settings-card-title {
-          font-size: 14px;
-          font-weight: 600;
-          color: #e2e8f0;
-          margin: 0 0 2px;
-        }
-
-        .settings-card-desc {
-          font-size: 12px;
-          color: #64748b;
-          margin: 0;
-        }
-
-        .settings-card-body {
-          padding: 20px 24px;
-          display: flex;
-          flex-direction: column;
-          gap: 18px;
-        }
-
-        .settings-field {
-          display: flex;
-          flex-direction: column;
-          gap: 6px;
-        }
-
-        .settings-label {
-          font-size: 12px;
-          font-weight: 600;
-          color: #94a3b8;
-          text-transform: uppercase;
-          letter-spacing: 0.05em;
-        }
-
-        .settings-value {
-          font-size: 14px;
-          color: #e2e8f0;
-          margin: 0;
-          padding: 9px 0;
-        }
-
-        .settings-warning {
-          display: flex;
-          align-items: center;
-          gap: 8px;
-          font-size: 12px;
-          color: #f59e0b;
-          margin: 8px 0 0;
-          padding: 8px 12px;
-          background: rgba(245, 158, 11, 0.08);
-          border: 1px solid rgba(245, 158, 11, 0.2);
-          border-radius: 6px;
-        }
-
-        .settings-toggle-label {
-          display: flex;
-          align-items: center;
-          gap: 10px;
-          font-size: 14px;
-          color: #e2e8f0;
-          cursor: pointer;
-        }
-
-        .settings-toggle {
-          width: 18px;
-          height: 18px;
-          cursor: pointer;
-          accent-color: #38bdf8;
-        }
-
-        .settings-toggle:disabled {
-          opacity: 0.5;
-          cursor: not-allowed;
-        }
-
-        .settings-hint {
-          font-size: 12px;
-          color: #94a3b8;
-          margin: 4px 0 0;
-        }
-
-        .settings-action-bar {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          gap: 12px;
-          padding: 14px 20px;
-          /* #423: add safe-area-inset-bottom so buttons clear the home indicator */
-          padding-bottom: max(14px, calc(14px + var(--sai-bottom, 0px)));
-          background: rgba(2, 6, 23, 0.88);
-          backdrop-filter: blur(16px);
-          border: 1px solid rgba(148, 163, 184, 0.15);
-          border-radius: 12px;
-          position: sticky;
-          bottom: 24px;
-          z-index: 40;
-          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-        }
-
-        .settings-dirty-indicator {
-          font-size: 12px;
-          color: #f59e0b;
-        }
-
-        .settings-actions {
-          display: flex;
-          gap: 10px;
-          margin-left: auto;
-        }
-
-        .settings-spinner {
-          display: inline-block;
-          width: 14px;
-          height: 14px;
-          border: 2px solid rgba(255, 255, 255, 0.25);
-          border-top-color: #fff;
-          border-radius: 50%;
-          animation: spin 0.65s linear infinite;
-        }
-
-        @keyframes spin {
-          to {
-            transform: rotate(360deg);
-          }
-        }
-
-        /* Modal */
-        .modal-overlay {
-          position: fixed;
-          inset: 0;
-          background: rgba(0, 0, 0, 0.6);
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          z-index: 50;
-          backdrop-filter: blur(4px);
-        }
-
-        .modal-content {
-          background: rgba(15, 23, 42, 0.95);
-          border: 1px solid rgba(148, 163, 184, 0.2);
-          border-radius: 14px;
-          width: 100%;
-          max-width: 400px;
-          box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-          animation: slideUp 0.3s ease-out;
-        }
-
-        @keyframes slideUp {
-          from {
-            opacity: 0;
-            transform: translateY(20px);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0);
-          }
-        }
-
-        .modal-header {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          padding: 20px 24px;
-          border-bottom: 1px solid rgba(148, 163, 184, 0.1);
-        }
-
-        .modal-title {
-          font-size: 16px;
-          font-weight: 600;
-          color: #e2e8f0;
-          margin: 0;
-        }
-
-        .modal-close {
-          background: transparent;
-          border: none;
-          color: #94a3b8;
-          font-size: 20px;
-          cursor: pointer;
-          transition: color 0.2s;
-        }
-
-        .modal-close:hover {
-          color: #e2e8f0;
-        }
-
-        .modal-body {
-          padding: 20px 24px;
-        }
-
-        .modal-field {
-          display: flex;
-          flex-direction: column;
-          gap: 6px;
-        }
-
-        .modal-label {
-          font-size: 12px;
-          font-weight: 600;
-          color: #94a3b8;
-          text-transform: uppercase;
-          letter-spacing: 0.05em;
-        }
-
-        .modal-input {
-          background: rgba(15, 23, 42, 0.8);
-          border: 1px solid rgba(148, 163, 184, 0.2);
-          border-radius: 8px;
-          padding: 10px 14px;
-          min-height: 44px;
-          color: #e2e8f0;
-          font-size: 14px;
-          outline: none;
-          transition: all 0.2s;
-        }
-
-        .modal-input:focus {
-          border-color: #38bdf8;
-          box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.12);
-        }
-
-        .modal-footer {
-          display: flex;
-          gap: 10px;
-          padding: 16px 24px;
-          border-top: 1px solid rgba(148, 163, 184, 0.1);
-          justify-content: flex-end;
-        }
-
-        @media (max-width: 520px) {
-          .settings-card-header {
-            padding: 16px;
-          }
-
-          .settings-card-body {
-            padding: 16px;
-          }
-
-          .settings-action-bar {
-            flex-direction: column;
-            align-items: stretch;
-          }
-
-          .settings-actions {
-            flex-direction: column;
-            margin-left: 0;
-          }
-
-          .modal-content {
-            margin: 16px;
-          }
-        }
-      `}</style>
     </div>
   );
 }

--- a/src/app/dashboard/settings/settings.module.css
+++ b/src/app/dashboard/settings/settings.module.css
@@ -1,0 +1,372 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.settingsHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.settingsTitle {
+  font-size: 24px;
+  font-weight: 700;
+  color: #e2e8f0;
+  margin: 0 0 4px;
+}
+
+.settingsSubtitle {
+  font-size: 14px;
+  color: #94a3b8;
+  margin: 0;
+}
+
+.settingsBanner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 10px;
+  font-size: 13px;
+  border: 1px solid;
+  animation: slideDown 0.2s ease-out;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.settingsBannerSuccess {
+  background: rgba(16, 185, 129, 0.08);
+  border-color: rgba(16, 185, 129, 0.3);
+  color: #6ee7b7;
+}
+
+.settingsBannerSuccess svg {
+  color: #10b981;
+  flex-shrink: 0;
+}
+
+.settingsBannerError {
+  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+}
+
+.settingsBannerError svg {
+  color: #ef4444;
+  flex-shrink: 0;
+}
+
+.settingsCard {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.settingsCardHeader {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.settingsCardIcon {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  background: rgba(56, 189, 248, 0.1);
+  border: 1px solid rgba(56, 189, 248, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #38bdf8;
+  flex-shrink: 0;
+}
+
+.settingsCardTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: #e2e8f0;
+  margin: 0 0 2px;
+}
+
+.settingsCardDesc {
+  font-size: 12px;
+  color: #64748b;
+  margin: 0;
+}
+
+.settingsCardBody {
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.settingsField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settingsLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.settingsValue {
+  font-size: 14px;
+  color: #e2e8f0;
+  margin: 0;
+  padding: 9px 0;
+}
+
+.settingsSelect {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 8px;
+  padding: 10px 14px;
+  color: #e2e8f0;
+  font-size: 14px;
+  outline: none;
+  transition: all 0.2s;
+}
+
+.settingsSelect:focus {
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.12);
+}
+
+.settingsSelect option {
+  background: #0f172a;
+  color: #e2e8f0;
+}
+
+.settingsWarning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: #f59e0b;
+  margin: 8px 0 0;
+  padding: 8px 12px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  border-radius: 6px;
+}
+
+.settingsToggleLabel {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 14px;
+  color: #e2e8f0;
+  cursor: pointer;
+}
+
+.settingsToggle {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  accent-color: #38bdf8;
+}
+
+.settingsToggle:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.settingsHint {
+  font-size: 12px;
+  color: #94a3b8;
+  margin: 4px 0 0;
+}
+
+.settingsActionBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 20px;
+  /* #423: add safe-area-inset-bottom so buttons clear the home indicator */
+  padding-bottom: max(14px, calc(14px + var(--sai-bottom, 0px)));
+  background: rgba(2, 6, 23, 0.88);
+  backdrop-filter: blur(16px);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 12px;
+  position: sticky;
+  bottom: 24px;
+  z-index: 40;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.settingsDirtyIndicator {
+  font-size: 12px;
+  color: #f59e0b;
+}
+
+.settingsActions {
+  display: flex;
+  gap: 10px;
+  margin-left: auto;
+}
+
+.settingsSpinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.65s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Modal (security password-change dialog) */
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  backdrop-filter: blur(4px);
+}
+
+.modalContent {
+  background: rgba(15, 23, 42, 0.95);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 14px;
+  width: 100%;
+  max-width: 400px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  animation: slideUp 0.3s ease-out;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.modalTitle {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e2e8f0;
+  margin: 0;
+}
+
+.modalClose {
+  background: transparent;
+  border: none;
+  color: #94a3b8;
+  font-size: 20px;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.modalClose:hover {
+  color: #e2e8f0;
+}
+
+.modalBody {
+  padding: 20px 24px;
+}
+
+.modalField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.modalLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: #94a3b8;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.modalInput {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 8px;
+  padding: 10px 14px;
+  min-height: 44px;
+  color: #e2e8f0;
+  font-size: 14px;
+  outline: none;
+  transition: all 0.2s;
+}
+
+.modalInput:focus {
+  border-color: #38bdf8;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.12);
+}
+
+.modalFooter {
+  display: flex;
+  gap: 10px;
+  padding: 16px 24px;
+  border-top: 1px solid rgba(148, 163, 184, 0.1);
+  justify-content: flex-end;
+}
+
+@media (max-width: 520px) {
+  .settingsCardHeader {
+    padding: 16px;
+  }
+
+  .settingsCardBody {
+    padding: 16px;
+  }
+
+  .settingsActionBar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .settingsActions {
+    flex-direction: column;
+    margin-left: 0;
+  }
+
+  .modalContent {
+    margin: 16px;
+  }
+}

--- a/src/components/settings/OnboardingSettings.tsx
+++ b/src/components/settings/OnboardingSettings.tsx
@@ -8,6 +8,7 @@ import { clearOnboardingState, loadOnboardingState as getOnboardingState } from 
 import { logger } from '@/lib/logger';
 import { formatDate } from '@/lib/formatters';
 import { STORAGE_KEYS } from '@/lib/storage-keys';
+import { useI18n } from '@/contexts/I18nContext';
 
 interface OnboardingState {
   completed: boolean;
@@ -19,6 +20,8 @@ export default function OnboardingSettings() {
   const [onboardingState, setOnboardingState] = useState<OnboardingState | null>(null);
   const [isResetting, setIsResetting] = useState(false);
   const { pushToast } = useToast();
+  const { messages } = useI18n();
+  const t = messages.settings.onboarding;
 
   const fetchOnboardingState = useCallback(() => {
     try {
@@ -34,7 +37,7 @@ export default function OnboardingSettings() {
   }, [fetchOnboardingState]);
 
   const handleResetOnboarding = async () => {
-    if (!confirm('Are you sure you want to reset the onboarding process? This will allow you to go through the setup again.')) {
+    if (!confirm(t.confirmReset)) {
       return;
     }
 
@@ -57,8 +60,8 @@ export default function OnboardingSettings() {
     } catch (error) {
       logger.error('Failed to reset onboarding:', error);
       pushToast({
-        title: 'Failed to reset onboarding',
-        description: 'Please try again.',
+        title: t.toastFailTitle,
+        description: t.toastFailDesc,
         variant: 'error',
       });
     } finally {
@@ -76,36 +79,38 @@ export default function OnboardingSettings() {
       <div className="space-y-6">
         {/* Header */}
         <div>
-          <h3 className="text-lg font-semibold text-white mb-2">Onboarding Settings</h3>
+          <h3 className="text-lg font-semibold text-white mb-2">{t.title}</h3>
           <p className="text-slate-400 text-sm">
-            Manage your onboarding progress and review setup steps.
+            {t.subtitle}
           </p>
         </div>
 
         {/* Current Status */}
         <div className="p-4 bg-white/5 rounded-lg">
           <div className="flex items-center justify-between mb-3">
-            <span className="text-sm font-medium text-slate-300">Status</span>
+            <span className="text-sm font-medium text-slate-300">{t.statusLabel}</span>
             <span className={`px-2 py-1 text-xs font-medium rounded-full ${
-              onboardingState?.completed 
-                ? 'bg-green-500/20 text-green-400' 
+              onboardingState?.completed
+                ? 'bg-green-500/20 text-green-400'
                 : 'bg-yellow-500/20 text-yellow-400'
             }`}>
-              {onboardingState?.completed ? 'Completed' : 'In Progress'}
+              {onboardingState?.completed ? t.statusCompleted : t.statusInProgress}
             </span>
           </div>
-          
+
           {onboardingState && (
             <div className="space-y-2 text-sm">
               {onboardingState.lastStep !== undefined && (
                 <div className="flex justify-between">
-                  <span className="text-slate-400">Last Step:</span>
-                  <span className="text-white">Step {onboardingState.lastStep + 1}</span>
+                  <span className="text-slate-400">{t.lastStepLabel}</span>
+                  <span className="text-white">
+                    {t.lastStepValue.replace('{{step}}', String(onboardingState.lastStep + 1))}
+                  </span>
                 </div>
               )}
               {onboardingState.timestamp && (
                 <div className="flex justify-between">
-                  <span className="text-slate-400">Completed:</span>
+                  <span className="text-slate-400">{t.completedLabel}</span>
                   <span className="text-white">
                     {formatDate(new Date(onboardingState.timestamp))}
                   </span>
@@ -118,11 +123,11 @@ export default function OnboardingSettings() {
         {/* Actions */}
         <div className="space-y-3">
           <div>
-            <h4 className="text-sm font-medium text-white mb-2">Actions</h4>
+            <h4 className="text-sm font-medium text-white mb-2">{t.actionsTitle}</h4>
             <div className="space-y-2">
               {onboardingState?.completed && (
-                <Button 
-                  variant="secondary" 
+                <Button
+                  variant="secondary"
                   onClick={handleReviewOnboarding}
                   className="w-full justify-start"
                 >
@@ -130,11 +135,11 @@ export default function OnboardingSettings() {
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
                   </svg>
-                  Review Onboarding
+                  {t.reviewAction}
                 </Button>
               )}
-              
-              <Button 
+
+              <Button
                 onClick={handleResetOnboarding}
                 disabled={isResetting}
                 className="w-full justify-start"
@@ -145,14 +150,14 @@ export default function OnboardingSettings() {
                       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                       <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                     </svg>
-                    Resetting...
+                    {t.resetting}
                   </span>
                 ) : (
                   <span className="flex items-center">
                     <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
                     </svg>
-                    Reset Onboarding
+                    {t.resetAction}
                   </span>
                 )}
               </Button>
@@ -167,10 +172,10 @@ export default function OnboardingSettings() {
               </svg>
               <div className="text-xs text-slate-300">
                 <p className="mb-1">
-                  <strong>Review Onboarding:</strong> Go through the setup steps again without changing your current settings.
+                  <strong>{t.helpReviewLabel}</strong> {t.helpReviewDesc}
                 </p>
                 <p>
-                  <strong>Reset Onboarding:</strong> Clear all onboarding progress and start fresh from the beginning.
+                  <strong>{t.helpResetLabel}</strong> {t.helpResetDesc}
                 </p>
               </div>
             </div>

--- a/src/components/settings/ThemeSettings.tsx
+++ b/src/components/settings/ThemeSettings.tsx
@@ -3,26 +3,29 @@
 import { useTheme } from "@/contexts/ThemeProvider";
 import { Sun, Moon, Monitor } from "lucide-react";
 import type { ThemeMode } from "@/contexts/ThemeProvider";
-
-const THEME_OPTIONS: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
-  { value: "light", label: "Light", icon: Sun },
-  { value: "dark", label: "Dark", icon: Moon },
-  { value: "system", label: "System", icon: Monitor },
-];
+import { useI18n } from "@/contexts/I18nContext";
 
 export function ThemeSettings() {
   const { theme, setTheme, mounted } = useTheme();
+  const { messages } = useI18n();
+  const t = messages.settings;
+
+  const THEME_OPTIONS: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
+    { value: "light", label: t.preferences.appearance.light, icon: Sun },
+    { value: "dark", label: t.preferences.appearance.dark, icon: Moon },
+    { value: "system", label: t.preferences.appearance.system, icon: Monitor },
+  ];
 
   if (!mounted) {
     return (
-      <div className="flex items-center gap-1.5 rounded-xl bg-surface-elevated p-1" role="radiogroup" aria-label="Theme selection">
+      <div className="flex items-center gap-1.5 rounded-xl bg-surface-elevated p-1" role="radiogroup" aria-label={t.themeSelector.ariaLabel}>
         <div className="min-h-[44px] w-full" />
       </div>
     );
   }
 
   return (
-    <div className="flex items-center gap-1.5 rounded-xl bg-surface-elevated p-1" role="radiogroup" aria-label="Theme selection">
+    <div className="flex items-center gap-1.5 rounded-xl bg-surface-elevated p-1" role="radiogroup" aria-label={t.themeSelector.ariaLabel}>
       {THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
         <button
           key={value}

--- a/src/components/strategies/StrategySelector.tsx
+++ b/src/components/strategies/StrategySelector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useReducer, useRef } from "react";
+import { useEffect, useMemo, useReducer, useRef } from "react";
 import Link from "next/link";
 import {
   TrendingUp,
@@ -17,13 +17,21 @@ import {
   StrategyCard,
   StrategyKind,
   StrategyPreference,
-  getStrategy,
   loadStoredPreference,
   saveStoredPreference,
 } from "@/lib/strategies";
 import { apiRequest, ApiRequestError } from "@/lib/api-client";
 import { formatApyRange } from "@/lib/formatters";
 import { Button } from "@/components/ui/Button";
+import { useI18n } from "@/contexts/I18nContext";
+import type { AppMessages } from "@/lib/i18n/messages";
+
+type StrategiesMessages = AppMessages["settings"]["strategies"];
+
+function localizeStrategy(strategy: StrategyCard, t: StrategiesMessages): StrategyCard {
+  const copy = t.cards[strategy.kind];
+  return { ...strategy, ...copy };
+}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -121,6 +129,7 @@ interface StrategyCardProps {
   isSelected: boolean;
   onSelect: (kind: StrategyKind) => void;
   saving: boolean;
+  t: StrategiesMessages;
 }
 
 function StrategyCardView({
@@ -128,6 +137,7 @@ function StrategyCardView({
   isSelected,
   onSelect,
   saving,
+  t,
 }: StrategyCardProps) {
   // Spec: selected state → border-2 primary + background tint
   const cardClass = isSelected
@@ -142,7 +152,7 @@ function StrategyCardView({
       {isSelected && (
         <span className="absolute top-4 right-4 flex items-center gap-1 rounded-full bg-sky-500/20 px-2 py-0.5 text-xs font-semibold text-sky-400">
           <CheckCircle2 size={11} aria-hidden />
-          Current
+          {t.currentBadge}
         </span>
       )}
 
@@ -187,7 +197,7 @@ function StrategyCardView({
             : "bg-sky-500 text-white hover:bg-sky-400 shadow-lg shadow-sky-500/20 disabled:opacity-50"
         }`}
       >
-        {isSelected ? "Active strategy" : strategy.primaryAction}
+        {isSelected ? t.activeStrategyButton : strategy.primaryAction}
       </button>
     </article>
   );
@@ -196,25 +206,25 @@ function StrategyCardView({
 // ─── Confirmation modal ───────────────────────────────────────────────────────
 
 interface ConfirmModalProps {
-  from: StrategyKind | null;
-  to: StrategyKind;
+  fromStrategy: StrategyCard | null;
+  toStrategy: StrategyCard;
   saveStatus: SaveStatus;
   errorMessage: string | null;
+  t: StrategiesMessages;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
 function ConfirmModal({
-  from,
-  to,
+  fromStrategy,
+  toStrategy,
   saveStatus,
   errorMessage,
+  t,
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
   const confirmRef = useRef<HTMLButtonElement>(null);
-  const toStrategy = getStrategy(to);
-  const fromStrategy = from ? getStrategy(from) : null;
   const saving = saveStatus === "saving";
 
   // Trap focus and handle Escape
@@ -248,7 +258,7 @@ function ConfirmModal({
           type="button"
           onClick={onCancel}
           disabled={saving}
-          aria-label="Cancel"
+          aria-label={t.confirmModal.closeLabel}
           className="absolute right-4 top-4 rounded-lg p-1.5 text-slate-500 hover:text-slate-300 hover:bg-white/5 transition-colors disabled:opacity-40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
         >
           <X size={16} aria-hidden />
@@ -260,21 +270,24 @@ function ConfirmModal({
         </div>
 
         <h2 id="confirm-modal-title" className="mb-1 text-base font-bold text-slate-100">
-          Confirm strategy change
+          {t.confirmModal.title}
         </h2>
 
         {/* From → To */}
         <p className="mb-4 text-sm text-slate-400">
           {fromStrategy ? (
             <>
-              Switching from{" "}
-              <span className="font-semibold text-slate-200">{fromStrategy.title}</span> to{" "}
-              <span className="font-semibold text-slate-200">{toStrategy.title}</span>.
+              {t.confirmModal.switchingFrom.split("{{from}}")[0]}
+              <span className="font-semibold text-slate-200">{fromStrategy.title}</span>
+              {t.confirmModal.switchingFrom.split("{{from}}")[1].split("{{to}}")[0]}
+              <span className="font-semibold text-slate-200">{toStrategy.title}</span>
+              {t.confirmModal.switchingFrom.split("{{to}}")[1]}
             </>
           ) : (
             <>
-              Setting your strategy to{" "}
-              <span className="font-semibold text-slate-200">{toStrategy.title}</span>.
+              {t.confirmModal.settingTo.split("{{to}}")[0]}
+              <span className="font-semibold text-slate-200">{toStrategy.title}</span>
+              {t.confirmModal.settingTo.split("{{to}}")[1]}
             </>
           )}
         </p>
@@ -282,13 +295,13 @@ function ConfirmModal({
         {/* Risk/APY summary */}
         <div className="mb-5 rounded-xl border border-white/8 bg-white/3 p-4 space-y-2 text-sm">
           <div className="flex justify-between">
-            <span className="text-slate-500">APY range</span>
+            <span className="text-slate-500">{t.comparison.apyRangeLabel}</span>
             <span className="font-semibold text-slate-200 tabular-nums">
               {formatApyRange(toStrategy.apyMin, toStrategy.apyMax)}
             </span>
           </div>
           <div className="flex justify-between">
-            <span className="text-slate-500">Risk level</span>
+            <span className="text-slate-500">{t.comparison.riskLevelLabel}</span>
             <span
               className={`rounded-full px-2 py-0.5 text-xs font-semibold ${riskBadgeClass(toStrategy.riskTier)}`}
             >
@@ -297,10 +310,7 @@ function ConfirmModal({
           </div>
         </div>
 
-        <p className="mb-5 text-xs text-slate-500">
-          Active positions will be rebalanced on the next scheduled cycle. This
-          change does not trigger an immediate on-chain transaction.
-        </p>
+        <p className="mb-5 text-xs text-slate-500">{t.confirmModal.note}</p>
 
         {/* Error */}
         {errorMessage && (
@@ -320,7 +330,7 @@ function ConfirmModal({
             disabled={saving}
             className="flex-1 rounded-lg border border-white/15 py-2.5 text-sm font-medium text-slate-400 hover:text-white hover:border-white/30 transition-colors disabled:opacity-40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-sky-500"
           >
-            Cancel
+            {t.confirmModal.cancel}
           </button>
           <button
             ref={confirmRef}
@@ -332,10 +342,10 @@ function ConfirmModal({
             {saving ? (
               <>
                 <Loader2 size={14} className="animate-spin" aria-hidden />
-                Saving…
+                {t.confirmModal.saving}
               </>
             ) : (
-              "Confirm change"
+              t.confirmModal.confirm
             )}
           </button>
         </div>
@@ -346,14 +356,22 @@ function ConfirmModal({
 
 // ─── Comparison table ─────────────────────────────────────────────────────────
 
-function ComparisonTable({ current }: { current: StrategyKind | null }) {
+function ComparisonTable({
+  current,
+  strategies,
+  t,
+}: {
+  current: StrategyKind | null;
+  strategies: StrategyCard[];
+  t: StrategiesMessages;
+}) {
   const highlight = (kind: StrategyKind) =>
     kind === current ? "bg-sky-500/8 font-semibold text-slate-100" : "text-slate-400";
 
   return (
-    <section aria-label="Strategy comparison">
+    <section aria-label={t.comparison.title}>
       <h2 className="mb-3 text-base font-semibold text-slate-200">
-        Strategy comparison
+        {t.comparison.title}
       </h2>
 
       {/* Spec: mobile horizontally scrollable; sticky header on desktop */}
@@ -365,9 +383,9 @@ function ComparisonTable({ current }: { current: StrategyKind | null }) {
                 scope="col"
                 className="px-4 py-3 text-left text-xs font-semibold text-slate-500 uppercase tracking-wider w-[140px]"
               >
-                Feature
+                {t.comparison.featureHeader}
               </th>
-              {STRATEGIES.map((s) => (
+              {strategies.map((s) => (
                 <th
                   key={s.kind}
                   scope="col"
@@ -380,7 +398,7 @@ function ComparisonTable({ current }: { current: StrategyKind | null }) {
                   {s.title}
                   {s.kind === current && (
                     <span className="ml-1.5 inline-flex items-center rounded-full bg-sky-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-sky-400 normal-case tracking-normal">
-                      active
+                      {t.comparison.activeBadge}
                     </span>
                   )}
                 </th>
@@ -413,7 +431,8 @@ function ComparisonTable({ current }: { current: StrategyKind | null }) {
 
 // ─── Success toast ────────────────────────────────────────────────────────────
 
-function SuccessBanner({ strategy }: { strategy: StrategyKind }) {
+function SuccessBanner({ strategy, t }: { strategy: StrategyCard; t: StrategiesMessages }) {
+  const [before, after] = t.success.updated.split("{{strategy}}");
   return (
     <div
       role="status"
@@ -422,9 +441,9 @@ function SuccessBanner({ strategy }: { strategy: StrategyKind }) {
     >
       <CheckCircle2 size={16} className="shrink-0" aria-hidden />
       <span>
-        Strategy updated to{" "}
-        <span className="font-semibold">{getStrategy(strategy).title}</span>. Rebalancing
-        will apply on the next scheduled cycle.
+        {before}
+        <span className="font-semibold">{strategy.title}</span>
+        {after}
       </span>
     </div>
   );
@@ -462,6 +481,14 @@ function SkeletonCards() {
 
 export function StrategySelector() {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+  const { messages } = useI18n();
+  const t = messages.settings.strategies;
+  const localizedStrategies = useMemo(
+    () => STRATEGIES.map((strategy) => localizeStrategy(strategy, t)),
+    [t],
+  );
+  const getLocalizedStrategy = (kind: StrategyKind) =>
+    localizedStrategies.find((s) => s.kind === kind)!;
 
   // Load preference on mount — client localStorage first, then API
   useEffect(() => {
@@ -521,35 +548,33 @@ export function StrategySelector() {
         {/* Page header */}
         <div className="mb-8">
           <p className="text-xs font-semibold uppercase tracking-widest text-sky-400 mb-1">
-            Settings
+            {t.eyebrow}
           </p>
-          <h1 className="text-2xl font-bold text-slate-100">Choose your strategy</h1>
-          <p className="mt-1.5 text-sm text-slate-500">
-            Select the risk/APY profile that matches your goals. Your active positions
-            will rebalance on the next scheduled cycle.
-          </p>
+          <h1 className="text-2xl font-bold text-slate-100">{t.title}</h1>
+          <p className="mt-1.5 text-sm text-slate-500">{t.description}</p>
         </div>
 
         {/* Success banner */}
         {saveStatus === "success" && current && (
           <div className="mb-6">
-            <SuccessBanner strategy={current} />
+            <SuccessBanner strategy={getLocalizedStrategy(current)} t={t} />
           </div>
         )}
 
         {/* Strategy cards — Spec: 3 cards with equal visual weight */}
-        <section aria-label="Strategy options" className="mb-10">
+        <section aria-label={t.title} className="mb-10">
           {loadingInitial ? (
             <SkeletonCards />
           ) : (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-              {STRATEGIES.map((strategy) => (
+              {localizedStrategies.map((strategy) => (
                 <StrategyCardView
                   key={strategy.kind}
                   strategy={strategy}
                   isSelected={strategy.kind === current}
                   onSelect={handleSelect}
                   saving={saveStatus === "saving"}
+                  t={t}
                 />
               ))}
             </div>
@@ -558,14 +583,14 @@ export function StrategySelector() {
 
         {/* Comparison table */}
         <div className="mb-10">
-          <ComparisonTable current={current} />
+          <ComparisonTable current={current} strategies={localizedStrategies} t={t} />
         </div>
 
         {/* Dashboard link */}
         <div className="flex justify-center">
           <Link href="/dashboard">
             <Button variant="ghost" size="sm" className="text-slate-500">
-              ← Back to portfolio
+              ← {t.backToPortfolio}
             </Button>
           </Link>
         </div>
@@ -574,10 +599,11 @@ export function StrategySelector() {
       {/* Confirmation modal */}
       {pending && (
         <ConfirmModal
-          from={current}
-          to={pending}
+          fromStrategy={current ? getLocalizedStrategy(current) : null}
+          toStrategy={getLocalizedStrategy(pending)}
           saveStatus={saveStatus}
           errorMessage={errorMessage}
+          t={t}
           onConfirm={handleConfirm}
           onCancel={handleCancel}
         />

--- a/src/hooks/useSettingsForm.test.ts
+++ b/src/hooks/useSettingsForm.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { renderHook, act } from "@/test-utils/render-hook";
+import { useSettingsForm } from "./useSettingsForm";
+
+interface Draft {
+  enabled: boolean;
+}
+
+function flush(ms = 0) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("useSettingsForm", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("loads defaults when storage is empty, then clears pageLoading", async () => {
+    const { result } = renderHook(() =>
+      useSettingsForm<Draft>("test-key", { enabled: false }, { auditSection: "test" }),
+    );
+
+    assert.equal(result.current.pageLoading, true);
+
+    await act(async () => {
+      await flush(650);
+    });
+
+    assert.equal(result.current.pageLoading, false);
+    assert.deepEqual(result.current.saved, { enabled: false });
+  });
+
+  it("hydrates saved/draft from localStorage", async () => {
+    localStorage.setItem("test-key", JSON.stringify({ enabled: true }));
+
+    const { result } = renderHook(() =>
+      useSettingsForm<Draft>("test-key", { enabled: false }, { auditSection: "test" }),
+    );
+
+    await act(async () => {
+      await flush(650);
+    });
+
+    assert.deepEqual(result.current.saved, { enabled: true });
+    assert.deepEqual(result.current.draft, { enabled: true });
+  });
+
+  it("tracks isDirty and persists on handleSave", async () => {
+    const { result } = renderHook(() =>
+      useSettingsForm<Draft>("test-key", { enabled: false }, { auditSection: "test", saveDelayMs: 0 }),
+    );
+
+    await act(async () => {
+      await flush(650);
+    });
+
+    act(() => {
+      result.current.setDraft({ enabled: true });
+    });
+    assert.equal(result.current.isDirty, true);
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    assert.equal(result.current.isDirty, false);
+    assert.equal(result.current.status, "success");
+    assert.deepEqual(JSON.parse(localStorage.getItem("test-key")!), { enabled: true });
+  });
+
+  it("handleCancel reverts draft to saved", async () => {
+    const { result } = renderHook(() =>
+      useSettingsForm<Draft>("test-key", { enabled: false }, { auditSection: "test" }),
+    );
+
+    await act(async () => {
+      await flush(650);
+    });
+
+    act(() => {
+      result.current.setDraft({ enabled: true });
+      result.current.setEditing(true);
+    });
+
+    act(() => {
+      result.current.handleCancel();
+    });
+
+    assert.deepEqual(result.current.draft, { enabled: false });
+    assert.equal(result.current.editing, false);
+  });
+
+  it("aborts the save and sets error status when validate throws", async () => {
+    const { result } = renderHook(() =>
+      useSettingsForm<Draft>("test-key", { enabled: false }, {
+        auditSection: "test",
+        saveDelayMs: 0,
+        validate: () => {
+          throw new Error("blocked");
+        },
+      }),
+    );
+
+    await act(async () => {
+      await flush(650);
+    });
+
+    act(() => {
+      result.current.setDraft({ enabled: true });
+    });
+
+    await act(async () => {
+      await result.current.handleSave();
+    });
+
+    assert.equal(result.current.status, "error");
+    assert.equal(localStorage.getItem("test-key"), null);
+  });
+});

--- a/src/hooks/useSettingsForm.ts
+++ b/src/hooks/useSettingsForm.ts
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { mockAuditService } from "@/lib/mock-audit";
+
+type SaveStatus = "idle" | "success" | "error";
+
+interface UseSettingsFormOptions<T> {
+  auditSection: string;
+  loadDelayMs?: number;
+  saveDelayMs?: number;
+  statusResetMs?: number;
+  /** Runs after the mocked save delay, before persisting. Throw to abort the save. */
+  validate?: (draft: T) => void;
+  onSaveSuccess?: (saved: T) => void;
+  onSaveError?: (error: unknown) => void;
+}
+
+export function useSettingsForm<T>(
+  storageKey: string,
+  defaultValue: T,
+  options: UseSettingsFormOptions<T>,
+) {
+  const [saved, setSaved] = useState<T>(defaultValue);
+  const [draft, setDraft] = useState<T>(defaultValue);
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState<SaveStatus>("idle");
+  const [pageLoading, setPageLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      try {
+        const stored = localStorage.getItem(storageKey);
+        if (stored) {
+          const data = JSON.parse(stored) as T;
+          setSaved(data);
+          setDraft(data);
+        }
+      } catch {}
+      setPageLoading(false);
+    }, options.loadDelayMs ?? 600);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storageKey]);
+
+  const isDirty = JSON.stringify(draft) !== JSON.stringify(saved);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setStatus("idle");
+    try {
+      await new Promise((resolve) => setTimeout(resolve, options.saveDelayMs ?? 600));
+      options.validate?.(draft);
+      localStorage.setItem(storageKey, JSON.stringify(draft));
+      setSaved(draft);
+      setStatus("success");
+      setEditing(false);
+      mockAuditService.logEvent("settings_change", {
+        section: options.auditSection,
+        changes: draft,
+      });
+      options.onSaveSuccess?.(draft);
+      setTimeout(() => setStatus("idle"), options.statusResetMs ?? 3000);
+    } catch (error) {
+      setStatus("error");
+      options.onSaveError?.(error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setDraft(saved);
+    setEditing(false);
+    setStatus("idle");
+  };
+
+  return {
+    saved,
+    setSaved,
+    draft,
+    setDraft,
+    editing,
+    setEditing,
+    saving,
+    setSaving,
+    status,
+    setStatus,
+    pageLoading,
+    isDirty,
+    handleSave,
+    handleCancel,
+  };
+}

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -300,6 +300,109 @@ export interface AppMessages {
         failDesc: string;
       };
     };
+    security: {
+      title: string;
+      subtitle: string;
+      banner: {
+        success: string;
+        error: string;
+      };
+      password: {
+        title: string;
+        desc: string;
+        lastChangedLabel: string;
+        daysAgoSuffix: string;
+        warning: string;
+        changeAction: string;
+      };
+      twoFactor: {
+        title: string;
+        desc: string;
+        enableLabel: string;
+        enabledHint: string;
+        disabledHint: string;
+      };
+      loginAlerts: {
+        title: string;
+        desc: string;
+        enableLabel: string;
+        enabledHint: string;
+        disabledHint: string;
+      };
+      actions: {
+        edit: string;
+        unsaved: string;
+        cancel: string;
+        save: string;
+        saving: string;
+      };
+      modal: {
+        title: string;
+        closeLabel: string;
+        newPasswordLabel: string;
+        newPasswordPlaceholder: string;
+        cancel: string;
+        updating: string;
+        update: string;
+      };
+    };
+    strategies: {
+      eyebrow: string;
+      title: string;
+      description: string;
+      backToPortfolio: string;
+      currentBadge: string;
+      activeStrategyButton: string;
+      comparison: {
+        title: string;
+        featureHeader: string;
+        activeBadge: string;
+        apyRangeLabel: string;
+        riskLevelLabel: string;
+      };
+      success: {
+        updated: string;
+      };
+      confirmModal: {
+        title: string;
+        switchingFrom: string;
+        settingTo: string;
+        note: string;
+        cancel: string;
+        confirm: string;
+        saving: string;
+        closeLabel: string;
+      };
+      cards: {
+        conservative: { title: string; riskLabel: string; description: string; primaryAction: string };
+        balanced: { title: string; riskLabel: string; description: string; primaryAction: string };
+        growth: { title: string; riskLabel: string; description: string; primaryAction: string };
+      };
+    };
+    onboarding: {
+      title: string;
+      subtitle: string;
+      statusLabel: string;
+      statusCompleted: string;
+      statusInProgress: string;
+      lastStepLabel: string;
+      lastStepValue: string;
+      completedLabel: string;
+      actionsTitle: string;
+      reviewAction: string;
+      resetAction: string;
+      resetting: string;
+      confirmReset: string;
+      toastFailTitle: string;
+      toastFailDesc: string;
+      helpReviewLabel: string;
+      helpReviewDesc: string;
+      helpResetLabel: string;
+      helpResetDesc: string;
+    };
+    themeSelector: {
+      ariaLabel: string;
+    };
   };
 }
 
@@ -709,6 +812,124 @@ export const dictionaries: Record<AppLocale, AppMessages> = {
           failDesc: "This mocked failure path intentionally blocks saving while security alerts are disabled.",
         },
       },
+      security: {
+        title: "Security",
+        subtitle: "Manage your password, two-factor authentication, and login alerts.",
+        banner: {
+          success: "Security settings updated successfully",
+          error: "Failed to update security settings. Please try again.",
+        },
+        password: {
+          title: "Password",
+          desc: "Keep your account secure with a strong, regularly updated password.",
+          lastChangedLabel: "Last changed",
+          daysAgoSuffix: "days ago",
+          warning: "Your password is over 90 days old. Consider updating it.",
+          changeAction: "Change password",
+        },
+        twoFactor: {
+          title: "Two-Factor Authentication",
+          desc: "Add an extra layer of security to your account.",
+          enableLabel: "Enable two-factor authentication",
+          enabledHint: "Two-factor authentication is protecting your account.",
+          disabledHint: "Enable two-factor authentication for stronger protection.",
+        },
+        loginAlerts: {
+          title: "Login Alerts",
+          desc: "Get notified whenever a new device signs in to your account.",
+          enableLabel: "Enable login alerts",
+          enabledHint: "You'll be notified of new sign-ins.",
+          disabledHint: "You won't be notified of new sign-ins.",
+        },
+        actions: {
+          edit: "Edit Security Settings",
+          unsaved: "Unsaved changes",
+          cancel: "Cancel",
+          save: "Save Changes",
+          saving: "Saving…",
+        },
+        modal: {
+          title: "Change password",
+          closeLabel: "Close",
+          newPasswordLabel: "New password",
+          newPasswordPlaceholder: "Enter new password",
+          cancel: "Cancel",
+          updating: "Updating…",
+          update: "Update password",
+        },
+      },
+      strategies: {
+        eyebrow: "Settings",
+        title: "Choose your strategy",
+        description: "Select the risk/APY profile that matches your goals. Your active positions will rebalance on the next scheduled cycle.",
+        backToPortfolio: "Back to portfolio",
+        currentBadge: "Current",
+        activeStrategyButton: "Active strategy",
+        comparison: {
+          title: "Strategy comparison",
+          featureHeader: "Feature",
+          activeBadge: "active",
+          apyRangeLabel: "APY range",
+          riskLevelLabel: "Risk level",
+        },
+        success: {
+          updated: "Strategy updated to {{strategy}}. Rebalancing will apply on the next scheduled cycle.",
+        },
+        confirmModal: {
+          title: "Confirm strategy change",
+          switchingFrom: "Switching from {{from}} to {{to}}.",
+          settingTo: "Setting your strategy to {{to}}.",
+          note: "Active positions will be rebalanced on the next scheduled cycle. This change does not trigger an immediate on-chain transaction.",
+          cancel: "Cancel",
+          confirm: "Confirm change",
+          saving: "Saving…",
+          closeLabel: "Cancel",
+        },
+        cards: {
+          conservative: {
+            title: "Conservative",
+            riskLabel: "Low risk",
+            description: "Stablecoin lending and idle reserve coverage. Capital-preserving with predictable yield and minimal drawdown exposure.",
+            primaryAction: "Select Conservative",
+          },
+          balanced: {
+            title: "Balanced",
+            riskLabel: "Medium risk",
+            description: "Yield split across Blend lending, DEX liquidity, and a stable reserve. Best for steady growth with controlled volatility.",
+            primaryAction: "Select Balanced",
+          },
+          growth: {
+            title: "Growth",
+            riskLabel: "High risk",
+            description: "Leans into incentive programs, active rebalancing, and higher-volatility positions. Maximum upside with elevated risk.",
+            primaryAction: "Select Growth",
+          },
+        },
+      },
+      onboarding: {
+        title: "Onboarding Settings",
+        subtitle: "Manage your onboarding progress and review setup steps.",
+        statusLabel: "Status",
+        statusCompleted: "Completed",
+        statusInProgress: "In Progress",
+        lastStepLabel: "Last Step:",
+        lastStepValue: "Step {{step}}",
+        completedLabel: "Completed:",
+        actionsTitle: "Actions",
+        reviewAction: "Review Onboarding",
+        resetAction: "Reset Onboarding",
+        resetting: "Resetting...",
+        confirmReset: "Are you sure you want to reset the onboarding process? This will allow you to go through the setup again.",
+        toastFailTitle: "Failed to reset onboarding",
+        toastFailDesc: "Please try again.",
+        helpReviewLabel: "Review Onboarding:",
+        helpReviewDesc: "Go through the setup steps again without changing your current settings.",
+        helpResetLabel: "Reset Onboarding:",
+        helpResetDesc: "Clear all onboarding progress and start fresh from the beginning.",
+      },
+      themeSelector: {
+        ariaLabel: "Theme selection",
+      },
     },
   },
   fr: {
@@ -1112,6 +1333,124 @@ export const dictionaries: Record<AppLocale, AppMessages> = {
           failTitle: "Impossible d'enregistrer votre sélection actuelle",
           failDesc: "Ce chemin d'échec simulé bloque intentionnellement la sauvegarde lorsque les alertes de sécurité sont désactivées.",
         },
+      },
+      security: {
+        title: "Sécurité",
+        subtitle: "Gérez le mot de passe, l'authentification à deux facteurs et les alertes de connexion de votre compte.",
+        banner: {
+          success: "Paramètres de sécurité mis à jour avec succès",
+          error: "Échec de la mise à jour des paramètres de sécurité. Veuillez réessayer.",
+        },
+        password: {
+          title: "Mot de passe",
+          desc: "Protégez votre compte avec un mot de passe fort et régulièrement mis à jour.",
+          lastChangedLabel: "Dernière modification",
+          daysAgoSuffix: "jours",
+          warning: "Votre mot de passe date de plus de 90 jours. Pensez à le mettre à jour.",
+          changeAction: "Changer le mot de passe",
+        },
+        twoFactor: {
+          title: "Authentification à deux facteurs",
+          desc: "Ajoutez une couche de sécurité supplémentaire à votre compte.",
+          enableLabel: "Activer l'authentification à deux facteurs",
+          enabledHint: "L'authentification à deux facteurs protège votre compte.",
+          disabledHint: "Activez l'authentification à deux facteurs pour une meilleure protection.",
+        },
+        loginAlerts: {
+          title: "Alertes de connexion",
+          desc: "Soyez averti chaque fois qu'un nouvel appareil se connecte à votre compte.",
+          enableLabel: "Activer les alertes de connexion",
+          enabledHint: "Vous serez averti des nouvelles connexions.",
+          disabledHint: "Vous ne serez pas averti des nouvelles connexions.",
+        },
+        actions: {
+          edit: "Modifier les paramètres de sécurité",
+          unsaved: "Modifications non enregistrées",
+          cancel: "Annuler",
+          save: "Enregistrer les modifications",
+          saving: "Enregistrement…",
+        },
+        modal: {
+          title: "Changer le mot de passe",
+          closeLabel: "Fermer",
+          newPasswordLabel: "Nouveau mot de passe",
+          newPasswordPlaceholder: "Entrez le nouveau mot de passe",
+          cancel: "Annuler",
+          updating: "Mise à jour…",
+          update: "Mettre à jour le mot de passe",
+        },
+      },
+      strategies: {
+        eyebrow: "Paramètres",
+        title: "Choisissez votre stratégie",
+        description: "Sélectionnez le profil de risque/rendement qui correspond à vos objectifs. Vos positions actives seront rééquilibrées lors du prochain cycle programmé.",
+        backToPortfolio: "Retour au portefeuille",
+        currentBadge: "Actuelle",
+        activeStrategyButton: "Stratégie active",
+        comparison: {
+          title: "Comparaison des stratégies",
+          featureHeader: "Caractéristique",
+          activeBadge: "active",
+          apyRangeLabel: "Plage de rendement",
+          riskLevelLabel: "Niveau de risque",
+        },
+        success: {
+          updated: "Stratégie mise à jour vers {{strategy}}. Le rééquilibrage s'appliquera au prochain cycle programmé.",
+        },
+        confirmModal: {
+          title: "Confirmer le changement de stratégie",
+          switchingFrom: "Passage de {{from}} à {{to}}.",
+          settingTo: "Définition de votre stratégie sur {{to}}.",
+          note: "Les positions actives seront rééquilibrées lors du prochain cycle programmé. Ce changement ne déclenche pas de transaction on-chain immédiate.",
+          cancel: "Annuler",
+          confirm: "Confirmer le changement",
+          saving: "Enregistrement…",
+          closeLabel: "Annuler",
+        },
+        cards: {
+          conservative: {
+            title: "Conservateur",
+            riskLabel: "Risque faible",
+            description: "Prêt en stablecoins et couverture de réserve inactive. Préservation du capital avec rendement prévisible et exposition minimale aux baisses.",
+            primaryAction: "Choisir Conservateur",
+          },
+          balanced: {
+            title: "Équilibré",
+            riskLabel: "Risque moyen",
+            description: "Rendement réparti entre le prêt Blend, la liquidité DEX et une réserve stable. Idéal pour une croissance régulière avec une volatilité maîtrisée.",
+            primaryAction: "Choisir Équilibré",
+          },
+          growth: {
+            title: "Croissance",
+            riskLabel: "Risque élevé",
+            description: "Mise sur les programmes d'incitation, le rééquilibrage actif et des positions à volatilité plus élevée. Potentiel maximal avec risque accru.",
+            primaryAction: "Choisir Croissance",
+          },
+        },
+      },
+      onboarding: {
+        title: "Paramètres d'intégration",
+        subtitle: "Gérez votre progression d'intégration et révisez les étapes de configuration.",
+        statusLabel: "Statut",
+        statusCompleted: "Terminé",
+        statusInProgress: "En cours",
+        lastStepLabel: "Dernière étape :",
+        lastStepValue: "Étape {{step}}",
+        completedLabel: "Terminé :",
+        actionsTitle: "Actions",
+        reviewAction: "Revoir l'intégration",
+        resetAction: "Réinitialiser l'intégration",
+        resetting: "Réinitialisation...",
+        confirmReset: "Voulez-vous vraiment réinitialiser le processus d'intégration ? Vous pourrez suivre à nouveau la configuration.",
+        toastFailTitle: "Échec de la réinitialisation de l'intégration",
+        toastFailDesc: "Veuillez réessayer.",
+        helpReviewLabel: "Revoir l'intégration :",
+        helpReviewDesc: "Parcourez à nouveau les étapes de configuration sans modifier vos paramètres actuels.",
+        helpResetLabel: "Réinitialiser l'intégration :",
+        helpResetDesc: "Effacez toute la progression d'intégration et recommencez depuis le début.",
+      },
+      themeSelector: {
+        ariaLabel: "Sélection du thème",
       },
     },
   },


### PR DESCRIPTION
## Summary
- Extract a shared `useSettingsForm(key, initialValue)` hook encapsulating the draft/dirty/save/status state machine, and migrate `preferences/page.tsx`, `security/page.tsx`, and `notifications/page.tsx` to use it.
- Deduplicate the identical inline styles between `preferences/page.tsx` and `security/page.tsx` into a shared `settings.module.css`.
- Wire i18n into `StrategySelector.tsx` (card copy, comparison table labels, confirm modal, success banner) via new `settings.strategies` message keys (en/fr).
- Wire i18n into `OnboardingSettings.tsx` and `ThemeSettings.tsx` via new `settings.onboarding` / `settings.themeSelector` message keys (en/fr). `security/page.tsx` was already migrated to `useI18n` as part of the hook extraction.
- Bugfix found along the way: `security/page.tsx` referenced `messages.settings.security.*` throughout, but those keys were never defined in `messages.ts` (only the much smaller `settings.index.security` existed) — added the full `settings.security` type + en/fr data so the page actually renders its copy instead of crashing on undefined property access.

## Verification
- `yarn typecheck` — clean (aside from a pre-existing, unrelated parse error in `PortfolioDashboard.tsx` on `main`, not touched by this PR)
- `yarn lint` (`next lint`) — clean for all files in this PR (3 pre-existing warnings/errors in unrelated files: `login/page.tsx`, `AuditTrail.tsx`, `PortfolioDashboard.tsx`)
- `yarn test` — 551/551 passing, including new `useSettingsForm.test.ts`
- No new duplicate abstractions: `ThemeSettings.tsx` reuses the existing `settings.preferences.appearance.{light,dark,system}` keys instead of duplicating them.

Closes #648
Closes #649
Closes #647
Closes #646