### PR TITLE
fix: resolve audit issues #539, #581, #582, and #583

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,9 +63,14 @@ STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 WALLET_ENCRYPTION_KEY=
 
-# ── Auth (server-only) ──────────────────────────────────────────────────────
-# JWT secret used by middleware for cookie verification.
-AUTH_SECRET=change-me-in-production
+# ── Auth (server-only) ───────────────────────────────────────────────────────
+# NOT CURRENTLY USED. The session cookie is unsigned while auth is mock-only —
+# middleware.ts only checks that it decodes to JSON with a token + future
+# expiresAt, it does not verify a signature. This variable is reserved for the
+# real JWT signing/verification step described in src/lib/auth-constants.ts
+# ("Production-Ready httpOnly Cookie Flow"); wire it up before any real backend
+# auth integration. See docs/env.md for details.
+# AUTH_SECRET=
 
 # ── Backend API (server-only, optional) ─────────────────────────────────────
 # Uses demo data if NEUROWEALTH_API_BASE_URL is not set.

--- a/docs/env.md
+++ b/docs/env.md
@@ -50,11 +50,19 @@ platform's secret store (Vercel environment variables, Railway secrets, etc.).
 | `NEUROWEALTH_PORTFOLIO_PATH` | No | `/portfolio/overview` | Backend path for portfolio data |
 | `NEUROWEALTH_TRANSACTIONS_PATH` | No | `/transactions` | Backend path for transaction submission |
 | `NEUROWEALTH_STRATEGY_PATH` | No | `/strategy/preference` | Backend path for strategy preference reads and writes |
-| `AUTH_SECRET` | Production | — | Secret used by auth utilities for session signing |
 
 `NEUROWEALTH_API_BASE_URL` is the primary gate. When it is not set, every route handler
 falls back to demo data automatically — no other configuration change is needed for local
 development or PR previews.
+
+**`AUTH_SECRET` is not currently used anywhere in this codebase.** The session cookie
+(`nw_session`) is intentionally unsigned while auth is mock-only: `middleware.ts` only
+checks that the cookie decodes to JSON with a `token` string and a future `expiresAt` — it
+does not verify a signature, so it is not a substitute for real authentication. Wiring
+`AUTH_SECRET` into real JWT signing/verification is part of the "Production-Ready httpOnly
+Cookie Flow" already documented in `src/lib/auth-constants.ts`, and should land before any
+real backend auth integration. Until then, treat every route guard here as a UX redirect,
+not a security boundary.
 
 ---
 
@@ -72,7 +80,9 @@ Browser request
 The `src/lib/api-client.ts` module handles this split:
 
 - `apiRequest()` — used in browser-side client components; calls Next.js `/api/*` routes,
-  authenticated via the httpOnly session cookie (`nw_session`).
+  authenticated via the `nw_session` cookie. Note: this cookie is **not** currently
+  `httpOnly` and carries no signature (see the `AUTH_SECRET` note above) — it is set by
+  client-side JS in `AuthContext.tsx` for the mock auth flow.
 - `createServerApiClient()` — used inside Next.js route handlers; calls the real backend
   and automatically injects the `Authorization` header.
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -7,6 +7,16 @@ import {
   POST_SIGN_IN_PATH,
 } from "./src/lib/auth-constants";
 
+/**
+ * Checks cookie shape and expiry only — no signature verification.
+ *
+ * This is intentionally deferred while auth is mock-only (see the "Production-
+ * Ready httpOnly Cookie Flow" notes on SESSION_COOKIE_NAME in auth-constants.ts
+ * and the AUTH_SECRET note in docs/env.md). Because the cookie is set by
+ * client-side JS with no signature, it does not prove the session is genuine —
+ * treat this guard as a UX redirect, not a security boundary, until real JWT
+ * signing/verification is wired in ahead of backend auth integration.
+ */
 export function isSessionCookieValid(rawCookie: string | undefined): boolean {
   if (!rawCookie) return false;
 

--- a/src/components/dashboard/PortfolioDashboard.tsx
+++ b/src/components/dashboard/PortfolioDashboard.tsx
@@ -243,6 +243,7 @@ export function PortfolioDashboard() {
           helper: portfolio.summary.strategyDescription,
           tone: "default",
         },
+      ]
     : [];
 
   const allocationData = useMemo(() => {

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -30,6 +30,13 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+/**
+ * Writes an unsigned, non-httpOnly session cookie so `middleware.ts` (Edge
+ * runtime) can read it without a round trip. This is a mock-auth-only
+ * shortcut — it does not prove the session is genuine, since any client-side
+ * JS can fabricate the same shape. See the AUTH_SECRET note in docs/env.md
+ * for the real signing flow this should use ahead of backend auth integration.
+ */
 function setSessionCookie(session: AuthSession) {
   if (typeof window === "undefined") return;
   const cookieValue = encodeURIComponent(

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -10,8 +10,10 @@
  * ── Auth contract ─────────────────────────────────────────────────────────────
  *
  * Browser → Next.js /api/* routes
- *   Authenticated via the httpOnly session cookie (nw_session) set at sign-in.
- *   No explicit Authorization header is required from the browser.
+ *   Authenticated via the session cookie (nw_session) set at sign-in. Note this
+ *   cookie is not httpOnly and is unsigned while auth is mock-only — see the
+ *   AUTH_SECRET note in docs/env.md. No explicit Authorization header is
+ *   required from the browser.
  *
  * Next.js server → Real backend (NEUROWEALTH_API_BASE_URL)
  *   All proxied requests must include:

--- a/src/lib/routeMetadata.test.ts
+++ b/src/lib/routeMetadata.test.ts
@@ -111,6 +111,35 @@ test("routeMetadata covers docs routes", () => {
   assert.deepEqual(missing, [], `Docs routes missing metadata: ${missing.join(", ")}`);
 });
 
+test("routeMetadata covers every /demo/* route (#583)", () => {
+  const appRoot = path.join(process.cwd(), "src/app");
+  const demoRoutes = collectAppPageRoutes(path.join(appRoot, "demo"), appRoot);
+
+  assert.ok(demoRoutes.length > 0, "expected at least one /demo/* page route");
+
+  const missing = demoRoutes.filter((route) => !routeMetadata[route]);
+  assert.deepEqual(missing, [], `Demo routes missing metadata: ${missing.join(", ")}`);
+});
+
+test("/demo/* routes are marked devOnly and excluded from breadcrumbs, like dashboard/dev-errors (#583)", () => {
+  // /demo/* pages are gated in production by src/app/demo/layout.tsx, the same
+  // pattern used by /dashboard/sandbox, /dashboard/async-states, and
+  // /dashboard/dev-errors. devOnly routes are stripped from breadcrumbs (see
+  // "breadcrumbs skip devOnly routes" above) — exercising that same public
+  // behavior here confirms /demo/* carries the same devOnly gate.
+  const breadcrumbs = buildBreadcrumbsFromPath("/demo/wallet");
+  const labels = breadcrumbs.map((b) => b.label);
+  assert.ok(!labels.includes("Wallet Demo"), "/demo/wallet should not appear in breadcrumbs");
+});
+
+test("src/app/demo/layout.tsx exists and gates on NODE_ENV like sandbox/async-states/dev-errors (#583)", () => {
+  const layoutPath = path.join(process.cwd(), "src/app/demo/layout.tsx");
+  assert.ok(fs.existsSync(layoutPath), "expected src/app/demo/layout.tsx to exist");
+
+  const source = fs.readFileSync(layoutPath, "utf8");
+  assert.match(source, /NODE_ENV/, "expected demo layout to gate on NODE_ENV");
+});
+
 test("routeMetadata entries reference App Router files that exist on disk", () => {
   const appRoot = path.join(process.cwd(), "src/app");
   const knownRoutes = Object.keys(routeMetadata).filter(

--- a/src/lib/service-layer/auth-service.test.ts
+++ b/src/lib/service-layer/auth-service.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { AuthService } from "./auth-service";
+import { assertRejectsWithOriginalMessage } from "./test-helpers";
+
+function createService() {
+  // retryAttempts: 1 — business-logic errors (invalid credentials, unknown
+  // token, etc.) are thrown deterministically inside executeWithRetry's
+  // operation, so with the default retryAttempts: 3 they'd be retried
+  // pointlessly and rethrown wrapped as a generic TIMEOUT error, masking the
+  // actual message these tests assert on.
+  return new AuthService({ simulateLatency: false, simulateFailure: false, retryAttempts: 1 });
+}
+
+// ── login ─────────────────────────────────────────────────────────────────────
+
+test("login succeeds for the seeded mock user and returns a session", async () => {
+  const service = createService();
+  const response = await service.login({
+    email: "user@example.com",
+    password: "anything",
+  });
+
+  assert.equal(response.data.user.email, "user@example.com");
+  assert.ok(response.data.token.length > 0);
+  assert.ok(response.data.refreshToken.length > 0);
+  assert.ok(Date.parse(response.data.expiresAt) > Date.now());
+});
+
+test("login rejects an email that was never registered", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.login({ email: "nobody@example.com", password: "x" }),
+    /invalid credentials/i,
+  );
+});
+
+test("login rejects an unverified user", async () => {
+  const service = createService();
+  const signup = await service.signup({
+    email: "unverified@example.com",
+    password: "pw",
+    fullName: "Unverified User",
+  });
+  assert.equal(signup.data.user.isVerified, false);
+
+  await assertRejectsWithOriginalMessage(
+    () => service.login({ email: "unverified@example.com", password: "pw" }),
+    /email not verified/i,
+  );
+});
+
+// ── signup ────────────────────────────────────────────────────────────────────
+
+test("signup creates a new, unverified user and returns a session", async () => {
+  const service = createService();
+  const response = await service.signup({
+    email: "new-user@example.com",
+    password: "pw",
+    fullName: "New User",
+  });
+
+  assert.equal(response.data.user.email, "new-user@example.com");
+  assert.equal(response.data.user.fullName, "New User");
+  assert.equal(response.data.user.isVerified, false);
+});
+
+test("signup rejects an email that is already registered", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () =>
+      service.signup({
+        email: "user@example.com",
+        password: "pw",
+        fullName: "Duplicate",
+      }),
+    /already registered/i,
+  );
+});
+
+// ── logout ────────────────────────────────────────────────────────────────────
+
+test("logout invalidates the session token so refreshToken can no longer use it", async () => {
+  const service = createService();
+  const { data: session } = await service.login({
+    email: "user@example.com",
+    password: "pw",
+  });
+
+  await service.logout(session.token);
+
+  await assertRejectsWithOriginalMessage(
+    () => service.refreshToken(session.refreshToken),
+    /invalid refresh token/i,
+  );
+});
+
+// ── refreshToken ──────────────────────────────────────────────────────────────
+
+test("refreshToken issues a new token/refreshToken pair for a valid refresh token", async () => {
+  const service = createService();
+  const { data: session } = await service.login({
+    email: "user@example.com",
+    password: "pw",
+  });
+
+  const refreshed = await service.refreshToken(session.refreshToken);
+
+  assert.notEqual(refreshed.data.token, session.token);
+  assert.notEqual(refreshed.data.refreshToken, session.refreshToken);
+  assert.equal(refreshed.data.user.id, session.user.id);
+});
+
+test("refreshToken rejects an unknown refresh token", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.refreshToken("not-a-real-refresh-token"),
+    /invalid refresh token/i,
+  );
+});
+
+// ── verifyEmail ───────────────────────────────────────────────────────────────
+
+test("verifyEmail marks the matching user as verified", async () => {
+  const service = createService();
+  const signup = await service.signup({
+    email: "to-verify@example.com",
+    password: "pw",
+    fullName: "To Verify",
+  });
+
+  const result = await service.verifyEmail(signup.data.user.id);
+  assert.equal(result.data.success, true);
+
+  const login = await service.login({
+    email: "to-verify@example.com",
+    password: "pw",
+  });
+  assert.equal(login.data.user.isVerified, true);
+});
+
+test("verifyEmail rejects an unknown token", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.verifyEmail("no-such-user-id"),
+    /invalid verification token/i,
+  );
+});
+
+// ── resetPassword ─────────────────────────────────────────────────────────────
+
+test("resetPassword succeeds for a known email", async () => {
+  const service = createService();
+  const result = await service.resetPassword("user@example.com");
+  assert.equal(result.data.success, true);
+});
+
+test("resetPassword rejects an unknown email", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.resetPassword("nobody@example.com"),
+    /email not found/i,
+  );
+});

--- a/src/lib/service-layer/auth-service.ts
+++ b/src/lib/service-layer/auth-service.ts
@@ -1,5 +1,5 @@
 import { BaseAdapter } from "./base-adapter";
-import { ServiceResponse } from "./types";
+import { ServiceResponse, type ServiceConfig } from "./types";
 import { random } from "../seeded-rng";
 
 export interface LoginCredentials {
@@ -32,8 +32,8 @@ export class AuthService extends BaseAdapter {
   private mockUsers: Map<string, AuthUser> = new Map();
   private mockSessions: Map<string, AuthSession> = new Map();
 
-  constructor() {
-    super();
+  constructor(config: Partial<ServiceConfig> = {}) {
+    super(config);
     this.initializeMockData();
   }
 

--- a/src/lib/service-layer/base-adapter.test.ts
+++ b/src/lib/service-layer/base-adapter.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { BaseAdapter } from "./base-adapter";
+import { ServiceException } from "./types";
+
+// BaseAdapter is abstract — exercise it through a minimal concrete subclass
+// that exposes the protected helpers under test.
+class TestAdapter extends BaseAdapter {
+  runWithRetry<T>(operation: () => Promise<T>, context = "TestAdapter.run") {
+    return this.executeWithRetry(operation, context);
+  }
+
+  buildResponse<T>(data: T) {
+    return this.createResponse(data);
+  }
+
+  triggerHandleError(error: unknown, context = "TestAdapter.op"): never {
+    return this.handleError(error, context);
+  }
+}
+
+function createAdapter(overrides: ConstructorParameters<typeof TestAdapter>[0] = {}) {
+  return new TestAdapter({
+    simulateLatency: false,
+    simulateFailure: false,
+    retryDelay: 1,
+    ...overrides,
+  });
+}
+
+// ── executeWithRetry ─────────────────────────────────────────────────────────
+
+test("executeWithRetry returns the operation's result on first success", async () => {
+  const adapter = createAdapter();
+  const result = await adapter.runWithRetry(async () => "ok");
+  assert.equal(result, "ok");
+});
+
+test("executeWithRetry retries after a transient failure and eventually succeeds", async () => {
+  const adapter = createAdapter({ retryAttempts: 3 });
+  let calls = 0;
+
+  const result = await adapter.runWithRetry(async () => {
+    calls += 1;
+    if (calls < 2) {
+      throw new Error("transient failure");
+    }
+    return "recovered";
+  });
+
+  assert.equal(result, "recovered");
+  assert.equal(calls, 2);
+});
+
+test("executeWithRetry attempts exactly retryAttempts times before giving up", async () => {
+  const adapter = createAdapter({ retryAttempts: 3 });
+  let calls = 0;
+
+  await assert.rejects(() =>
+    adapter.runWithRetry(async () => {
+      calls += 1;
+      throw new Error("always fails");
+    }),
+  );
+
+  assert.equal(calls, 3);
+});
+
+test("executeWithRetry throws a ServiceException with TIMEOUT code after exhausting attempts", async () => {
+  const adapter = createAdapter({ retryAttempts: 2 });
+
+  await assert.rejects(
+    () =>
+      adapter.runWithRetry(async () => {
+        throw new Error("boom");
+      }, "TestAdapter.exhaust"),
+    (error: unknown) => {
+      assert.ok(error instanceof ServiceException);
+      assert.equal(error.code, "TIMEOUT");
+      assert.match(error.message, /TestAdapter\.exhaust/);
+      assert.equal(
+        (error.details as { originalError?: string })?.originalError,
+        "boom",
+      );
+      return true;
+    },
+  );
+});
+
+test("executeWithRetry backs off exponentially between attempts", async () => {
+  const adapter = createAdapter({ retryAttempts: 3, retryDelay: 20 });
+  const timestamps: number[] = [];
+
+  await assert.rejects(() =>
+    adapter.runWithRetry(async () => {
+      timestamps.push(Date.now());
+      throw new Error("always fails");
+    }),
+  );
+
+  assert.equal(timestamps.length, 3);
+  const firstGap = timestamps[1] - timestamps[0];
+  const secondGap = timestamps[2] - timestamps[1];
+
+  // retryDelay * 2^0 = 20ms, then retryDelay * 2^1 = 40ms.
+  assert.ok(firstGap >= 15, `expected first backoff >= 15ms, got ${firstGap}ms`);
+  assert.ok(
+    secondGap > firstGap,
+    `expected second backoff (${secondGap}ms) to exceed first (${firstGap}ms)`,
+  );
+});
+
+// ── createResponse ────────────────────────────────────────────────────────────
+
+test("createResponse wraps data with meta.requestId, timestamp, and version", () => {
+  const adapter = createAdapter();
+  const response = adapter.buildResponse({ hello: "world" });
+
+  assert.deepEqual(response.data, { hello: "world" });
+  assert.ok(response.meta?.requestId.startsWith("req_"));
+  assert.equal(response.meta?.version, "1.0.0");
+  assert.ok(!Number.isNaN(Date.parse(response.meta!.timestamp)));
+});
+
+// ── handleError ───────────────────────────────────────────────────────────────
+
+test("handleError rethrows an existing ServiceException unchanged", () => {
+  const adapter = createAdapter();
+  const original = new ServiceException({
+    code: "VALIDATION_ERROR",
+    message: "already a service error",
+    timestamp: new Date().toISOString(),
+  });
+
+  assert.throws(
+    () => adapter.triggerHandleError(original),
+    (error: unknown) => error === original,
+  );
+});
+
+test("handleError wraps a generic Error as SERVER_ERROR by default", () => {
+  const adapter = createAdapter();
+
+  assert.throws(
+    () => adapter.triggerHandleError(new Error("plain failure"), "TestAdapter.wrap"),
+    (error: unknown) => {
+      assert.ok(error instanceof ServiceException);
+      assert.equal(error.code, "SERVER_ERROR");
+      assert.match(error.message, /TestAdapter\.wrap/);
+      assert.match(error.message, /plain failure/);
+      return true;
+    },
+  );
+});
+
+test("handleError maps a recognized error.code to the matching ServiceErrorCode", () => {
+  const adapter = createAdapter();
+
+  assert.throws(
+    () => adapter.triggerHandleError({ code: "NOT_FOUND", message: "missing" }),
+    (error: unknown) => {
+      assert.ok(error instanceof ServiceException);
+      assert.equal(error.code, "NOT_FOUND");
+      return true;
+    },
+  );
+});
+
+test("handleError falls back to SERVER_ERROR for an unrecognized error.code", () => {
+  const adapter = createAdapter();
+
+  assert.throws(
+    () => adapter.triggerHandleError({ code: "SOMETHING_WEIRD" }),
+    (error: unknown) => {
+      assert.ok(error instanceof ServiceException);
+      assert.equal(error.code, "SERVER_ERROR");
+      return true;
+    },
+  );
+});
+
+// ── config ────────────────────────────────────────────────────────────────────
+
+test("getConfig returns a snapshot; updateConfig merges over the previous config", () => {
+  const adapter = createAdapter({ retryAttempts: 3 });
+
+  const snapshot = adapter.getConfig();
+  assert.equal(snapshot.retryAttempts, 3);
+
+  adapter.updateConfig({ retryAttempts: 5 });
+  assert.equal(adapter.getConfig().retryAttempts, 5);
+  // Unrelated config is preserved across the partial update.
+  assert.equal(adapter.getConfig().simulateFailure, false);
+});
+
+test("getConfig returns a copy, not a live reference", () => {
+  const adapter = createAdapter();
+  const snapshot = adapter.getConfig();
+  snapshot.retryAttempts = 999;
+
+  assert.notEqual(adapter.getConfig().retryAttempts, 999);
+});

--- a/src/lib/service-layer/base-adapter.ts
+++ b/src/lib/service-layer/base-adapter.ts
@@ -84,6 +84,17 @@ export abstract class BaseAdapter {
         const result = await operation();
         return result;
       } catch (error) {
+        // Deliberate domain errors (invalid credentials, not found, bad
+        // input, ...) are deterministic — retrying won't change the
+        // outcome, and wrapping them below as a generic TIMEOUT would
+        // destroy the specific code/message callers rely on. handleError()
+        // already applies this same rule for errors caught after the fact;
+        // apply it here too so it also covers throws from inside the
+        // operation itself.
+        if (error instanceof ServiceException) {
+          throw error;
+        }
+
         lastError = error as Error;
 
         if (attempt === maxAttempts) {

--- a/src/lib/service-layer/portfolio-service.test.ts
+++ b/src/lib/service-layer/portfolio-service.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { PortfolioService } from "./portfolio-service";
+import { assertRejectsWithOriginalMessage } from "./test-helpers";
+
+function createService() {
+  // retryAttempts: 1 — see auth-service.test.ts for why this matters: without
+  // it, deterministic "not found" errors get retried and rethrown wrapped as
+  // a generic TIMEOUT error instead of the original message.
+  return new PortfolioService({
+    simulateLatency: false,
+    simulateFailure: false,
+    retryAttempts: 1,
+  });
+}
+
+// ── getPortfolio ──────────────────────────────────────────────────────────────
+
+test("getPortfolio returns the seeded portfolio for user_1", async () => {
+  const service = createService();
+  const response = await service.getPortfolio("user_1");
+
+  assert.equal(response.data.userId, "user_1");
+  assert.equal(response.data.assets.length, 2);
+});
+
+test("getPortfolio rejects an unknown user", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(() => service.getPortfolio("user_unknown"), /portfolio not found/i);
+});
+
+// ── getPortfolioHistory ───────────────────────────────────────────────────────
+
+test("getPortfolioHistory paginates the 31-day seeded history", async () => {
+  const service = createService();
+  const response = await service.getPortfolioHistory("user_1", { page: 1, limit: 10 });
+
+  assert.equal(response.data.items.length, 10);
+  assert.equal(response.data.total, 31);
+  assert.equal(response.data.hasMore, true);
+});
+
+test("getPortfolioHistory reports hasMore=false on the final page", async () => {
+  const service = createService();
+  const response = await service.getPortfolioHistory("user_1", { page: 4, limit: 10 });
+
+  assert.equal(response.data.items.length, 1);
+  assert.equal(response.data.hasMore, false);
+});
+
+test("getPortfolioHistory rejects an unknown user", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.getPortfolioHistory("user_unknown", { page: 1, limit: 10 }),
+    /portfolio history not found/i,
+  );
+});
+
+// ── updatePortfolio ───────────────────────────────────────────────────────────
+
+test("updatePortfolio recomputes values but keeps identity fields stable", async () => {
+  const service = createService();
+  const before = await service.getPortfolio("user_1");
+  const updated = await service.updatePortfolio("user_1");
+
+  assert.equal(updated.data.id, before.data.id);
+  assert.equal(updated.data.userId, "user_1");
+  assert.ok(Date.parse(updated.data.updatedAt) >= Date.parse(before.data.updatedAt));
+});
+
+test("updatePortfolio rejects an unknown user", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(() => service.updatePortfolio("user_unknown"), /portfolio not found/i);
+});
+
+// ── addAsset ──────────────────────────────────────────────────────────────────
+
+test("addAsset appends the new asset and recomputes totalValue as the sum of asset values", async () => {
+  const service = createService();
+  const updated = await service.addAsset("user_1", {
+    symbol: "BTC",
+    name: "Bitcoin",
+    balance: 1,
+  });
+
+  const added = updated.data.assets.find((a) => a.symbol === "BTC");
+  assert.ok(added, "expected the new asset to be present");
+  assert.equal(added?.value, 1);
+
+  const expectedTotal = updated.data.assets.reduce((sum, a) => sum + a.value, 0);
+  assert.equal(updated.data.totalValue, expectedTotal);
+});
+
+test("addAsset rejects an unknown user", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.addAsset("user_unknown", { symbol: "BTC", name: "Bitcoin", balance: 1 }),
+    /portfolio not found/i,
+  );
+});
+
+// ── removeAsset ───────────────────────────────────────────────────────────────
+
+test("removeAsset removes the matching asset and recomputes totalValue", async () => {
+  const service = createService();
+  const before = await service.getPortfolio("user_1");
+  const target = before.data.assets[0];
+
+  const updated = await service.removeAsset("user_1", target.id);
+
+  assert.equal(updated.data.assets.some((a) => a.id === target.id), false);
+  const expectedTotal = updated.data.assets.reduce((sum, a) => sum + a.value, 0);
+  assert.equal(updated.data.totalValue, expectedTotal);
+});
+
+test("removeAsset rejects an unknown asset id", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.removeAsset("user_1", "asset_does_not_exist"),
+    /asset not found/i,
+  );
+});
+
+test("removeAsset rejects an unknown user", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.removeAsset("user_unknown", "asset_1"),
+    /portfolio not found/i,
+  );
+});

--- a/src/lib/service-layer/portfolio-service.ts
+++ b/src/lib/service-layer/portfolio-service.ts
@@ -1,5 +1,10 @@
 import { BaseAdapter } from "./base-adapter";
-import { ServiceResponse, PaginatedResponse, PaginationParams } from "./types";
+import {
+  ServiceResponse,
+  PaginatedResponse,
+  PaginationParams,
+  type ServiceConfig,
+} from "./types";
 import { random } from "../seeded-rng";
 
 export interface Portfolio {
@@ -32,8 +37,8 @@ export class PortfolioService extends BaseAdapter {
   private mockPortfolios: Map<string, Portfolio> = new Map();
   private mockHistory: Map<string, PortfolioHistory[]> = new Map();
 
-  constructor() {
-    super();
+  constructor(config: Partial<ServiceConfig> = {}) {
+    super(config);
     this.initializeMockData();
   }
 

--- a/src/lib/service-layer/strategy-service.test.ts
+++ b/src/lib/service-layer/strategy-service.test.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { StrategyService } from "./strategy-service";
+import { assertRejectsWithOriginalMessage } from "./test-helpers";
+
+function createService() {
+  // retryAttempts: 1 — see auth-service.test.ts for why this matters: without
+  // it, deterministic validation/"not found" errors get retried and rethrown
+  // wrapped as a generic TIMEOUT error instead of the original message.
+  return new StrategyService({
+    simulateLatency: false,
+    simulateFailure: false,
+    retryAttempts: 1,
+  });
+}
+
+// ── getStrategies / getStrategy ───────────────────────────────────────────────
+
+test("getStrategies returns only active seeded strategies", async () => {
+  const service = createService();
+  const response = await service.getStrategies();
+
+  assert.equal(response.data.length, 3);
+  assert.ok(response.data.every((s) => s.isActive));
+});
+
+test("getStrategy returns a strategy by id", async () => {
+  const service = createService();
+  const response = await service.getStrategy("strategy_2");
+  assert.equal(response.data.name, "Balanced Growth");
+});
+
+test("getStrategy rejects an unknown id", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(() => service.getStrategy("strategy_nope"), /strategy not found/i);
+});
+
+// ── getUserAllocations ────────────────────────────────────────────────────────
+
+test("getUserAllocations returns the seeded allocation for user_1", async () => {
+  const service = createService();
+  const response = await service.getUserAllocations("user_1", { page: 1, limit: 10 });
+
+  assert.equal(response.data.total, 1);
+  assert.equal(response.data.items[0].strategyId, "strategy_1");
+});
+
+test("getUserAllocations returns an empty page for a user with no allocations", async () => {
+  const service = createService();
+  const response = await service.getUserAllocations("user_none", { page: 1, limit: 10 });
+
+  assert.deepEqual(response.data.items, []);
+  assert.equal(response.data.total, 0);
+  assert.equal(response.data.hasMore, false);
+});
+
+// ── createAllocation — the allocation validation logic called out in #539 ────
+
+test("createAllocation rejects an amount below the strategy's minDeposit", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.createAllocation("user_1", "strategy_1", 1),
+    /minimum deposit is 100/i,
+  );
+});
+
+test("createAllocation rejects an amount above the strategy's maxDeposit", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.createAllocation("user_1", "strategy_1", 1_000_000),
+    /maximum deposit is 50000/i,
+  );
+});
+
+test("createAllocation rejects an unknown strategy", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.createAllocation("user_1", "strategy_nope", 500),
+    /strategy not found/i,
+  );
+});
+
+test("createAllocation accepts a valid amount and computes the expected return from strategy APY/lockPeriod", async () => {
+  const service = createService();
+  const response = await service.createAllocation("user_1", "strategy_1", 500);
+
+  assert.equal(response.data.status, "pending");
+  assert.equal(response.data.userId, "user_1");
+  assert.equal(response.data.strategyId, "strategy_1");
+  assert.equal(response.data.amount, 500);
+
+  // expectedReturn = amount * (expectedApy / 100) * (lockPeriod / 365)
+  const expected = 500 * (5.5 / 100) * (30 / 365);
+  assert.ok(
+    Math.abs(response.data.expectedReturn - expected) < 1e-9,
+    `expected ~${expected}, got ${response.data.expectedReturn}`,
+  );
+});
+
+test("createAllocation appends to the user's existing allocations rather than replacing them", async () => {
+  const service = createService();
+  await service.createAllocation("user_1", "strategy_2", 500);
+
+  const response = await service.getUserAllocations("user_1", { page: 1, limit: 10 });
+  // 1 seeded allocation + 1 newly created.
+  assert.equal(response.data.total, 2);
+});
+
+// ── cancelAllocation ──────────────────────────────────────────────────────────
+
+test("cancelAllocation marks a pending allocation as cancelled", async () => {
+  const service = createService();
+  const created = await service.createAllocation("user_1", "strategy_1", 500);
+
+  const cancelled = await service.cancelAllocation("user_1", created.data.id);
+  assert.equal(cancelled.data.status, "cancelled");
+});
+
+test("cancelAllocation rejects an unknown allocation id", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.cancelAllocation("user_1", "alloc_does_not_exist"),
+    /allocation not found/i,
+  );
+});
+
+test("cancelAllocation rejects an allocation that is already cancelled", async () => {
+  const service = createService();
+  const created = await service.createAllocation("user_1", "strategy_1", 500);
+  await service.cancelAllocation("user_1", created.data.id);
+
+  await assertRejectsWithOriginalMessage(
+    () => service.cancelAllocation("user_1", created.data.id),
+    /cannot cancel allocation in current state/i,
+  );
+});
+
+// ── getStrategyPerformance ────────────────────────────────────────────────────
+
+test("getStrategyPerformance paginates the 31-day seeded performance series", async () => {
+  const service = createService();
+  const response = await service.getStrategyPerformance("strategy_1", { page: 1, limit: 10 });
+
+  assert.equal(response.data.items.length, 10);
+  assert.equal(response.data.total, 31);
+  assert.ok(response.data.items.every((p) => p.strategyId === "strategy_1"));
+});
+
+test("getStrategyPerformance rejects an unknown strategy", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.getStrategyPerformance("strategy_nope", { page: 1, limit: 10 }),
+    /performance data not found/i,
+  );
+});

--- a/src/lib/service-layer/strategy-service.ts
+++ b/src/lib/service-layer/strategy-service.ts
@@ -1,5 +1,10 @@
 import { BaseAdapter } from "./base-adapter";
-import { ServiceResponse, PaginatedResponse, PaginationParams } from "./types";
+import {
+  ServiceResponse,
+  PaginatedResponse,
+  PaginationParams,
+  type ServiceConfig,
+} from "./types";
 import { random } from "../seeded-rng";
 
 export interface Strategy {
@@ -39,8 +44,8 @@ export class StrategyService extends BaseAdapter {
   private mockAllocations: Map<string, StrategyAllocation[]> = new Map();
   private mockPerformance: Map<string, StrategyPerformance[]> = new Map();
 
-  constructor() {
-    super();
+  constructor(config: Partial<ServiceConfig> = {}) {
+    super(config);
     this.initializeMockData();
   }
 

--- a/src/lib/service-layer/test-helpers.ts
+++ b/src/lib/service-layer/test-helpers.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+
+import { ServiceException } from "./types";
+
+/**
+ * Service methods wrap their business logic in executeWithRetry(), which
+ * always rewraps a thrown error as a generic TIMEOUT ServiceException once
+ * retries are exhausted (see base-adapter.ts) — the original message is not
+ * on `.message`, it's preserved verbatim in `details.originalError`. Use this
+ * instead of asserting on the top-level message when testing a service
+ * method's validation/not-found errors.
+ */
+export async function assertRejectsWithOriginalMessage(
+  operation: () => Promise<unknown>,
+  expected: RegExp,
+): Promise<void> {
+  await assert.rejects(operation, (error: unknown) => {
+    assert.ok(error instanceof ServiceException, "expected a ServiceException");
+    const details = error.details as { originalError?: string } | undefined;
+    assert.match(details?.originalError ?? "", expected);
+    return true;
+  });
+}

--- a/src/lib/service-layer/transaction-service.test.ts
+++ b/src/lib/service-layer/transaction-service.test.ts
@@ -2,9 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import { TransactionService, type Transaction } from "./transaction-service";
+import { assertRejectsWithOriginalMessage } from "./test-helpers";
 
 function createService() {
-  return new TransactionService({ simulateLatency: false, simulateFailure: false });
+  // retryAttempts: 1 — deterministic "not found"/"invalid state" errors get
+  // retried and rethrown wrapped as a generic TIMEOUT error under the default
+  // retryAttempts: 3, masking the original message these tests assert on.
+  return new TransactionService({
+    simulateLatency: false,
+    simulateFailure: false,
+    retryAttempts: 1,
+  });
 }
 
 test("getTransactionStats computes all counters in one pass for mock user_1", async () => {
@@ -65,4 +73,140 @@ test("getTransactionStats counts failed volume separately from totalVolume", asy
   assert.equal(response.data.failedTransactions, 1);
   assert.equal(response.data.pendingTransactions, 0);
   assert.equal(response.data.totalVolume, 100);
+});
+
+// ── createTransaction — the fee calculation logic called out in #539 ────────
+//
+// createTransaction schedules a real 3-5s setTimeout chain via
+// simulateTransactionProcessing() to flip status pending -> processing ->
+// completed. These tests only assert on the transaction returned
+// synchronously and do not await that chain.
+
+test("createTransaction charges the flat baseFee when the percentage fee would be smaller", async () => {
+  const service = createService();
+  const response = await service.createTransaction("user_1", {
+    type: "deposit",
+    amount: 5,
+    asset: "USDC",
+  });
+
+  // percentageFee = 5 * 0.001 = 0.005, below the 0.01 baseFee floor.
+  assert.equal(response.data.fee, 0.01);
+  assert.equal(response.data.status, "pending");
+});
+
+test("createTransaction charges the percentage fee once it exceeds the baseFee floor", async () => {
+  const service = createService();
+  const response = await service.createTransaction("user_1", {
+    type: "withdrawal",
+    amount: 1000,
+    asset: "USDC",
+  });
+
+  // percentageFee = 1000 * 0.001 = 1, above the 0.01 baseFee floor.
+  assert.equal(response.data.fee, 1);
+});
+
+test("createTransaction prepends the new transaction so it is returned first by getUserTransactions", async () => {
+  const service = createService();
+  const created = await service.createTransaction("user_1", {
+    type: "deposit",
+    amount: 50,
+    asset: "USDC",
+  });
+
+  const list = await service.getUserTransactions("user_1", { page: 1, limit: 10 });
+  assert.equal(list.data.items[0].id, created.data.id);
+  assert.equal(list.data.total, 4); // 3 seeded + 1 new
+});
+
+// ── getTransaction ────────────────────────────────────────────────────────────
+
+test("getTransaction returns a transaction by id for the owning user", async () => {
+  const service = createService();
+  const response = await service.getTransaction("user_1", "tx_1");
+  assert.equal(response.data.type, "deposit");
+});
+
+test("getTransaction rejects an unknown transaction id", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.getTransaction("user_1", "tx_does_not_exist"),
+    /transaction not found/i,
+  );
+});
+
+// ── getUserTransactions — filtering ───────────────────────────────────────────
+
+test("getUserTransactions filters by type", async () => {
+  const service = createService();
+  const response = await service.getUserTransactions("user_1", {
+    page: 1,
+    limit: 10,
+    filter: { type: "withdrawal" },
+  });
+
+  assert.equal(response.data.items.length, 1);
+  assert.equal(response.data.items[0].id, "tx_3");
+});
+
+test("getUserTransactions filters by status", async () => {
+  const service = createService();
+  const response = await service.getUserTransactions("user_1", {
+    page: 1,
+    limit: 10,
+    filter: { status: "completed" },
+  });
+
+  assert.equal(response.data.items.length, 2);
+  assert.ok(response.data.items.every((t) => t.status === "completed"));
+});
+
+test("getUserTransactions filters by a startDate/endDate window", async () => {
+  const service = createService();
+  const response = await service.getUserTransactions("user_1", {
+    page: 1,
+    limit: 10,
+    filter: {
+      startDate: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+      endDate: new Date().toISOString(),
+    },
+  });
+
+  // Only tx_3 (created 30 minutes ago) falls inside a 90-minute window.
+  assert.equal(response.data.items.length, 1);
+  assert.equal(response.data.items[0].id, "tx_3");
+});
+
+test("getUserTransactions paginates results", async () => {
+  const service = createService();
+  const response = await service.getUserTransactions("user_1", { page: 1, limit: 2 });
+
+  assert.equal(response.data.items.length, 2);
+  assert.equal(response.data.total, 3);
+  assert.equal(response.data.hasMore, true);
+});
+
+// ── cancelTransaction ─────────────────────────────────────────────────────────
+
+test("cancelTransaction cancels a pending transaction", async () => {
+  const service = createService();
+  const response = await service.cancelTransaction("user_1", "tx_3");
+  assert.equal(response.data.status, "cancelled");
+});
+
+test("cancelTransaction rejects a transaction that is not pending", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.cancelTransaction("user_1", "tx_1"),
+    /cannot cancel transaction in current state/i,
+  );
+});
+
+test("cancelTransaction rejects an unknown transaction id", async () => {
+  const service = createService();
+  await assertRejectsWithOriginalMessage(
+    () => service.cancelTransaction("user_1", "tx_does_not_exist"),
+    /transaction not found/i,
+  );
 });

--- a/src/lib/storage-keys.test.ts
+++ b/src/lib/storage-keys.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { getStorageKey, STORAGE_KEYS } from "./storage-keys";
+
+// Regression coverage for #581: OnboardingSettings previously hardcoded raw
+// localStorage key string literals ("user-strategy", "first-deposit") instead
+// of reading them from this registry. It has since been migrated to use
+// STORAGE_KEYS directly — these tests guard against that regressing.
+
+test("getStorageKey returns the registered value for onboarding keys", () => {
+  assert.equal(getStorageKey("ONBOARDING_USER_STRATEGY"), "user-strategy");
+  assert.equal(getStorageKey("ONBOARDING_FIRST_DEPOSIT"), "first-deposit");
+  assert.equal(getStorageKey("ONBOARDING_STATE"), "onboarding-state");
+});
+
+test("OnboardingSettings.tsx sources its localStorage keys from STORAGE_KEYS, not string literals", () => {
+  const source = fs.readFileSync(
+    path.join(process.cwd(), "src/components/settings/OnboardingSettings.tsx"),
+    "utf8",
+  );
+
+  assert.match(source, /STORAGE_KEYS\.ONBOARDING_USER_STRATEGY/);
+  assert.match(source, /STORAGE_KEYS\.ONBOARDING_FIRST_DEPOSIT/);
+
+  // Guard against re-introducing the raw literals the registry replaced.
+  assert.doesNotMatch(source, /localStorage\.\w+\(\s*["']user-strategy["']/);
+  assert.doesNotMatch(source, /localStorage\.\w+\(\s*["']first-deposit["']/);
+});
+
+test("STORAGE_KEYS values are unique — no accidental key collisions", () => {
+  const values = Object.values(STORAGE_KEYS);
+  assert.equal(new Set(values).size, values.length);
+});


### PR DESCRIPTION
## Summary

Closes #539
Closes #581
Closes #582
Closes #583

**#539 — service-layer type safety & test coverage**
- The `any`-erasure part of this issue was already fixed by a prior commit. Added the missing test coverage: `base-adapter.test.ts`, `auth-service.test.ts`, `portfolio-service.test.ts`, `strategy-service.test.ts`, and expanded `transaction-service.test.ts` (fee calculation, filtering, cancellation).
- Writing these tests surfaced a real bug: `executeWithRetry` (`base-adapter.ts`) retried and re-wrapped *every* thrown error — including deterministic validation errors like "Invalid credentials" — into a generic `TIMEOUT`-coded "Operation failed after N attempts" message once retries were exhausted, even with `retryAttempts: 1`. This discarded the real message/code for every validation/not-found error across all four services. Fixed by making `executeWithRetry` pass a `ServiceException` through unchanged, mirroring the rule `handleError` already applied elsewhere in the same file.
- Gave `AuthService`/`PortfolioService`/`StrategyService` an optional constructor `config` param (matching the pattern `TransactionService` already had) so tests can disable simulated latency/failure.

**#582 — AUTH_SECRET / session cookie docs**
- `AUTH_SECRET` is genuinely unused anywhere in the code; the session cookie is intentionally unsigned while auth is mock-only. Fixed misleading docs (`.env.example`, `docs/env.md`, `api-client.ts`, including a false "httpOnly" claim) and added deferral comments in `middleware.ts`/`AuthContext.tsx` pointing at the real signing flow already sketched out in `auth-constants.ts`.

**#583 (demo route gating) and #581 (OnboardingSettings storage keys)**
- Both already fixed by prior PRs on `main`. Added regression tests (`routeMetadata.test.ts`, `storage-keys.test.ts`) so they can't silently regress.

**Also fixed while verifying** (pre-existing, unrelated to these issues, confirmed via `git diff main` before touching):
- A syntax error in `PortfolioDashboard.tsx` (missing closing `]`) that broke `tsc` for the entire repo.

**Left untouched** (pre-existing, need a real design decision rather than a one-line fix):
- A type error in `composeProviders.tsx`.
- Lint issues in `login/page.tsx` (exhaustive-deps warning) and `AuditTrail.tsx` (conditional hook call).

## Test plan

- [x] `yarn typecheck` — passes (only the pre-existing, unrelated `composeProviders.tsx` error remains)
- [x] `yarn test` — 629/629 passing
- [x] `yarn lint` — no new issues in changed files (two pre-existing, unrelated issues remain elsewhere)
