### PR TITLE
test: add getPageNumbers coverage and fix any-cast in Pagination (#549)

### DIFF
--- a/src/components/pagination-filters/Pagination.test.ts
+++ b/src/components/pagination-filters/Pagination.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getPageNumbers } from "./Pagination";
+
+test("getPageNumbers returns every page when total is 7 or fewer, regardless of current page", () => {
+  assert.deepEqual(getPageNumbers(1, 1), [1]);
+  assert.deepEqual(getPageNumbers(1, 5), [1, 2, 3, 4, 5]);
+  assert.deepEqual(getPageNumbers(5, 5), [1, 2, 3, 4, 5]);
+  assert.deepEqual(getPageNumbers(1, 7), [1, 2, 3, 4, 5, 6, 7]);
+  assert.deepEqual(getPageNumbers(7, 7), [1, 2, 3, 4, 5, 6, 7]);
+});
+
+test("getPageNumbers handles the zero-page edge case", () => {
+  assert.deepEqual(getPageNumbers(1, 0), []);
+});
+
+test("getPageNumbers switches from a flat list to windowed ellipsis once total exceeds 7", () => {
+  assert.deepEqual(getPageNumbers(1, 8), [1, 2, 3, 4, 5, "ellipsis", 8]);
+  assert.deepEqual(getPageNumbers(8, 8), [1, "ellipsis", 4, 5, 6, 7, 8]);
+});
+
+test("getPageNumbers shows a leading window with trailing ellipsis when current page is near the start", () => {
+  assert.deepEqual(getPageNumbers(1, 20), [1, 2, 3, 4, 5, "ellipsis", 20]);
+  assert.deepEqual(getPageNumbers(4, 20), [1, 2, 3, 4, 5, "ellipsis", 20]);
+});
+
+test("getPageNumbers shows a trailing window with leading ellipsis when current page is near the end", () => {
+  assert.deepEqual(getPageNumbers(17, 20), [1, "ellipsis", 16, 17, 18, 19, 20]);
+  assert.deepEqual(getPageNumbers(20, 20), [1, "ellipsis", 16, 17, 18, 19, 20]);
+});
+
+test("getPageNumbers centers a small window around the current page with ellipses on both sides", () => {
+  assert.deepEqual(getPageNumbers(10, 20), [1, "ellipsis", 9, 10, 11, "ellipsis", 20]);
+  assert.deepEqual(getPageNumbers(5, 9), [1, "ellipsis", 4, 5, 6, "ellipsis", 9]);
+});
+
+test("getPageNumbers always includes the first and last page for large page counts", () => {
+  for (const current of [1, 4, 5, 10, 16, 17, 20]) {
+    const pages = getPageNumbers(current, 20);
+    assert.equal(pages[0], 1);
+    assert.equal(pages[pages.length - 1], 20);
+  }
+});
+
+test("getPageNumbers windows correctly for very large totals", () => {
+  assert.deepEqual(getPageNumbers(500, 1000), [1, "ellipsis", 499, 500, 501, "ellipsis", 1000]);
+  assert.deepEqual(getPageNumbers(1, 1000), [1, 2, 3, 4, 5, "ellipsis", 1000]);
+  assert.deepEqual(getPageNumbers(1000, 1000), [1, "ellipsis", 996, 997, 998, 999, 1000]);
+});

--- a/src/components/pagination-filters/Pagination.tsx
+++ b/src/components/pagination-filters/Pagination.tsx
@@ -24,7 +24,7 @@ const ChevronRight = () => (
   </svg>
 );
 
-function getPageNumbers(current: number, total: number): (number | "ellipsis")[] {
+export function getPageNumbers(current: number, total: number): (number | "ellipsis")[] {
   if (total <= 7) return Array.from({ length: total }, (_, i) => i + 1);
   if (current <= 4) return [1, 2, 3, 4, 5, "ellipsis", total];
   if (current >= total - 3) return [1, "ellipsis", total - 4, total - 3, total - 2, total - 1, total];
@@ -69,7 +69,7 @@ export default function Pagination({
     onPageChange?.(p);
   };
 
-  const handleJump = (e: React.FormEvent) => {
+  const handleJump = (e: React.SyntheticEvent) => {
     e.preventDefault();
     const n = parseInt(jumpVal, 10);
     if (!isNaN(n)) { go(n); setJumpVal(""); }
@@ -165,7 +165,7 @@ export default function Pagination({
             max={totalPages}
             value={jumpVal}
             onChange={(e) => setJumpVal(e.target.value)}
-            onKeyDown={(e) => { if (e.key === "Enter") handleJump(e as any); }}
+            onKeyDown={(e) => { if (e.key === "Enter") handleJump(e); }}
             aria-label="Jump to page"
             style={{
               width: 52, height: 36, borderRadius: 8, border: "0.5px solid #374151",


### PR DESCRIPTION
closes #549 

getPageNumbers had zero test coverage for its ellipsis-windowing logic, and the input's onKeyDown handler cast a KeyboardEvent to any to satisfy handleJump's FormEvent parameter. Widen handleJump's parameter to React.SyntheticEvent (the common base of FormEvent and KeyboardEvent, and all handleJump uses is preventDefault()) so both call sites type-check without a cast.

Export getPageNumbers and add unit tests across small (<=7), large, and edge (0-page, boundary-of-7/8, very-large) page counts.