### PR TITLE
refactor: establish shared z-index scale for overlays (#565)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,6 +30,16 @@
   --color-warning: #F59E0B;
   --color-info: #0EA5E9;
   --shadow-card: 0 1px 2px rgb(0 0 0 / 0.2);
+
+  /* Overlay stacking scale (#565) — shared z-index tiers for anything that
+   * floats above normal page content. Values are spaced out (10 apart) to
+   * leave room to insert a tier later without renumbering everything.
+   * Ascending order is intentional: later tiers must cover earlier ones. */
+  --z-index-overlay: 1000;   /* persistent fixed chrome: nav bar, cookie banner */
+  --z-index-dropdown: 1010;  /* contextual popovers: search results, notification menu */
+  --z-index-modal: 1020;     /* modal/drawer dialogs and their backdrops */
+  --z-index-toast: 1030;     /* toast notifications — must surface above open modals */
+  --z-index-dev-tool: 1040;  /* diagnostics panel — always on top for debugging */
 }
 
 :root {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -37,7 +37,7 @@ export function Navbar() {
   }, [isMobileSearchOpen]);
 
   return (
-    <nav aria-label="Main navigation" className="fixed top-0 left-0 right-0 z-50 border-b border-white/5 bg-dark-900/80 backdrop-blur-md">
+    <nav aria-label="Main navigation" className="fixed top-0 left-0 right-0 z-overlay border-b border-white/5 bg-dark-900/80 backdrop-blur-md">
       <div className="mx-auto flex max-w-7xl items-center justify-between gap-2 px-4 py-4 sm:px-6 md:gap-4 md:px-8 md:py-5">
         <Link href="/" aria-label="NeuroWealth home" className="flex items-center gap-2 text-lg font-bold text-white">
           <span aria-hidden="true" className="text-brand-400">&#x2B21;</span> NeuroWealth
@@ -119,7 +119,7 @@ export function Navbar() {
       {isMobileSearchOpen && (
         <div
           ref={mobileSearchRef}
-          className="fixed inset-0 z-[80] bg-slate-950/90 backdrop-blur-md md:hidden"
+          className="fixed inset-0 z-modal bg-slate-950/90 backdrop-blur-md md:hidden"
           role="dialog"
           aria-modal="true"
           aria-label="Global search"
@@ -140,7 +140,7 @@ export function Navbar() {
             <GlobalSearch
               autoFocus
               onRequestClose={() => setIsMobileSearchOpen(false)}
-              className="z-[81]"
+              className="z-dropdown"
             />
 
             <p className="mt-3 text-xs text-slate-400">

--- a/src/components/cookie/CookieBanner.tsx
+++ b/src/components/cookie/CookieBanner.tsx
@@ -11,7 +11,7 @@ export function CookieBanner() {
       role="dialog"
       aria-label="Cookie consent"
       aria-live="polite"
-      className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-between gap-4 px-4 sm:px-6"
+      className="fixed bottom-0 left-0 right-0 z-overlay flex items-center justify-between gap-4 px-4 sm:px-6"
       style={{
         minHeight: "72px",
         maxHeight: "96px",

--- a/src/components/cookie/PrivacyModal.tsx
+++ b/src/components/cookie/PrivacyModal.tsx
@@ -23,7 +23,7 @@ export function PrivacyModal() {
   const toggle = (key: keyof CookiePreferences) => { if (key === "necessary") return; setLocalPrefs((p) => ({ ...p, [key]: !p[key] })); };
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center" role="dialog" aria-modal="true" aria-label="Privacy preferences">
+    <div className="fixed inset-0 z-modal flex items-end sm:items-center justify-center" role="dialog" aria-modal="true" aria-label="Privacy preferences">
       <div onClick={closeModal} style={{ position: "absolute", inset: 0, background: "rgba(2, 6, 18, 0.8)", backdropFilter: "blur(8px)", WebkitBackdropFilter: "blur(8px)" }} />
       <div className="relative w-full sm:max-w-lg flex flex-col" style={{ background: "rgba(4, 10, 22, 0.98)", border: "1px solid rgba(34,211,238,0.15)", borderRadius: "16px", boxShadow: "0 0 0 1px rgba(34,211,238,0.05), 0 24px 64px rgba(0,0,0,0.8)", maxHeight: "90vh", overflow: "hidden" }}>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "18px 20px", borderBottom: `1px solid ${BORDER_SUBTLE}`, flexShrink: 0 }}>

--- a/src/components/diagnostics/DiagnosticsPanel.tsx
+++ b/src/components/diagnostics/DiagnosticsPanel.tsx
@@ -24,7 +24,7 @@ export function DiagnosticsPanel() {
   }
 
   return (
-    <div className="fixed bottom-4 right-4 z-[9999]">
+    <div className="fixed bottom-4 right-4 z-dev-tool">
       {!isOpen ? (
         <button
           type="button"

--- a/src/components/diagnostics/DiagnosticsPanelContent.tsx
+++ b/src/components/diagnostics/DiagnosticsPanelContent.tsx
@@ -24,7 +24,7 @@ export function DiagnosticsPanelContent({ onClose }: DiagnosticsPanelContentProp
   }, [onClose]);
 
   return (
-    <div className="fixed bottom-4 right-4 z-[9999]">
+    <div className="fixed bottom-4 right-4 z-dev-tool">
       <div
         role="dialog"
         aria-modal="true"

--- a/src/components/notifications/NotificationToggle.tsx
+++ b/src/components/notifications/NotificationToggle.tsx
@@ -44,7 +44,7 @@ export function NotificationToggle() {
 
       {isOpen && (
         <div 
-          className="absolute right-0 mt-2 z-[100] animate-in fade-in zoom-in duration-200 origin-top-right"
+          className="absolute right-0 mt-2 z-dropdown animate-in fade-in zoom-in duration-200 origin-top-right"
           onKeyDown={(e) => {
             if (e.key === 'Escape') {
               setIsOpen(false);

--- a/src/components/notifications/ToastProvider.tsx
+++ b/src/components/notifications/ToastProvider.tsx
@@ -179,7 +179,7 @@ function ToastViewport({
 }) {
   return (
     <div
-      className="pointer-events-none fixed inset-x-0 top-4 z-[100] flex justify-center px-4 sm:justify-end"
+      className="pointer-events-none fixed inset-x-0 top-4 z-toast flex justify-center px-4 sm:justify-end"
       aria-label="Notifications"
     >
       <div className="flex w-full max-w-md flex-col gap-3">

--- a/src/components/search/GlobalSearch.tsx
+++ b/src/components/search/GlobalSearch.tsx
@@ -306,7 +306,7 @@ export function GlobalSearch({
         <div
           id={listboxId}
           role="listbox"
-          className="absolute left-0 right-0 top-[calc(100%+8px)] z-[70] max-h-[min(70vh,28rem)] overflow-auto rounded-2xl border border-white/10 bg-slate-950/95 p-2 shadow-2xl shadow-black/50 backdrop-blur-md"
+          className="absolute left-0 right-0 top-[calc(100%+8px)] z-dropdown max-h-[min(70vh,28rem)] overflow-auto rounded-2xl border border-white/10 bg-slate-950/95 p-2 shadow-2xl shadow-black/50 backdrop-blur-md"
         >
           {isLoading && (
             <div className="flex min-h-11 items-center gap-2 rounded-xl px-3 py-2 text-sm text-slate-300">

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -49,7 +49,7 @@ export function Drawer({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex"
+      className="fixed inset-0 z-modal flex"
       aria-modal="true"
       role="dialog"
       aria-labelledby="drawer-title"

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -51,7 +51,7 @@ export function Modal({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center"
+      className="fixed inset-0 z-modal flex items-center justify-center"
       aria-modal="true"
       role="dialog"
       aria-labelledby="modal-title"


### PR DESCRIPTION
closes #565 
closes #562 

Overlay z-index values were scattered ad-hoc (z-50, z-[60], z-[70], z-[80]/z-[81], z-[100], z-[9999]) with no defined relationship between them — notably Modal and Drawer both used z-50, so if both were ever triggered together the stacking order would be DOM-order-dependent rather than intentional.

Define a 5-tier scale as CSS custom properties in the Tailwind v4 @theme block (globals.css), which is this repo's documented source of truth for design tokens (tailwind.config.ts is structural-only, see its file header). Tiers are spaced 10 apart, ascending overlay < dropdown < modal < toast < dev-tool, so later tiers intentionally cover earlier ones and there's room to insert more later:

  - z-overlay   persistent fixed chrome (nav bar, cookie banner)
  - z-dropdown  contextual popovers (search results, notification menu)
  - z-modal     modal/drawer dialogs and their backdrops
  - z-toast     toast notifications, above any open modal
  - z-dev-tool  diagnostics panel, always on top for debugging

Migrated all 9 files listed in the issue, plus DiagnosticsPanelContent.tsx (agreed alternative: DiagnosticsPanelContent.tsx didn't exist when the issue was filed — a same-day upstream refactor split DiagnosticsPanel's `fixed z-[9999]` wrapper into this new sibling file, which duplicates the exact same ad-hoc value, so leaving it unmigrated would recreate the inconsistency this issue is fixing).

Left the internal z-10 panel-above-backdrop values in Modal/Drawer untouched — they only order two children within one component's own stacking context (backdrop has no z-index) and were never part of the cross-component collision this issue describes, so folding them into the shared scale would be scope creep, not a fix.