### PR TITLE
Fix settings casing, id collisions, mock-store duplication, strategy figure mismatch

### DIFF
--- a/src/components/cookie/PrivacyModal.tsx
+++ b/src/components/cookie/PrivacyModal.tsx
@@ -77,7 +77,7 @@ export function PrivacyModal() {
             onMouseLeave={e => { e.currentTarget.style.borderColor = "rgba(255,255,255,0.12)"; e.currentTarget.style.color = "rgba(255,255,255,0.45)"; }}>Reject all</button>
           <button onClick={() => savePreferences(localPrefs)} style={{ flex: 1, height: "44px", borderRadius: "10px", fontSize: "13px", fontWeight: 500, cursor: "pointer", background: "rgba(34,211,238,0.1)", border: "1px solid rgba(34,211,238,0.3)", color: CYAN }}
             onMouseEnter={e => { e.currentTarget.style.background = "rgba(34,211,238,0.18)"; }}
-            onMouseLeave={e => { e.currentTarget.style.background = "rgba(34,211,238,0.1)"; }}>Save preferences</button>
+            onMouseLeave={e => { e.currentTarget.style.background = "rgba(34,211,238,0.1)"; }}>Save Preferences</button>
           <button onClick={acceptAll} style={{ flex: 1, height: "44px", borderRadius: "10px", fontSize: "13px", fontWeight: 600, cursor: "pointer", background: "linear-gradient(135deg, #22d3ee 0%, #06b6d4 100%)", border: "none", color: "#020917" }}
             onMouseEnter={e => { e.currentTarget.style.opacity = "0.85"; }}
             onMouseLeave={e => { e.currentTarget.style.opacity = "1"; }}>Accept all</button>

--- a/src/lib/i18n/messages.ts
+++ b/src/lib/i18n/messages.ts
@@ -547,7 +547,7 @@ export const dictionaries: Record<AppLocale, AppMessages> = {
       items: [
         {
           name: "Conservative",
-          apy: "3–6%",
+          apy: "4–6%",
           risk: "Low",
           desc: "Stablecoin lending on Blend. Steady, predictable returns with minimal exposure.",
           accentText: "text-sky-400",
@@ -556,7 +556,7 @@ export const dictionaries: Record<AppLocale, AppMessages> = {
         },
         {
           name: "Balanced",
-          apy: "6–10%",
+          apy: "7–10%",
           risk: "Medium",
           desc: "Mix of lending and DEX liquidity provision for better yield without excessive risk.",
           accentText: "text-emerald-400",
@@ -566,8 +566,8 @@ export const dictionaries: Record<AppLocale, AppMessages> = {
         },
         {
           name: "Growth",
-          apy: "10–15%",
-          risk: "Higher",
+          apy: "11–18%",
+          risk: "High",
           desc: "Aggressive multi-protocol deployment for maximum returns.",
           accentText: "text-amber-400",
           border: "border-amber-500/20",
@@ -1069,7 +1069,7 @@ export const dictionaries: Record<AppLocale, AppMessages> = {
       items: [
         {
           name: "Prudente",
-          apy: "3–6 %",
+          apy: "4–6 %",
           risk: "faible",
           desc: "Prêts en stablecoins sur Blend pour des rendements stables et prévisibles.",
           accentText: "text-sky-400",
@@ -1078,7 +1078,7 @@ export const dictionaries: Record<AppLocale, AppMessages> = {
         },
         {
           name: "Équilibrée",
-          apy: "6–10 %",
+          apy: "7–10 %",
           risk: "moyen",
           desc: "Combinaison de lending et de liquidité DEX pour un bon équilibre risque/rendement.",
           accentText: "text-emerald-400",
@@ -1088,7 +1088,7 @@ export const dictionaries: Record<AppLocale, AppMessages> = {
         },
         {
           name: "Croissance",
-          apy: "10–15 %",
+          apy: "11–18 %",
           risk: "élevé",
           desc: "Allocation agressive multi-protocole pour maximiser le potentiel de rendement.",
           accentText: "text-amber-400",

--- a/src/lib/service-layer/auth-service.ts
+++ b/src/lib/service-layer/auth-service.ts
@@ -1,4 +1,4 @@
-import { BaseAdapter } from "./base-adapter";
+import { BaseAdapter, MockStore } from "./base-adapter";
 import { ServiceResponse, type ServiceConfig } from "./types";
 import { random } from "../seeded-rng";
 
@@ -29,8 +29,8 @@ export interface AuthSession {
 }
 
 export class AuthService extends BaseAdapter {
-  private mockUsers: Map<string, AuthUser> = new Map();
-  private mockSessions: Map<string, AuthSession> = new Map();
+  private mockUsers = new MockStore<string, AuthUser>();
+  private mockSessions = new MockStore<string, AuthSession>();
 
   constructor(config: Partial<ServiceConfig> = {}) {
     super(config);

--- a/src/lib/service-layer/base-adapter.ts
+++ b/src/lib/service-layer/base-adapter.ts
@@ -52,6 +52,34 @@ function createServiceError(
   };
 }
 
+export class MockStore<K, V> {
+  private store = new Map<K, V>();
+
+  get(key: K): V | undefined {
+    return this.store.get(key);
+  }
+
+  set(key: K, value: V): void {
+    this.store.set(key, value);
+  }
+
+  has(key: K): boolean {
+    return this.store.has(key);
+  }
+
+  delete(key: K): boolean {
+    return this.store.delete(key);
+  }
+
+  values(): IterableIterator<V> {
+    return this.store.values();
+  }
+
+  keys(): IterableIterator<K> {
+    return this.store.keys();
+  }
+}
+
 export abstract class BaseAdapter {
   protected config: ServiceConfig;
 
@@ -161,5 +189,9 @@ export abstract class BaseAdapter {
 
   public getConfig(): ServiceConfig {
     return { ...this.config };
+  }
+
+  protected generateId(prefix: string): string {
+    return `${prefix}_${Date.now()}_${random().toString(36).substr(2, 9)}`;
   }
 }

--- a/src/lib/service-layer/portfolio-service.ts
+++ b/src/lib/service-layer/portfolio-service.ts
@@ -1,4 +1,4 @@
-import { BaseAdapter } from "./base-adapter";
+import { BaseAdapter, MockStore } from "./base-adapter";
 import {
   ServiceResponse,
   PaginatedResponse,
@@ -34,8 +34,8 @@ export interface PortfolioHistory {
 }
 
 export class PortfolioService extends BaseAdapter {
-  private mockPortfolios: Map<string, Portfolio> = new Map();
-  private mockHistory: Map<string, PortfolioHistory[]> = new Map();
+  private mockPortfolios = new MockStore<string, Portfolio>();
+  private mockHistory = new MockStore<string, PortfolioHistory[]>();
 
   constructor(config: Partial<ServiceConfig> = {}) {
     super(config);
@@ -166,7 +166,7 @@ export class PortfolioService extends BaseAdapter {
 
       const newAsset: Asset = {
         ...asset,
-        id: `asset_${Date.now()}`,
+        id: this.generateId("asset"),
         value: asset.balance * 1, // Simplified valuation
         valueChange24h: 0,
         valueChange24hPercent: 0,

--- a/src/lib/service-layer/strategy-service.ts
+++ b/src/lib/service-layer/strategy-service.ts
@@ -1,4 +1,4 @@
-import { BaseAdapter } from "./base-adapter";
+import { BaseAdapter, MockStore } from "./base-adapter";
 import {
   ServiceResponse,
   PaginatedResponse,
@@ -40,9 +40,9 @@ export interface StrategyPerformance {
 }
 
 export class StrategyService extends BaseAdapter {
-  private mockStrategies: Map<string, Strategy> = new Map();
-  private mockAllocations: Map<string, StrategyAllocation[]> = new Map();
-  private mockPerformance: Map<string, StrategyPerformance[]> = new Map();
+  private mockStrategies = new MockStore<string, Strategy>();
+  private mockAllocations = new MockStore<string, StrategyAllocation[]>();
+  private mockPerformance = new MockStore<string, StrategyPerformance[]>();
 
   constructor(config: Partial<ServiceConfig> = {}) {
     super(config);
@@ -189,7 +189,7 @@ export class StrategyService extends BaseAdapter {
       }
 
       const allocation: StrategyAllocation = {
-        id: `alloc_${Date.now()}`,
+        id: this.generateId("alloc"),
         userId,
         strategyId,
         amount,

--- a/src/lib/service-layer/transaction-service.ts
+++ b/src/lib/service-layer/transaction-service.ts
@@ -1,4 +1,4 @@
-import { BaseAdapter } from "./base-adapter";
+import { BaseAdapter, MockStore } from "./base-adapter";
 import {
   ServiceResponse,
   PaginatedResponse,
@@ -41,7 +41,7 @@ export interface TransactionFilter {
 }
 
 export class TransactionService extends BaseAdapter {
-  private mockTransactions: Map<string, Transaction[]> = new Map();
+  private mockTransactions = new MockStore<string, Transaction[]>();
 
   constructor(config: Partial<ServiceConfig> = {}) {
     super(config);
@@ -100,7 +100,7 @@ export class TransactionService extends BaseAdapter {
   ): Promise<ServiceResponse<Transaction>> {
     return this.executeWithRetry(async () => {
       const transaction: Transaction = {
-        id: `tx_${Date.now()}`,
+        id: this.generateId("tx"),
         userId,
         type: params.type,
         amount: params.amount,


### PR DESCRIPTION
## Summary

Bundles fixes for four small, independent issues found in the round-2 audit (commit 779e531):

- **#637** — Standardized save-action button casing to Title Case. `PrivacyModal`'s "Save preferences" button now reads "Save Preferences", matching the "Save Changes" convention already used consistently across the security/notifications/preferences settings pages.
- **#641** — Added `BaseAdapter.generateId(prefix)`, a collision-resistant id generator (timestamp + random suffix, same shape as the adapter's existing internal `generateRequestId`). `PortfolioService`, `TransactionService`, and `StrategyService` now use it instead of `` `prefix_${Date.now()}` ``.
- **#642** — Added a generic `MockStore<K, V>` helper to `base-adapter.ts` wrapping the Map-based CRUD boilerplate. Migrated `AuthService`, `PortfolioService`, `StrategyService`, and `TransactionService` off their hand-rolled `Map` fields onto it (API-compatible, so call sites were unaffected).
- **#645** — Reconciled the landing page's advertised strategy figures (`messages.ts`, EN + FR) with the in-app `StrategySelector` data (`strategies.ts`), which is the operative source of truth (drives real min/max deposit and allocation logic). Landing now reads: Conservative 4–6%/Low, Balanced 7–10%/Medium, Growth 11–18%/High — matching the app exactly.

## Test plan
- [x] `npm run typecheck` — no new errors introduced (one pre-existing, unrelated error in `composeProviders.tsx`)
- [x] `service-layer` unit tests (auth/base-adapter/portfolio/strategy/transaction) — 66/66 passing
- [x] Manual read-through of `PrivacyModal.tsx` and `security/page.tsx` to confirm casing now matches across settings surfaces

Closes #637, #641, #642, #645