### PR TITLE
refactor: extract shared form field pattern for labels and errors

### DIFF
--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -10,6 +10,7 @@ import {
   Card,
   FieldError,
   FormErrorSummary,
+  FormField,
   SectionError,
 } from "@/components/ui";
 import {
@@ -204,210 +205,187 @@ export default function SignUpPage() {
         ) : null}
 
         <form className="space-y-5" onSubmit={handleSubmit} noValidate>
-          <div>
-            <label
-              htmlFor="name"
-              className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
-            >
-              Full Name
-            </label>
-            <input
-              id="name"
-              type="text"
-              value={name}
-              onChange={(event) => {
-                setName(event.target.value);
-                setErrors((current) => ({ ...current, name: undefined }));
-              }}
-              disabled={isLoading || isSuccess}
-              aria-invalid={Boolean(errors.name)}
-              aria-describedby={errors.name ? "signup-name-error" : undefined}
-              className={`w-full min-h-11 rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
-                errors.name
-                  ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500"
-                  : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400"
-              }`}
-              placeholder="John Doe"
-            />
-            <FieldError id="signup-name-error" message={errors.name} />
-          </div>
-
-          <div>
-            <label
-              htmlFor="email"
-              className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
-            >
-              Email Address
-            </label>
-            <div className="relative">
+          <FormField id="signup-name" label="Full Name" error={errors.name}>
+            {(controlProps) => (
               <input
-                id="email"
-                type="email"
-                value={email}
+                {...controlProps}
+                type="text"
+                value={name}
                 onChange={(event) => {
-                  setEmail(event.target.value);
-                  setErrors((current) => ({ ...current, email: undefined }));
-                  validateEmailAsync(event.target.value);
+                  setName(event.target.value);
+                  setErrors((current) => ({ ...current, name: undefined }));
                 }}
                 disabled={isLoading || isSuccess}
-                aria-invalid={Boolean(errors.email)}
-                aria-describedby={joinDescribedBy(
-                  "signup-email-hint",
-                  errors.email ? "signup-email-error" : undefined,
-                )}
-                aria-busy={emailValidating}
                 className={`w-full min-h-11 rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
-                  errors.email
+                  errors.name
                     ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500"
                     : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400"
                 }`}
-                placeholder="name@example.com"
+                placeholder="John Doe"
               />
-              {emailValidating && (
-                <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                  <div className="h-4 w-4 animate-spin rounded-full border-2 border-sky-400/30 border-t-sky-400" />
-                </div>
-              )}
-            </div>
-            <p id="signup-email-hint" className="mt-2 text-sm text-slate-500">
-              Async mock check: addresses containing{" "}
-              <span className="font-mono">taken</span> are rejected.
-            </p>
-            <FieldError id="signup-email-error" message={errors.email} />
-          </div>
+            )}
+          </FormField>
 
-          <SectionError title="Password & Terms" message={passwordSectionError}>
-            <div className="space-y-4">
-              <div>
-                <label
-                  htmlFor="password"
-                  className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
-                >
-                  Password
-                </label>
+          <FormField
+            id="signup-email"
+            label="Email Address"
+            error={errors.email}
+            hint={
+              <>
+                Async mock check: addresses containing{" "}
+                <span className="font-mono">taken</span> are rejected.
+              </>
+            }
+          >
+            {(controlProps) => (
+              <div className="relative">
                 <input
-                  id="password"
-                  type="password"
-                  value={password}
+                  {...controlProps}
+                  type="email"
+                  value={email}
                   onChange={(event) => {
-                    setPassword(event.target.value);
-                    setErrors((current) => ({
-                      ...current,
-                      password: undefined,
-                    }));
+                    setEmail(event.target.value);
+                    setErrors((current) => ({ ...current, email: undefined }));
+                    validateEmailAsync(event.target.value);
                   }}
                   disabled={isLoading || isSuccess}
-                  aria-invalid={Boolean(errors.password)}
-                  aria-describedby={joinDescribedBy(
-                    "signup-password-strength",
-                    errors.password ? "signup-password-error" : undefined,
-                  )}
+                  aria-busy={emailValidating}
                   className={`w-full min-h-11 rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
-                    errors.password
+                    errors.email
                       ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500"
                       : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400"
                   }`}
-                  placeholder="Create a strong password"
+                  placeholder="name@example.com"
                 />
-                <FieldError
-                  id="signup-password-error"
-                  message={errors.password}
-                />
-
-                {password ? (
-                  <div
-                    id="signup-password-strength"
-                    className="mt-3 flex items-center gap-3"
-                  >
-                    <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-800">
-                      <div
-                        className="h-full transition-all"
-                        style={{
-                          width: `${(passwordStrength.level / 4) * 100}%`,
-                          backgroundColor: passwordStrength.color,
-                        }}
-                      />
-                    </div>
-                    <span
-                      className="text-sm font-semibold"
-                      style={{ color: passwordStrength.color }}
-                    >
-                      {passwordStrength.label}
-                    </span>
+                {emailValidating && (
+                  <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-sky-400/30 border-t-sky-400" />
                   </div>
-                ) : null}
+                )}
+              </div>
+            )}
+          </FormField>
 
-                <div className="mt-3 space-y-2 rounded-xl border border-slate-700/50 bg-slate-950/35 p-4 text-sm text-slate-400">
-                  {[
-                    {
-                      ok: password.length >= 8,
-                      label: "At least 8 characters",
-                    },
-                    {
-                      ok: hasUppercase(password),
-                      label: "One uppercase letter",
-                    },
-                    { ok: hasNumber(password), label: "One number" },
-                    {
-                      ok: hasSpecialChar(password),
-                      label: "One special character",
-                    },
-                  ].map((rule) => (
-                    <div
-                      key={rule.label}
-                      className={`flex items-center gap-2 ${rule.ok ? "text-emerald-300" : "text-slate-500"}`}
-                    >
-                      {rule.ok ? (
-                        <Check className="h-4 w-4" aria-hidden="true" />
-                      ) : (
-                        <X className="h-4 w-4" aria-hidden="true" />
-                      )}
-                      <span>{rule.label}</span>
+          <SectionError title="Password & Terms" message={passwordSectionError}>
+            <div className="space-y-4">
+              <FormField
+                id="signup-password"
+                label="Password"
+                error={errors.password}
+                hint={
+                  password ? (
+                    <div className="flex items-center gap-3">
+                      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-slate-800">
+                        <div
+                          className="h-full transition-all"
+                          style={{
+                            width: `${(passwordStrength.level / 4) * 100}%`,
+                            backgroundColor: passwordStrength.color,
+                          }}
+                        />
+                      </div>
+                      <span
+                        className="text-sm font-semibold"
+                        style={{ color: passwordStrength.color }}
+                      >
+                        {passwordStrength.label}
+                      </span>
                     </div>
-                  ))}
-                </div>
-              </div>
+                  ) : null
+                }
+              >
+                {(controlProps) => (
+                  <>
+                    <input
+                      {...controlProps}
+                      type="password"
+                      value={password}
+                      onChange={(event) => {
+                        setPassword(event.target.value);
+                        setErrors((current) => ({
+                          ...current,
+                          password: undefined,
+                        }));
+                      }}
+                      disabled={isLoading || isSuccess}
+                      className={`w-full min-h-11 rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
+                        errors.password
+                          ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500"
+                          : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400"
+                      }`}
+                      placeholder="Create a strong password"
+                    />
 
-              <div>
-                <label className="flex items-start gap-3 text-sm text-slate-300">
-                  <input
-                    id="terms"
-                    type="checkbox"
-                    checked={termsAccepted}
-                    onChange={(event) => {
-                      setTermsAccepted(event.target.checked);
-                      setErrors((current) => ({
-                        ...current,
-                        terms: undefined,
-                      }));
-                    }}
-                    disabled={isLoading || isSuccess}
-                    aria-invalid={Boolean(errors.terms)}
-                    aria-describedby={
-                      errors.terms ? "signup-terms-error" : undefined
-                    }
-                    className="mt-0.5 h-4 w-4 accent-sky-400"
-                  />
-                  <span>
-                    I agree to the{" "}
-                    <a
-                      href="#"
-                      className="font-semibold text-sky-300 hover:text-sky-200"
-                    >
-                      Terms of Service
-                    </a>{" "}
-                    and{" "}
-                    <a
-                      href="#"
-                      className="font-semibold text-sky-300 hover:text-sky-200"
-                    >
-                      Privacy Policy
-                    </a>
-                    .
-                  </span>
-                </label>
-                <FieldError id="signup-terms-error" message={errors.terms} />
-              </div>
+                    <div className="mt-3 space-y-2 rounded-xl border border-slate-700/50 bg-slate-950/35 p-4 text-sm text-slate-400">
+                      {[
+                        {
+                          ok: password.length >= 8,
+                          label: "At least 8 characters",
+                        },
+                        {
+                          ok: hasUppercase(password),
+                          label: "One uppercase letter",
+                        },
+                        { ok: hasNumber(password), label: "One number" },
+                        {
+                          ok: hasSpecialChar(password),
+                          label: "One special character",
+                        },
+                      ].map((rule) => (
+                        <div
+                          key={rule.label}
+                          className={`flex items-center gap-2 ${rule.ok ? "text-emerald-300" : "text-slate-500"}`}
+                        >
+                          {rule.ok ? (
+                            <Check className="h-4 w-4" aria-hidden="true" />
+                          ) : (
+                            <X className="h-4 w-4" aria-hidden="true" />
+                          )}
+                          <span>{rule.label}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                )}
+              </FormField>
+
+              <FormField id="signup-terms" error={errors.terms}>
+                {(controlProps) => (
+                  <label htmlFor={controlProps.id} className="flex items-start gap-3 text-sm text-slate-300">
+                    <input
+                      {...controlProps}
+                      type="checkbox"
+                      checked={termsAccepted}
+                      onChange={(event) => {
+                        setTermsAccepted(event.target.checked);
+                        setErrors((current) => ({
+                          ...current,
+                          terms: undefined,
+                        }));
+                      }}
+                      disabled={isLoading || isSuccess}
+                      className="mt-0.5 h-4 w-4 accent-sky-400"
+                    />
+                    <span>
+                      I agree to the{" "}
+                      <a
+                        href="#"
+                        className="font-semibold text-sky-300 hover:text-sky-200"
+                      >
+                        Terms of Service
+                      </a>{" "}
+                      and{" "}
+                      <a
+                        href="#"
+                        className="font-semibold text-sky-300 hover:text-sky-200"
+                      >
+                        Privacy Policy
+                      </a>
+                      .
+                    </span>
+                  </label>
+                )}
+              </FormField>
             </div>
           </SectionError>
 

--- a/src/components/help/SupportForm.tsx
+++ b/src/components/help/SupportForm.tsx
@@ -7,6 +7,7 @@ import {
   Card,
   FieldError,
   FormErrorSummary,
+  FormField,
   SectionError,
 } from "@/components/ui";
 import {
@@ -272,231 +273,175 @@ export default function SupportForm() {
         <form onSubmit={handleSubmit} className="space-y-5" noValidate>
           <SectionError title="Contact Details" message={contactSectionError}>
             <div className="grid gap-5 md:grid-cols-2">
-              <div>
-                <label
-                  htmlFor="support-name"
-                  className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
-                >
-                  Name
-                </label>
-                <input
-                  id="support-name"
-                  type="text"
-                  value={formData.name}
-                  onChange={(event) => updateField("name", event.target.value)}
-                  aria-invalid={Boolean(errors.name)}
-                  aria-describedby={
-                    errors.name ? "support-name-error" : undefined
-                  }
-                  className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
-                    errors.name
-                      ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
-                      : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
-                  }`}
-                  placeholder="Your full name"
-                />
-                <FieldError id="support-name-error" message={errors.name} />
-              </div>
+              <FormField id="support-name" label="Name" error={errors.name}>
+                {(controlProps) => (
+                  <input
+                    {...controlProps}
+                    type="text"
+                    value={formData.name}
+                    onChange={(event) => updateField("name", event.target.value)}
+                    className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
+                      errors.name
+                        ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
+                        : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
+                    }`}
+                    placeholder="Your full name"
+                  />
+                )}
+              </FormField>
 
-              <div>
-                <label
-                  htmlFor="support-email"
-                  className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
-                >
-                  Email Address
-                </label>
-                <input
-                  id="support-email"
-                  type="email"
-                  value={formData.email}
-                  onChange={(event) => updateField("email", event.target.value)}
-                  aria-invalid={Boolean(errors.email)}
-                  aria-describedby={
-                    errors.email ? "support-email-error" : undefined
-                  }
-                  className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
-                    errors.email
-                      ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
-                      : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
-                  }`}
-                  placeholder="name@example.com"
-                />
-                <FieldError id="support-email-error" message={errors.email} />
-              </div>
+              <FormField id="support-email" label="Email Address" error={errors.email}>
+                {(controlProps) => (
+                  <input
+                    {...controlProps}
+                    type="email"
+                    value={formData.email}
+                    onChange={(event) => updateField("email", event.target.value)}
+                    className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
+                      errors.email
+                        ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
+                        : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
+                    }`}
+                    placeholder="name@example.com"
+                  />
+                )}
+              </FormField>
             </div>
           </SectionError>
 
           <SectionError title="Request Details" message={requestSectionError}>
             <div className="space-y-5">
-              <div>
-                <label
-                  htmlFor="support-category"
-                  className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
-                >
-                  Category
-                </label>
-                <select
-                  id="support-category"
-                  value={formData.category}
-                  onChange={(event) =>
-                    updateField("category", event.target.value)
-                  }
-                  aria-invalid={Boolean(errors.category)}
-                  aria-describedby={
-                    errors.category ? "support-category-error" : undefined
-                  }
-                  className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
-                    errors.category
-                      ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
-                      : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
-                  }`}
-                >
-                  {categories.map((category) => (
-                    <option
-                      key={category}
-                      value={category}
-                      className="bg-slate-950"
-                    >
-                      {category}
-                    </option>
-                  ))}
-                </select>
-                <FieldError
-                  id="support-category-error"
-                  message={errors.category}
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="support-subject"
-                  className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
-                >
-                  Subject
-                </label>
-                <input
-                  id="support-subject"
-                  type="text"
-                  value={formData.subject}
-                  onChange={(event) =>
-                    updateField("subject", event.target.value)
-                  }
-                  maxLength={MAX_SUBJECT_LENGTH}
-                  aria-invalid={Boolean(errors.subject)}
-                  aria-describedby={joinDescribedBy(
-                    "support-subject-hint",
-                    errors.subject ? "support-subject-error" : undefined,
-                  )}
-                  className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
-                    errors.subject
-                      ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
-                      : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
-                  }`}
-                  placeholder="Brief description of your issue"
-                />
-                <div className="mt-2 flex items-center justify-between text-sm text-slate-500">
-                  <span id="support-subject-hint">Required</span>
-                  <span>
-                    {formData.subject.length}/{MAX_SUBJECT_LENGTH}
-                  </span>
-                </div>
-                <FieldError
-                  id="support-subject-error"
-                  message={errors.subject}
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="support-transaction-id"
-                  className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
-                >
-                  Transaction ID
-                </label>
-                <div className="relative">
-                  <input
-                    id="support-transaction-id"
-                    type="text"
-                    value={formData.transactionId}
+              <FormField id="support-category" label="Category" error={errors.category}>
+                {(controlProps) => (
+                  <select
+                    {...controlProps}
+                    value={formData.category}
                     onChange={(event) =>
-                      updateField("transactionId", event.target.value)
-                    }
-                    aria-invalid={Boolean(errors.transactionId)}
-                    aria-describedby={joinDescribedBy(
-                      "support-transaction-hint",
-                      errors.transactionId
-                        ? "support-transaction-error"
-                        : undefined,
-                    )}
-                    aria-busy={
-                      asyncValidationState.transactionId === "validating"
+                      updateField("category", event.target.value)
                     }
                     className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
-                      errors.transactionId
+                      errors.category
                         ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
                         : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
                     }`}
-                    placeholder="Optional: TX-123..."
-                  />
-                  {asyncValidationState.transactionId === "validating" && (
-                    <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                      <div className="h-4 w-4 animate-spin rounded-full border-2 border-sky-400/30 border-t-sky-400" />
-                    </div>
-                  )}
-                </div>
-                <p
-                  id="support-transaction-hint"
-                  className="mt-2 text-sm text-slate-500"
-                >
-                  Async mock check: references containing{" "}
-                  <span className="font-mono">404</span> fail lookup.
-                </p>
-                <FieldError
-                  id="support-transaction-error"
-                  message={errors.transactionId}
-                />
-              </div>
+                  >
+                    {categories.map((category) => (
+                      <option
+                        key={category}
+                        value={category}
+                        className="bg-slate-950"
+                      >
+                        {category}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              </FormField>
 
-              <div>
-                <label
-                  htmlFor="support-message"
-                  className="mb-2 block text-xs font-semibold uppercase tracking-[0.16em] text-slate-300"
-                >
-                  Message
-                </label>
-                <textarea
-                  id="support-message"
-                  value={formData.message}
-                  onChange={(event) =>
-                    updateField("message", event.target.value)
-                  }
-                  maxLength={MAX_MESSAGE_LENGTH}
-                  rows={6}
-                  aria-invalid={Boolean(errors.message)}
-                  aria-describedby={joinDescribedBy(
-                    "support-message-hint",
-                    errors.message ? "support-message-error" : undefined,
-                  )}
-                  className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
-                    errors.message
-                      ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
-                      : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
-                  }`}
-                  placeholder="Please provide details about your issue or question."
-                />
-                <div className="mt-2 flex items-center justify-between text-sm text-slate-500">
-                  <span id="support-message-hint">
-                    Please be as detailed as possible
+              <FormField
+                id="support-subject"
+                label="Subject"
+                error={errors.subject}
+                hint={
+                  <span className="flex items-center justify-between w-full">
+                    <span>Required</span>
+                    <span>
+                      {formData.subject.length}/{MAX_SUBJECT_LENGTH}
+                    </span>
                   </span>
-                  <span>
-                    {formData.message.length}/{MAX_MESSAGE_LENGTH}
+                }
+              >
+                {(controlProps) => (
+                  <input
+                    {...controlProps}
+                    type="text"
+                    value={formData.subject}
+                    onChange={(event) =>
+                      updateField("subject", event.target.value)
+                    }
+                    maxLength={MAX_SUBJECT_LENGTH}
+                    className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
+                      errors.subject
+                        ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
+                        : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
+                    }`}
+                    placeholder="Brief description of your issue"
+                  />
+                )}
+              </FormField>
+
+              <FormField
+                id="support-transaction-id"
+                label="Transaction ID"
+                error={errors.transactionId}
+                hint={
+                  <>
+                    Async mock check: references containing{" "}
+                    <span className="font-mono">404</span> fail lookup.
+                  </>
+                }
+              >
+                {(controlProps) => (
+                  <div className="relative">
+                    <input
+                      {...controlProps}
+                      type="text"
+                      value={formData.transactionId}
+                      onChange={(event) =>
+                        updateField("transactionId", event.target.value)
+                      }
+                      aria-busy={
+                        asyncValidationState.transactionId === "validating"
+                      }
+                      className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
+                        errors.transactionId
+                          ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
+                          : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
+                      }`}
+                      placeholder="Optional: TX-123..."
+                    />
+                    {asyncValidationState.transactionId === "validating" && (
+                      <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-sky-400/30 border-t-sky-400" />
+                      </div>
+                    )}
+                  </div>
+                )}
+              </FormField>
+
+              <FormField
+                id="support-message"
+                label="Message"
+                error={errors.message}
+                hint={
+                  <span className="flex items-center justify-between w-full">
+                    <span>
+                      Please be as detailed as possible
+                    </span>
+                    <span>
+                      {formData.message.length}/{MAX_MESSAGE_LENGTH}
+                    </span>
                   </span>
-                </div>
-                <FieldError
-                  id="support-message-error"
-                  message={errors.message}
-                />
-              </div>
+                }
+              >
+                {(controlProps) => (
+                  <textarea
+                    {...controlProps}
+                    value={formData.message}
+                    onChange={(event) =>
+                      updateField("message", event.target.value)
+                    }
+                    maxLength={MAX_MESSAGE_LENGTH}
+                    rows={6}
+                    className={`w-full rounded-xl border bg-slate-950/40 px-4 py-3 text-sm text-slate-100 outline-none transition ${
+                      errors.message
+                        ? "border-red-500/60 focus:border-red-500 focus:ring-2 focus:ring-red-500/15"
+                        : "border-slate-700/60 focus:border-sky-400 focus:ring-2 focus:ring-sky-400/15"
+                    }`}
+                    placeholder="Please provide details about your issue or question."
+                  />
+                )}
+              </FormField>
             </div>
           </SectionError>
 

--- a/src/components/ui/FormField.tsx
+++ b/src/components/ui/FormField.tsx
@@ -7,7 +7,7 @@ import { joinDescribedBy } from "@/lib/form-validation";
 
 interface FormFieldProps {
   id: string;
-  label: ReactNode;
+  label?: ReactNode;
   error?: string;
   hint?: ReactNode;
   children: (props: FormFieldControlProps) => ReactNode;
@@ -58,13 +58,15 @@ export function FormField({
 
   return (
     <div className={className}>
-      <label
-        htmlFor={id}
-        className={labelClassName}
-      >
-        {label}
-        {required && <span className="text-red-400"> *</span>}
-      </label>
+      {label && (
+        <label
+          htmlFor={id}
+          className={labelClassName}
+        >
+          {label}
+          {required && <span className="text-red-400"> *</span>}
+        </label>
+      )}
       {children(controlProps)}
       {hint && (
         <p id={hintId} className={cn(hintClassName)}>


### PR DESCRIPTION
Closes #347 

### Summary
Extracts a shared `FormField` primitive to eliminate duplicate label, hint, error, and aria-describedby wiring across the signup and support forms.

### Tasks Completed
*   Extended the existing `FormField` primitive to support conditionally rendering labels.
*   Migrated `src/app/(auth)/signup/page.tsx` forms to use `<FormField>`.
*   Migrated `src/components/help/SupportForm.tsx` forms to use `<FormField>`.
*   Maintained full assistive tech capabilities (`aria-describedby`, error mapping).

### Notes
This successfully completes the standalone cleanup issue from `CLEANUP_ISSUES_2026-05.md`, complementing the audit queue and product backlog.