### PR TITLE
fix: id collisions, mock store duplication, strategy APY figures

### DIFF
--- a/src/lib/service-layer/strategy-service.test.ts
+++ b/src/lib/service-layer/strategy-service.test.ts
@@ -91,7 +91,7 @@ test("createAllocation accepts a valid amount and computes the expected return f
   assert.equal(response.data.amount, 500);
 
   // expectedReturn = amount * (expectedApy / 100) * (lockPeriod / 365)
-  const expected = 500 * (5.5 / 100) * (30 / 365);
+  const expected = 500 * (5 / 100) * (30 / 365);
   assert.ok(
     Math.abs(response.data.expectedReturn - expected) < 1e-9,
     `expected ~${expected}, got ${response.data.expectedReturn}`,

--- a/src/lib/service-layer/strategy-service.ts
+++ b/src/lib/service-layer/strategy-service.ts
@@ -56,7 +56,7 @@ export class StrategyService extends BaseAdapter {
         name: "Conservative Yield",
         description: "Low-risk strategy focusing on stable returns",
         riskLevel: "low",
-        expectedApy: 5.5,
+        expectedApy: 5, // matches Conservative 4-6% range in strategies.ts/messages.ts
         minDeposit: 100,
         maxDeposit: 50000,
         lockPeriod: 30,
@@ -68,7 +68,7 @@ export class StrategyService extends BaseAdapter {
         name: "Balanced Growth",
         description: "Moderate risk with balanced growth potential",
         riskLevel: "medium",
-        expectedApy: 12.5,
+        expectedApy: 8.5, // matches Balanced 7-10% range in strategies.ts/messages.ts
         minDeposit: 500,
         maxDeposit: 100000,
         lockPeriod: 90,
@@ -80,7 +80,7 @@ export class StrategyService extends BaseAdapter {
         name: "Aggressive Yield",
         description: "High-risk strategy for maximum returns",
         riskLevel: "high",
-        expectedApy: 25.0,
+        expectedApy: 14.5, // matches Growth 11-18% range in strategies.ts/messages.ts
         minDeposit: 1000,
         maxDeposit: 500000,
         lockPeriod: 180,


### PR DESCRIPTION
## Summary

Closes #641, 
Close #642 
Closes #645

`BaseAdapter.generateId(prefix)`, the generic `MockStore<K, V>` helper, and the messages.ts/strategies.ts APY reconciliation described in these three issues were already landed upstream in commit `4755542` ("fix: settings casing, id collisions, mock store duplication, strategy figures"):

- **#641** — `generateId(prefix)` (timestamp + random suffix) exists on `BaseAdapter` and is used by `portfolio-service.ts`, `transaction-service.ts`, and `strategy-service.ts`.
- **#642** — `MockStore<K, V>` exists on `base-adapter.ts` and is used by `auth-service.ts`, `portfolio-service.ts`, `strategy-service.ts`, and `transaction-service.ts`.
- **#645** — `messages.ts` and `strategies.ts` both show Conservative 4-6%/Low, Balanced 7-10%/Medium, Growth 11-18%/High, in both EN and FR locales.

One gap remained: `strategy-service.ts`'s mock backend data (a separate mock-API layer, not the same as `strategies.ts`/`StrategySelector`) still had its own `expectedApy` values (5.5 / 12.5 / 25.0) that diverged from the canonical ranges above. This PR aligns those to the range midpoints (5 / 8.5 / 14.5) so the mock service layer is consistent with the rest of the app, and updates the one test that hardcoded the old 5.5 value.

## Changes

- `src/lib/service-layer/strategy-service.ts`: `expectedApy` 5.5→5, 12.5→8.5, 25.0→14.5 (with inline comments noting the canonical ranges they now match)
- `src/lib/service-layer/strategy-service.test.ts`: updated hardcoded expected-return calculation to match

## Test plan

- [x] `npm install`
- [x] `npm run typecheck` — clean, no errors
- [x] `node --import tsx --test src/lib/service-layer/strategy-service.test.ts` — 15/15 pass
